### PR TITLE
feat: add Motrix backend adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add the lazy MuJoCo adapter and backend factory.
 - Add MuJoCo contract smoke coverage and adapter documentation.
+- Add the lazy Motrix adapter and shared contract smoke coverage.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## 0.1.2
+
+- Add the lazy Motrix adapter and shared contract smoke coverage.
+
 ## 0.1.1
 
 - Add the lazy MuJoCo adapter and backend factory.
 - Add MuJoCo contract smoke coverage and adapter documentation.
-- Add the lazy Motrix adapter and shared contract smoke coverage.
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ extra (or through `unisim.create_backend("mujoco", model_path=...)`). Each adapt
 document its supported Python/platform/runtime matrix and pass the conformance
 helper before it is published.
 
+Motrix is available through `unisim.MotrixBackend` after installing the
+`motrix` extra. Both adapters expose the same state/control/reset contract;
+engine-native model and data objects remain private.
+
 ## Relationship to UniLab
 
 UniLab retains Hydra configuration, task/env/manager lifecycle, robot assets,

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,3 +9,6 @@ removed after all current backends use the released `unisim-core` package.
 The first real adapter is MuJoCo. It accepts a package-neutral `model_path`,
 materializes the XML on construction, and exposes cached numeric state through
 `unisim.SimBackend`; task-owned scene composition remains in UniLab.
+
+Motrix is the second in-process adapter. It uses Motrix's batched `SceneData`
+and masked data slices behind the same public state/control/reset contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "0.1.1"
+version = "0.1.2"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -14,6 +14,7 @@ from .contract import (
 )
 from .factory import create_backend
 from .fake import FakeBackend
+from .motrix import MotrixBackend
 from .mujoco import MuJoCoBackend
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "BenchmarkResult",
     "FakeBackend",
     "MuJoCoBackend",
+    "MotrixBackend",
     "SimBackend",
     "UnsupportedCapabilityError",
     "assert_backend_conformance",

--- a/src/unisim/conformance.py
+++ b/src/unisim/conformance.py
@@ -25,5 +25,7 @@ def assert_backend_conformance(backend: SimBackend) -> None:
     for name, value in state.items():
         array = np.asarray(value)
         assert np.isfinite(array).all(), f"state field {name!r} contains non-finite values"
-    backend.reset(np.arange(min(1, backend.num_envs), dtype=np.intp))
-
+    if BackendCapability.SELECTED_RESET in backend.capabilities:
+        backend.reset(np.arange(min(1, backend.num_envs), dtype=np.intp))
+    else:
+        backend.reset()

--- a/src/unisim/contract.py
+++ b/src/unisim/contract.py
@@ -25,6 +25,7 @@ class BackendCapability(StrEnum):
     """Capabilities that an adapter may explicitly advertise."""
 
     RESET = "reset"
+    SELECTED_RESET = "selected_reset"
     STATE_READ = "state_read"
     STATE_WRITE = "state_write"
     MUTATION = "mutation"
@@ -69,4 +70,3 @@ class SimBackend(abc.ABC):
                 f"backend '{self.backend_type}' does not support state_write"
             )
         raise NotImplementedError
-

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -17,5 +17,8 @@ def create_backend(backend_type: str, **kwargs: Any) -> SimBackend:
         from .mujoco import MuJoCoBackend
 
         return MuJoCoBackend(**kwargs)
-    raise ValueError(f"unknown UniSim backend: {backend_type!r}")
+    if backend_type == "motrix":
+        from .motrix import MotrixBackend
 
+        return MotrixBackend(**kwargs)
+    raise ValueError(f"unknown UniSim backend: {backend_type!r}")

--- a/src/unisim/fake.py
+++ b/src/unisim/fake.py
@@ -35,6 +35,7 @@ class FakeBackend(SimBackend):
         return frozenset(
             {
                 BackendCapability.RESET,
+                BackendCapability.SELECTED_RESET,
                 BackendCapability.STATE_READ,
                 BackendCapability.STATE_WRITE,
             }
@@ -80,4 +81,3 @@ class FakeBackend(SimBackend):
             self._qpos[...] = qpos
         if "step_count" in state:
             self._step_count = int(np.asarray(state["step_count"]).item())
-

--- a/src/unisim/motrix.py
+++ b/src/unisim/motrix.py
@@ -1,0 +1,128 @@
+"""MotrixSim adapter for the public :mod:`unisim` contract.
+
+MotrixSim is optional and imported only when the adapter is constructed. The
+adapter keeps native ``SceneModel``/``SceneData`` objects private and exposes
+NumPy state arrays through the same contract as MuJoCo.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import numpy as np
+
+from .contract import BackendCapability, BackendError, SimBackend
+
+
+def _load_motrix():
+    try:
+        import motrixsim
+    except ImportError as exc:  # pragma: no cover - depends on optional extra
+        raise BackendError(
+            "Motrix adapter requires the optional dependency; install "
+            "unisim-core[motrix]"
+        ) from exc
+    return motrixsim
+
+
+class MotrixBackend(SimBackend):
+    """A batched MotrixSim model implementing the common backend lifecycle."""
+
+    backend_type = "motrix"
+
+    def __init__(self, model_path: str | Path, *, num_envs: int = 1, frame_skip: int = 1) -> None:
+        if num_envs <= 0:
+            raise ValueError("num_envs must be positive")
+        if frame_skip <= 0:
+            raise ValueError("frame_skip must be positive")
+        self._motrix = _load_motrix()
+        path = Path(model_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"Motrix model does not exist: {path}")
+        try:
+            self._model = self._motrix.load_model(str(path))
+            self._data = self._motrix.SceneData(self._model, batch=[num_envs])
+        except Exception as exc:  # noqa: BLE001 - normalize SDK diagnostics
+            raise BackendError(f"failed to materialize Motrix model {path}: {exc}") from exc
+        self._num_envs = num_envs
+        self._frame_skip = frame_skip
+        self._num_actuators = int(self._model.num_actuators)
+        self._num_dof_pos = int(self._model.num_dof_pos)
+        self._num_dof_vel = int(self._model.num_dof_vel)
+        self.reset()
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def num_actuators(self) -> int:
+        return self._num_actuators
+
+    @property
+    def capabilities(self) -> frozenset[BackendCapability]:
+        return frozenset(
+            {
+                BackendCapability.RESET,
+                BackendCapability.SELECTED_RESET,
+                BackendCapability.STATE_READ,
+                BackendCapability.STATE_WRITE,
+            }
+        )
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        controls = np.asarray(ctrl, dtype=np.float64)
+        expected = (self.num_envs, self.num_actuators)
+        if controls.shape != expected:
+            raise ValueError(f"ctrl shape {controls.shape} does not match {expected}")
+        if not np.isfinite(controls).all():
+            raise ValueError("ctrl contains NaN or Inf")
+        if nsteps < 1:
+            raise ValueError("nsteps must be positive")
+        self._data.actuator_ctrls = np.ascontiguousarray(controls)
+        self._model.step_n(self._data, int(nsteps * self._frame_skip))
+
+    def reset(self, env_ids: np.ndarray | None = None) -> None:
+        if env_ids is None:
+            self._data.reset(self._model)
+            return
+        ids = np.asarray(env_ids, dtype=np.intp)
+        if ids.ndim != 1:
+            raise ValueError("env_ids must be one-dimensional")
+        if np.any(ids < 0) or np.any(ids >= self.num_envs):
+            raise IndexError("env_ids contains an out-of-range index")
+        mask = np.zeros(self.num_envs, dtype=bool)
+        mask[ids] = True
+        self._data[mask].reset(self._model)
+
+    def get_state(self, fields: tuple[str, ...] | None = None) -> Mapping[str, np.ndarray]:
+        requested = ("qpos", "qvel", "ctrl") if fields is None else fields
+        result: dict[str, np.ndarray] = {}
+        for field in requested:
+            if field == "qpos":
+                result[field] = np.asarray(self._data.dof_pos).copy()
+            elif field == "qvel":
+                result[field] = np.asarray(self._data.dof_vel).copy()
+            elif field == "ctrl":
+                result[field] = np.asarray(self._data.actuator_ctrls).copy()
+            else:
+                raise KeyError(f"unknown Motrix state field: {field}")
+        return result
+
+    def set_state(self, state: Mapping[str, np.ndarray]) -> None:
+        if "qpos" in state:
+            qpos = np.asarray(state["qpos"], dtype=np.float64)
+            expected = (self.num_envs, self._num_dof_pos)
+            if qpos.shape != expected:
+                raise ValueError(f"qpos shape {qpos.shape} does not match {expected}")
+            self._data.set_dof_pos(qpos, self._model)
+        if "qvel" in state:
+            qvel = np.asarray(state["qvel"], dtype=np.float64)
+            expected = (self.num_envs, self._num_dof_vel)
+            if qvel.shape != expected:
+                raise ValueError(f"qvel shape {qvel.shape} does not match {expected}")
+            self._data.set_dof_vel(qvel)
+
+
+__all__ = ["MotrixBackend"]

--- a/src/unisim/mujoco.py
+++ b/src/unisim/mujoco.py
@@ -73,6 +73,7 @@ class MuJoCoBackend(SimBackend):
         return frozenset(
             {
                 BackendCapability.RESET,
+                BackendCapability.SELECTED_RESET,
                 BackendCapability.STATE_READ,
                 BackendCapability.STATE_WRITE,
             }

--- a/tests/test_motrix.py
+++ b/tests/test_motrix.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim import MotrixBackend, assert_backend_conformance
+
+MODEL = """<mujoco model='unisim-test'>
+  <option timestep='0.01'/>
+  <worldbody><body name='base'><joint name='slide' type='slide' axis='1 0 0'/>
+    <geom type='box' size='0.05 0.05 0.05'/></body></worldbody>
+  <actuator><motor joint='slide' ctrlrange='-1 1'/></actuator>
+</mujoco>"""
+
+
+def test_motrix_backend_contract(tmp_path: Path) -> None:
+    pytest.importorskip("motrixsim")
+    model_path = tmp_path / "model.xml"
+    model_path.write_text(MODEL)
+    backend = MotrixBackend(model_path, num_envs=2)
+    assert_backend_conformance(backend)
+    backend.step(np.zeros((2, 1)))
+    assert backend.get_state(("qpos",))["qpos"].shape == (2, 1)
+

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- add lazy MotrixSim adapter implementing `unisim.SimBackend`
- add full and selected reset via native batched `SceneData` slices
- keep Motrix model/data private and expose NumPy state/control arrays
- add optional Motrix factory route and conformance smoke
- update migration/readme/changelog docs; benchmark remains API/schema-only
- bump package to `0.1.2` because `0.1.1` is already published on TestPyPI

## Roadmap

- UniLab parent: https://github.com/unilabsim/UniLab/issues/1428
- UniSim issue: #4

## Validation

- `uv run --extra motrix pytest tests/test_motrix.py -q` -> 1 passed
- `uv run ruff check .` -> passed
- `uv build` -> passed
- TestPyPI `unisim-core==0.1.2`: https://test.pypi.org/project/unisim-core/0.1.2/
- isolated TestPyPI smoke with `--refresh`: `import unisim` and `create_backend("fake")` passed

No UniLab branch is modified by this PR. Production PyPI is not touched.
