### PR TITLE
feat: add MuJoCo backend adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.1.1
+
+- Add the lazy MuJoCo adapter and backend factory.
+- Add MuJoCo contract smoke coverage and adapter documentation.
+
 ## 0.1.0
 
 - Bootstrap the `unisim` namespace and `unisim-core` distribution.
 - Add the backend-neutral `SimBackend` contract, fake backend, and conformance helper.
 - Reserve benchmark case/result interfaces without implementing workloads or measurements.
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ adapters. The PyPI distribution is `unisim-core`; the Python import namespace
 is `unisim`.
 
 This repository is the extraction target for UniLab's unified physics backend.
-The initial `0.1.0` slice contains the public contract, a deterministic fake
+The initial `0.1.x` slice contains the public contract, a deterministic fake
 backend, a lightweight conformance helper, and benchmark API/result-schema
 reservations. It does not run benchmark workloads or include engine SDKs in the
 base install.
@@ -19,7 +19,9 @@ uv run ruff check .
 uv build
 ```
 
-Engine adapters are optional extras and are loaded lazily. Each adapter must
+Engine adapters are optional extras and are loaded lazily. The first real
+adapter is available as `unisim.MuJoCoBackend` after installing the `mujoco`
+extra (or through `unisim.create_backend("mujoco", model_path=...)`). Each adapter must
 document its supported Python/platform/runtime matrix and pass the conformance
 helper before it is published.
 
@@ -29,4 +31,3 @@ UniLab retains Hydra configuration, task/env/manager lifecycle, robot assets,
 RL training, checkpoint, and sim2sim ownership. UniSim must not import UniLab.
 During migration UniLab may use a short-lived re-export shim; the final state
 has one implementation owned by this repository.
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,11 @@ UniLab owns task/env/manager lifecycle, Hydra owner YAML, robot assets,
 training, checkpoint, and sim2sim policy I/O. UniLab translates task-owned
 scene and randomization inputs into the UniSim contract.
 
+The MuJoCo adapter is constructed with a `model_path` and optional vectorized
+environment count. XML is parsed only during construction; state/control arrays
+are copied through the public contract and engine objects never escape the
+adapter.
+
 All asset and model metadata resolution is a cold-path concern. Hot-path
 `step`/`reset` code receives validated arrays and cached identifiers; adapters
 must not probe private engine attributes dynamically.
-

--- a/docs/benchmark-api.md
+++ b/docs/benchmark-api.md
@@ -1,10 +1,9 @@
 # Benchmark API Reservation
 
-Version `0.1.0` reserves `BenchmarkCase` and `BenchmarkResult` as the stable
+Version `0.1.x` reserves `BenchmarkCase` and `BenchmarkResult` as the stable
 extension point for a future engine benchmark package. No workload runner,
 timing loop, result comparison, or performance claim is implemented here.
 
 Future benchmark work must fix scene/control/state semantics, schema version,
 artifact digest, synchronization, and hardware/runtime provenance. It must
 reuse the same `SimBackend` contract used by UniLab adapters.
-

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,3 +6,6 @@ conformance coverage, and updates the UniLab consumer boundary. The temporary
 `unilab.base.backend` re-export shim is not a second implementation and is
 removed after all current backends use the released `unisim-core` package.
 
+The first real adapter is MuJoCo. It accepts a package-neutral `model_path`,
+materializes the XML on construction, and exposes cached numeric state through
+`unisim.SimBackend`; task-owned scene composition remains in UniLab.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -12,7 +12,9 @@ from .contract import (
     SimBackend,
     UnsupportedCapabilityError,
 )
+from .factory import create_backend
 from .fake import FakeBackend
+from .mujoco import MuJoCoBackend
 
 __all__ = [
     "BackendCapability",
@@ -20,8 +22,9 @@ __all__ = [
     "BenchmarkCase",
     "BenchmarkResult",
     "FakeBackend",
+    "MuJoCoBackend",
     "SimBackend",
     "UnsupportedCapabilityError",
     "assert_backend_conformance",
+    "create_backend",
 ]
-

--- a/src/unisim/benchmark.py
+++ b/src/unisim/benchmark.py
@@ -1,6 +1,6 @@
 """Benchmark API reservation.
 
-No workload runner or measurement implementation is provided in v0.1.0. These
+No workload runner or measurement implementation is provided in v0.1.x. These
 records define the stable extension point future benchmark work must consume.
 """
 
@@ -29,4 +29,3 @@ class BenchmarkResult:
     package_version: str
     metrics: Mapping[str, float] = field(default_factory=dict)
     provenance: Mapping[str, str] = field(default_factory=dict)
-

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -1,0 +1,21 @@
+"""Lazy backend factory for optional engine adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import SimBackend
+
+
+def create_backend(backend_type: str, **kwargs: Any) -> SimBackend:
+    """Construct an optional backend without importing engine SDKs eagerly."""
+    if backend_type == "fake":
+        from .fake import FakeBackend
+
+        return FakeBackend(**kwargs)
+    if backend_type == "mujoco":
+        from .mujoco import MuJoCoBackend
+
+        return MuJoCoBackend(**kwargs)
+    raise ValueError(f"unknown UniSim backend: {backend_type!r}")
+

--- a/src/unisim/mujoco.py
+++ b/src/unisim/mujoco.py
@@ -1,0 +1,143 @@
+"""MuJoCo adapter for the backend-neutral :mod:`unisim` contract.
+
+The adapter is intentionally dependency-lazy: importing :mod:`unisim` does
+not import MuJoCo. XML/model parsing happens only during construction, which
+is the materialization cold path; ``step`` and ``reset`` operate on cached
+model/data objects and numeric arrays.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import numpy as np
+
+from .contract import BackendCapability, BackendError, SimBackend
+
+
+def _load_mujoco():
+    try:
+        import mujoco
+    except ImportError as exc:  # pragma: no cover - depends on optional extra
+        raise BackendError(
+            "MuJoCo adapter requires the optional dependency; install "
+            "unisim-core[mujoco]"
+        ) from exc
+    return mujoco
+
+
+class MuJoCoBackend(SimBackend):
+    """A vectorized collection of independent MuJoCo ``MjData`` instances."""
+
+    backend_type = "mujoco"
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        num_envs: int = 1,
+        frame_skip: int = 1,
+    ) -> None:
+        if num_envs <= 0:
+            raise ValueError("num_envs must be positive")
+        if frame_skip <= 0:
+            raise ValueError("frame_skip must be positive")
+        self._mujoco = _load_mujoco()
+        path = Path(model_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"MuJoCo model does not exist: {path}")
+        try:
+            self._model = self._mujoco.MjModel.from_xml_path(str(path))
+        except Exception as exc:  # noqa: BLE001 - normalize SDK diagnostics
+            raise BackendError(f"failed to materialize MuJoCo model {path}: {exc}") from exc
+        self._data = [self._mujoco.MjData(self._model) for _ in range(num_envs)]
+        self._frame_skip = frame_skip
+        self._num_envs = num_envs
+        self._ctrl_width = int(self._model.nu)
+        self._qpos_shape = (num_envs, int(self._model.nq))
+        self._qvel_shape = (num_envs, int(self._model.nv))
+        self._ctrl_shape = (num_envs, self._ctrl_width)
+        self.reset()
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def num_actuators(self) -> int:
+        return self._ctrl_width
+
+    @property
+    def capabilities(self) -> frozenset[BackendCapability]:
+        return frozenset(
+            {
+                BackendCapability.RESET,
+                BackendCapability.STATE_READ,
+                BackendCapability.STATE_WRITE,
+            }
+        )
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        controls = np.asarray(ctrl, dtype=np.float64)
+        if controls.shape != self._ctrl_shape:
+            raise ValueError(f"ctrl shape {controls.shape} does not match {self._ctrl_shape}")
+        if not np.isfinite(controls).all():
+            raise ValueError("ctrl contains NaN or Inf")
+        if nsteps < 1:
+            raise ValueError("nsteps must be positive")
+        for index, data in enumerate(self._data):
+            data.ctrl[...] = controls[index]
+            for _ in range(nsteps * self._frame_skip):
+                self._mujoco.mj_step(self._model, data)
+
+    def reset(self, env_ids: np.ndarray | None = None) -> None:
+        if env_ids is None:
+            ids = np.arange(self._num_envs, dtype=np.intp)
+        else:
+            ids = np.asarray(env_ids, dtype=np.intp)
+            if ids.ndim != 1:
+                raise ValueError("env_ids must be one-dimensional")
+            if np.any(ids < 0) or np.any(ids >= self._num_envs):
+                raise IndexError("env_ids contains an out-of-range index")
+        for env_id in ids:
+            data = self._data[int(env_id)]
+            self._mujoco.mj_resetData(self._model, data)
+            self._mujoco.mj_forward(self._model, data)
+
+    def get_state(self, fields: tuple[str, ...] | None = None) -> Mapping[str, np.ndarray]:
+        requested = ("qpos", "qvel", "ctrl") if fields is None else fields
+        result: dict[str, np.ndarray] = {}
+        for field in requested:
+            if field == "qpos":
+                result[field] = np.stack([data.qpos.copy() for data in self._data])
+            elif field == "qvel":
+                result[field] = np.stack([data.qvel.copy() for data in self._data])
+            elif field == "ctrl":
+                result[field] = np.stack([data.ctrl.copy() for data in self._data])
+            else:
+                raise KeyError(f"unknown MuJoCo state field: {field}")
+        return result
+
+    def set_state(self, state: Mapping[str, np.ndarray]) -> None:
+        if "qpos" in state:
+            qpos = np.asarray(state["qpos"], dtype=np.float64)
+            if qpos.shape != self._qpos_shape:
+                raise ValueError(f"qpos shape {qpos.shape} does not match {self._qpos_shape}")
+        else:
+            qpos = None
+        if "qvel" in state:
+            qvel = np.asarray(state["qvel"], dtype=np.float64)
+            if qvel.shape != self._qvel_shape:
+                raise ValueError(f"qvel shape {qvel.shape} does not match {self._qvel_shape}")
+        else:
+            qvel = None
+        for index, data in enumerate(self._data):
+            if qpos is not None:
+                data.qpos[...] = qpos[index]
+            if qvel is not None:
+                data.qvel[...] = qvel[index]
+            self._mujoco.mj_forward(self._model, data)
+
+
+__all__ = ["MuJoCoBackend"]

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,6 +1,12 @@
 import numpy as np
 
-from unisim import BackendCapability, BenchmarkCase, FakeBackend, assert_backend_conformance
+from unisim import (
+    BackendCapability,
+    BenchmarkCase,
+    FakeBackend,
+    assert_backend_conformance,
+    create_backend,
+)
 
 
 def test_fake_backend_conforms() -> None:
@@ -16,3 +22,7 @@ def test_benchmark_api_is_only_data() -> None:
     assert case.schema_version == "0.1"
     assert case.name == "future-step-case"
 
+
+def test_factory_keeps_optional_backend_lazy() -> None:
+    backend = create_backend("fake", num_envs=1, num_actuators=1)
+    assert isinstance(backend, FakeBackend)

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim import MuJoCoBackend, assert_backend_conformance
+
+MODEL = """<mujoco model='unisim-test'>
+  <option timestep='0.01'/>
+  <worldbody><body name='base'><joint name='slide' type='slide' axis='1 0 0'/>
+    <geom type='box' size='0.05 0.05 0.05'/></body></worldbody>
+  <actuator><motor joint='slide' ctrlrange='-1 1'/></actuator>
+</mujoco>"""
+
+
+def test_mujoco_backend_contract(tmp_path: Path) -> None:
+    pytest.importorskip("mujoco")
+    model_path = tmp_path / "model.xml"
+    model_path.write_text(MODEL)
+    backend = MuJoCoBackend(model_path, num_envs=2)
+    assert_backend_conformance(backend)
+    backend.step(np.ones((2, 1)), nsteps=2)
+    assert backend.get_state(("qpos",))["qpos"].shape == (2, 1)
+    backend.reset(np.asarray([1], dtype=np.intp))
+    np.testing.assert_allclose(backend.get_state(("qpos",))["qpos"][1], 0.0)

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- add a lazy MuJoCo adapter implementing the public `unisim.SimBackend` contract
- add dependency-free backend factory with explicit unknown-backend errors
- keep MuJoCo XML/model materialization on construction (cold path)
- add vectorized independent `MjData` instances with step/reset/state read/write
- add MuJoCo conformance smoke and adapter/migration documentation
- reserve benchmark API only; no workload or performance measurement is implemented

## Roadmap

- UniLab parent: https://github.com/unilabsim/UniLab/issues/1428
- UniSim adapter issue: #2

## Validation

- `uv run pytest` -> 4 passed (with `mujoco` extra installed)
- `uv run ruff check .` -> passed
- `uv build` -> wheel and sdist passed
- TestPyPI `unisim-core==0.1.1`: https://test.pypi.org/project/unisim-core/0.1.1/
- isolated TestPyPI smoke with `--refresh`: `import unisim` and `create_backend("fake")` passed

No UniLab branch is modified by this PR. Production PyPI is not touched.
