### PR TITLE
fix: fail closed for planned adapters

### DIFF
--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from .contract import SimBackend
+from .adapters import adapter_spec
+from .contract import BackendError, SimBackend
 
 
 def create_backend(backend_type: str, **kwargs: Any) -> SimBackend:
@@ -21,4 +22,13 @@ def create_backend(backend_type: str, **kwargs: Any) -> SimBackend:
         from .motrix import MotrixBackend
 
         return MotrixBackend(**kwargs)
+    try:
+        spec = adapter_spec(backend_type)
+    except KeyError:
+        raise ValueError(f"unknown UniSim backend: {backend_type!r}") from None
+    if spec.status == "planned":
+        raise BackendError(
+            f"backend '{backend_type}' is declared in the UniSim roadmap but its adapter "
+            "has not been migrated yet"
+        )
     raise ValueError(f"unknown UniSim backend: {backend_type!r}")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 
 from unisim import (
     ADAPTER_SPECS,
     BackendCapability,
+    BackendError,
     BenchmarkCase,
     FakeBackend,
     assert_backend_conformance,
@@ -39,3 +41,8 @@ def test_adapter_manifest_covers_roadmap_backends() -> None:
         "isaacgym",
         "isaacsim",
     }
+
+
+def test_planned_adapter_fails_closed() -> None:
+    with pytest.raises(BackendError, match="not been migrated"):
+        create_backend("drake")


### PR DESCRIPTION
## Summary

- recognize all seven roadmap backend identities through the shared manifest
- make planned-but-not-yet-migrated adapters fail closed with a stable diagnostic
- add regression coverage for the planned adapter path

## Validation

- `uv run ruff check .`
- `uv run pytest` -> 6 passed, 1 skipped

Tracks UniLab roadmap #1428. No UniLab branch is modified.
