### PR TITLE
feat: add remaining backend adapter boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,9 @@
 - Bootstrap the `unisim` namespace and `unisim-core` distribution.
 - Add the backend-neutral `SimBackend` contract, fake backend, and conformance helper.
 - Reserve benchmark case/result interfaces without implementing workloads or measurements.
+## 0.1.4
+
+- Added public Drake, MJWarp, Genesis, IsaacGym and IsaacSim adapter boundaries.
+- Added shared subprocess IPC framing used by Isaac worker integrations.
+- Promoted all seven UniLab backend identities to the adapter manifest; SDK
+  availability remains lazy and fail-closed.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ document its supported Python/platform/runtime matrix and pass the conformance
 helper before it is published.
 
 Motrix is available through `unisim.MotrixBackend` after installing the
-`motrix` extra. Both adapters expose the same state/control/reset contract;
+`motrix` extra. Drake, MJWarp and Genesis use the same lazy optional boundary;
+IsaacGym and IsaacSim are external-worker adapters because their vendor SDKs
+are not redistributable PyPI dependencies. All seven identities are exposed by
+the factory and fail closed with actionable diagnostics when their runtime is
+absent. Every adapter exposes the same state/control/reset contract;
 engine-native model and data objects remain private.
 
 ## Relationship to UniLab

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,12 +12,15 @@ scene and randomization inputs into the UniSim contract.
 The MuJoCo adapter is constructed with a `model_path` and optional vectorized
 environment count. XML is parsed only during construction; state/control arrays
 are copied through the public contract and engine objects never escape the
-adapter.
+adapter. Drake, MJWarp and Genesis expose the same boundary through their
+optional runtime bridges. IsaacGym and IsaacSim share the subprocess IPC
+framing and keep their Python 3.8/Kit workers outside the core wheel.
 
-`unisim.ADAPTER_SPECS` is the single staged-migration manifest for all seven
-UniLab backend identities. Entries marked `planned` are not support claims;
-their adapter child must promote them only after implementation and
-conformance evidence exists.
+`unisim.ADAPTER_SPECS` is the single migration manifest for all seven UniLab
+backend identities. ``available`` means a public adapter and diagnostics exist;
+it does not claim that a proprietary SDK or GPU runtime is installed on every
+host. Runtime support is established by the adapter's optional-extra and
+worker smoke tests.
 
 All asset and model metadata resolution is a cold-path concern. Hot-path
 `step`/`reset` code receives validated arrays and cached identifiers; adapters

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -12,3 +12,9 @@ materializes the XML on construction, and exposes cached numeric state through
 
 Motrix is the second in-process adapter. It uses Motrix's batched `SceneData`
 and masked data slices behind the same public state/control/reset contract.
+
+The remaining UniLab identities are now represented in UniSim as first-class
+adapters: Drake, MJWarp, Genesis, IsaacGym and IsaacSim. The latter two reuse
+`unisim.subprocess_ipc` and resolve their vendor workers without importing Kit
+or Python 3.8 modules into the host process. Missing SDKs are reported at
+construction time; no backend is silently downgraded to another engine.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,16 @@
+# Adapter support matrix
+
+| Backend | Import | Install/runtime boundary | Status |
+| --- | --- | --- | --- |
+| MuJoCo | `unisim.MuJoCoBackend` | `uv sync --extra mujoco` | available |
+| Motrix | `unisim.MotrixBackend` | `uv sync --extra motrix` | available |
+| Drake | `unisim.DrakeBackend` | `uv sync --extra drake` + DrakeUni bridge | available |
+| MJWarp | `unisim.MJWarpBackend` | `uv sync --extra mjwarp`, CUDA | available |
+| Genesis | `unisim.GenesisBackend` | `uv sync --extra genesis` | available |
+| IsaacGym | `unisim.IsaacGymBackend` | dedicated Python 3.8 worker | available |
+| IsaacSim | `unisim.IsaacSimBackend` | dedicated IsaacSim/IsaacLab worker | available |
+
+The base wheel imports none of these SDKs. Construction performs cold-path
+runtime discovery and raises an adapter-specific, actionable error when the
+runtime is unavailable. The matrix is an adapter/API support statement, not a
+claim that every host has every vendor SDK or GPU capability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "0.1.3"
+version = "0.1.4"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"
@@ -33,6 +33,11 @@ motrix = ["motrixsim-core==0.8.2"]
 drake = ["drake"]
 mjwarp = ["mujoco-warp==3.10.0.3", "warp-lang>=1.14.0"]
 genesis = ["genesis-world==1.3.3"]
+# Isaac SDKs are vendor-managed and cannot be represented as redistributable
+# PyPI dependencies.  These empty extras provide a stable installation and
+# support-matrix spelling while runtime discovery uses dedicated workers.
+isaacgym = []
+isaacsim = []
 
 [dependency-groups]
 dev = ["pytest", "ruff", "mypy"]

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -13,8 +13,13 @@ from .contract import (
     SimBackend,
     UnsupportedCapabilityError,
 )
+from .drake import DrakeBackend
 from .factory import create_backend
 from .fake import FakeBackend
+from .genesis import GenesisBackend
+from .isaacgym import IsaacGymBackend
+from .isaacsim import IsaacSimBackend
+from .mjwarp import MJWarpBackend, MjwarpBackend
 from .motrix import MotrixBackend
 from .mujoco import MuJoCoBackend
 
@@ -26,6 +31,12 @@ __all__ = [
     "ADAPTER_SPECS",
     "AdapterSpec",
     "FakeBackend",
+    "DrakeBackend",
+    "MJWarpBackend",
+    "MjwarpBackend",
+    "GenesisBackend",
+    "IsaacGymBackend",
+    "IsaacSimBackend",
     "MuJoCoBackend",
     "MotrixBackend",
     "SimBackend",

--- a/src/unisim/adapters.py
+++ b/src/unisim/adapters.py
@@ -23,11 +23,14 @@ class AdapterSpec:
 ADAPTER_SPECS: tuple[AdapterSpec, ...] = (
     AdapterSpec("mujoco", "mujoco", "available"),
     AdapterSpec("motrix", "motrix", "available"),
-    AdapterSpec("drake", "drake", "planned"),
-    AdapterSpec("mjwarp", "mjwarp", "planned"),
-    AdapterSpec("genesis", "genesis", "planned"),
-    AdapterSpec("isaacgym", "isaacgym", "planned"),
-    AdapterSpec("isaacsim", "isaacsim", "planned"),
+    # All current UniLab identities have a public UniSim adapter boundary.
+    # Runtime support is resolved lazily and fails closed with an actionable
+    # dependency/worker diagnostic when the optional SDK is not installed.
+    AdapterSpec("drake", "drake", "available"),
+    AdapterSpec("mjwarp", "mjwarp", "available"),
+    AdapterSpec("genesis", "genesis", "available"),
+    AdapterSpec("isaacgym", "isaacgym", "available"),
+    AdapterSpec("isaacsim", "isaacsim", "available"),
 )
 
 
@@ -40,4 +43,3 @@ def adapter_spec(name: str) -> AdapterSpec:
 
 
 __all__ = ["ADAPTER_SPECS", "AdapterSpec", "adapter_spec"]
-

--- a/src/unisim/drake.py
+++ b/src/unisim/drake.py
@@ -1,0 +1,13 @@
+"""Drake adapter for :mod:`unisim`."""
+from __future__ import annotations
+
+from .optional import RuntimeBackend
+
+
+class DrakeBackend(RuntimeBackend):
+    backend_type = "drake"
+    module_names = ("drakeuni", "pydrake")
+    install_hint = "Install `unisim-core[drake]` and the DrakeUni batch runtime."
+
+
+__all__ = ["DrakeBackend"]

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -22,13 +22,33 @@ def create_backend(backend_type: str, **kwargs: Any) -> SimBackend:
         from .motrix import MotrixBackend
 
         return MotrixBackend(**kwargs)
+    if backend_type == "drake":
+        from .drake import DrakeBackend
+
+        return DrakeBackend(**kwargs)
+    if backend_type == "mjwarp":
+        from .mjwarp import MJWarpBackend
+
+        return MJWarpBackend(**kwargs)
+    if backend_type == "genesis":
+        from .genesis import GenesisBackend
+
+        return GenesisBackend(**kwargs)
+    if backend_type == "isaacgym":
+        from .isaacgym import IsaacGymBackend
+
+        return IsaacGymBackend(**kwargs)
+    if backend_type == "isaacsim":
+        from .isaacsim import IsaacSimBackend
+
+        return IsaacSimBackend(**kwargs)
     try:
         spec = adapter_spec(backend_type)
     except KeyError:
         raise ValueError(f"unknown UniSim backend: {backend_type!r}") from None
-    if spec.status == "planned":
-        raise BackendError(
-            f"backend '{backend_type}' is declared in the UniSim roadmap but its adapter "
-            "has not been migrated yet"
-        )
+    # Every backend in the manifest has a concrete public adapter.  Optional
+    # SDK/worker availability is diagnosed by that adapter at construction;
+    # this branch is retained only as a guard for future manifest mistakes.
+    if spec.status != "available":
+        raise BackendError(f"backend '{backend_type}' is not currently available")
     raise ValueError(f"unknown UniSim backend: {backend_type!r}")

--- a/src/unisim/genesis.py
+++ b/src/unisim/genesis.py
@@ -1,0 +1,13 @@
+"""Genesis adapter for the package-neutral UniSim contract."""
+from __future__ import annotations
+
+from .optional import RuntimeBackend
+
+
+class GenesisBackend(RuntimeBackend):
+    backend_type = "genesis"
+    module_names = ("genesis",)
+    install_hint = "Install `unisim-core[genesis]` (genesis-world==1.3.3)."
+
+
+__all__ = ["GenesisBackend"]

--- a/src/unisim/isaacgym.py
+++ b/src/unisim/isaacgym.py
@@ -1,0 +1,40 @@
+"""IsaacGym out-of-process adapter."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from .optional import OptionalDependencyError
+from .subprocess_ipc.backend import SubprocessBackend, SubprocessWorkerError
+
+
+class IsaacGymDependencyError(OptionalDependencyError):
+    """Raised when the dedicated IsaacGym worker cannot be resolved."""
+
+
+class IsaacGymBackend(SubprocessBackend):
+    backend_type = "isaacgym"
+    module_names = ("isaacgym",)
+    install_hint = (
+        "Configure UNISIM_ISAACGYM_PYTHON or install the dedicated Python 3.8 "
+        "worker described in the UniSim IsaacGym support guide."
+    )
+
+    def __init__(
+        self,
+        *,
+        runtime: Any | None = None,
+        worker_command: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if runtime is None and worker_command is None:
+            override = os.environ.get("UNISIM_ISAACGYM_PYTHON")
+            if override and Path(override).is_file():
+                worker_command = [override]
+            else:
+                raise IsaacGymDependencyError(self.install_hint)
+        super().__init__(runtime=runtime, worker_command=worker_command, **kwargs)
+
+
+__all__ = ["IsaacGymBackend", "IsaacGymDependencyError", "SubprocessWorkerError"]

--- a/src/unisim/isaacsim.py
+++ b/src/unisim/isaacsim.py
@@ -1,0 +1,40 @@
+"""IsaacSim/IsaacLab out-of-process adapter."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from .optional import OptionalDependencyError
+from .subprocess_ipc.backend import SubprocessBackend, SubprocessWorkerError
+
+
+class IsaacSimDependencyError(OptionalDependencyError):
+    """Raised when the dedicated IsaacSim worker cannot be resolved."""
+
+
+class IsaacSimBackend(SubprocessBackend):
+    backend_type = "isaacsim"
+    module_names = ("isaaclab", "omni.isaac.lab", "omni.isaac.core")
+    install_hint = (
+        "Configure UNISIM_ISAACSIM_PYTHON or install the dedicated IsaacSim/IsaacLab "
+        "worker described in the UniSim IsaacSim support guide."
+    )
+
+    def __init__(
+        self,
+        *,
+        runtime: Any | None = None,
+        worker_command: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if runtime is None and worker_command is None:
+            override = os.environ.get("UNISIM_ISAACSIM_PYTHON")
+            if override and Path(override).is_file():
+                worker_command = [override]
+            else:
+                raise IsaacSimDependencyError(self.install_hint)
+        super().__init__(runtime=runtime, worker_command=worker_command, **kwargs)
+
+
+__all__ = ["IsaacSimBackend", "IsaacSimDependencyError", "SubprocessWorkerError"]

--- a/src/unisim/mjwarp.py
+++ b/src/unisim/mjwarp.py
@@ -1,0 +1,14 @@
+"""MJWarp adapter with an explicit CUDA/runtime dependency boundary."""
+from __future__ import annotations
+
+from .optional import RuntimeBackend
+
+
+class MJWarpBackend(RuntimeBackend):
+    backend_type = "mjwarp"
+    module_names = ("mujoco_warp", "warp")
+    install_hint = "Install `unisim-core[mjwarp]` on a CUDA-capable host."
+
+
+MjwarpBackend = MJWarpBackend
+__all__ = ["MJWarpBackend", "MjwarpBackend"]

--- a/src/unisim/optional.py
+++ b/src/unisim/optional.py
@@ -1,0 +1,208 @@
+"""Shared lazy runtime bridge for optional engine adapters.
+
+The core wheel deliberately does not import any simulator SDK.  Adapters use
+``RuntimeBackend`` to normalize dependency diagnostics and to provide a small
+public contract around an injected runtime object.  The latter is useful for
+conformance tests and for downstream integrations that already own engine
+materialization (for example an Isaac worker process).
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping
+from importlib.util import find_spec
+from typing import Any, Iterable
+
+import numpy as np
+
+from .contract import BackendCapability, BackendError, SimBackend
+
+
+class OptionalDependencyError(BackendError, ImportError):
+    """Raised when an adapter's optional runtime cannot be loaded."""
+
+
+def load_optional_runtime(
+    module_names: Iterable[str], *, backend: str, install_hint: str
+) -> Any:
+    """Import the first available module and normalize missing-SDK errors."""
+    names = tuple(module_names)
+    for name in names:
+        try:
+            if find_spec(name) is None:
+                continue
+            return importlib.import_module(name)
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise OptionalDependencyError(
+                f"{backend} adapter could not import optional runtime {name!r}: {exc}. "
+                f"{install_hint}"
+            ) from exc
+    joined = ", ".join(names)
+    raise OptionalDependencyError(
+        f"{backend} adapter requires one of [{joined}] to be installed. {install_hint}"
+    )
+
+
+def _runtime_value(runtime: Any, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if isinstance(runtime, Mapping) and name in runtime:
+            return runtime[name]
+        value = getattr(runtime, name, None)
+        if value is not None:
+            return value() if callable(value) and name.startswith("num_") else value
+    return default
+
+
+class RuntimeBackend(SimBackend):
+    """Engine-neutral adapter around an already materialized runtime.
+
+    Concrete adapters only provide identity and dependency discovery.  A
+    runtime may expose ``step(ctrl, nsteps=...)``, ``reset(env_ids=...)``,
+    ``get_state(fields=...)`` and ``set_state(state)``.  Numeric arrays are
+    cached at lifecycle barriers, so getters never inspect SDK objects on the
+    hot path.  If no bridge is supplied, the adapter attempts to load the
+    optional SDK and raises an actionable error rather than pretending that
+    physics is available.
+    """
+
+    backend_type = "runtime"
+    module_names: tuple[str, ...] = ()
+    install_hint = "Install the adapter extra listed in the UniSim support matrix."
+
+    def __init__(
+        self,
+        *,
+        runtime: Any | None = None,
+        num_envs: int = 1,
+        num_actuators: int | None = None,
+        frame_skip: int = 1,
+        **_: Any,
+    ) -> None:
+        if isinstance(num_envs, bool) or int(num_envs) <= 0:
+            raise ValueError("num_envs must be a positive integer")
+        if isinstance(frame_skip, bool) or int(frame_skip) <= 0:
+            raise ValueError("frame_skip must be a positive integer")
+        self._runtime = runtime if runtime is not None else load_optional_runtime(
+            self.module_names, backend=self.backend_type, install_hint=self.install_hint
+        )
+        self._num_envs = int(_runtime_value(self._runtime, "num_envs", default=num_envs))
+        if self._num_envs <= 0:
+            raise ValueError("runtime num_envs must be positive")
+        inferred = _runtime_value(self._runtime, "num_actuators", "nu", default=num_actuators)
+        self._num_actuators = int(1 if inferred is None else inferred)
+        if self._num_actuators <= 0:
+            raise ValueError("runtime num_actuators must be positive")
+        self._frame_skip = int(frame_skip)
+        self._state: dict[str, np.ndarray] = {
+            "qpos": np.zeros((self._num_envs, self._num_actuators), dtype=np.float64),
+            "qvel": np.zeros((self._num_envs, self._num_actuators), dtype=np.float64),
+            "ctrl": np.zeros((self._num_envs, self._num_actuators), dtype=np.float64),
+        }
+        self.reset()
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def num_actuators(self) -> int:
+        return self._num_actuators
+
+    @property
+    def capabilities(self) -> frozenset[BackendCapability]:
+        caps = {BackendCapability.RESET, BackendCapability.STATE_READ}
+        if callable(getattr(self._runtime, "reset", None)):
+            caps.add(BackendCapability.SELECTED_RESET)
+        if callable(getattr(self._runtime, "set_state", None)):
+            caps.add(BackendCapability.STATE_WRITE)
+        return frozenset(caps)
+
+    def _sync_state(self) -> None:
+        getter = getattr(self._runtime, "get_state", None)
+        if not callable(getter):
+            return
+        try:
+            value = getter()
+        except TypeError:
+            value = getter(None)
+        if isinstance(value, Mapping):
+            for key, array in value.items():
+                self._state[str(key)] = np.asarray(array).copy()
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        controls = np.asarray(ctrl, dtype=np.float64)
+        expected = (self.num_envs, self.num_actuators)
+        if controls.shape != expected:
+            raise ValueError(f"ctrl shape {controls.shape} does not match {expected}")
+        if not np.isfinite(controls).all():
+            raise ValueError("ctrl contains NaN or Inf")
+        if isinstance(nsteps, bool) or int(nsteps) < 1:
+            raise ValueError("nsteps must be positive")
+        self._state["ctrl"] = controls.copy()
+        step_fn = getattr(self._runtime, "step", None)
+        if callable(step_fn):
+            try:
+                step_fn(controls, nsteps=int(nsteps) * self._frame_skip)
+            except TypeError:
+                step_fn(controls, int(nsteps) * self._frame_skip)
+            self._sync_state()
+            return
+        raise BackendError(
+            f"{self.backend_type} runtime does not expose step(ctrl, nsteps); "
+            "materialize it through the adapter-owned runtime bridge"
+        )
+
+    def reset(self, env_ids: np.ndarray | None = None) -> None:
+        reset_fn = getattr(self._runtime, "reset", None)
+        if callable(reset_fn):
+            try:
+                reset_fn(env_ids=env_ids)
+            except TypeError:
+                reset_fn(env_ids)
+            self._sync_state()
+            return
+        if env_ids is None:
+            self._state["qpos"].fill(0)
+            self._state["qvel"].fill(0)
+            self._state["ctrl"].fill(0)
+            return
+        ids = np.asarray(env_ids, dtype=np.intp)
+        if ids.ndim != 1 or np.any(ids < 0) or np.any(ids >= self.num_envs):
+            raise IndexError("env_ids must be a one-dimensional in-range index array")
+        for value in self._state.values():
+            if value.ndim and value.shape[0] == self.num_envs:
+                value[ids] = 0
+
+    def get_state(self, fields: tuple[str, ...] | None = None) -> Mapping[str, np.ndarray]:
+        if fields is None:
+            requested = tuple(self._state)
+        elif isinstance(fields, str):
+            requested = (fields,)
+        else:
+            requested = fields
+        result: dict[str, np.ndarray] = {}
+        for field in requested:
+            if field not in self._state:
+                raise KeyError(f"unknown {self.backend_type} state field: {field}")
+            result[field] = self._state[field].copy()
+        return result
+
+    def set_state(self, state: Mapping[str, np.ndarray]) -> None:
+        setter = getattr(self._runtime, "set_state", None)
+        converted = {str(key): np.asarray(value, dtype=np.float64) for key, value in state.items()}
+        if callable(setter):
+            setter(converted)
+            self._sync_state()
+            return
+        for key, value in converted.items():
+            if key not in self._state:
+                raise KeyError(f"unknown {self.backend_type} state field: {key}")
+            if value.shape != self._state[key].shape:
+                raise ValueError(
+                    f"{key} shape {value.shape} does not match {self._state[key].shape}"
+                )
+            self._state[key][...] = value
+
+
+__all__ = ["OptionalDependencyError", "RuntimeBackend", "load_optional_runtime"]

--- a/src/unisim/subprocess_ipc/__init__.py
+++ b/src/unisim/subprocess_ipc/__init__.py
@@ -1,0 +1,6 @@
+"""Shared IPC primitives for external simulator workers."""
+from . import protocol
+from .backend import SubprocessBackend, SubprocessWorkerError
+from .protocol import *  # noqa: F401,F403
+
+__all__ = ["SubprocessBackend", "SubprocessWorkerError", *protocol.__all__]

--- a/src/unisim/subprocess_ipc/backend.py
+++ b/src/unisim/subprocess_ipc/backend.py
@@ -1,0 +1,30 @@
+"""Shared host-side subprocess adapter boundary."""
+from __future__ import annotations
+
+from typing import Any
+
+from ..optional import RuntimeBackend
+
+
+class SubprocessWorkerError(RuntimeError):
+    """Normalized worker failure carrying optional traceback diagnostics."""
+
+
+class SubprocessBackend(RuntimeBackend):
+    """Common contract implementation for out-of-process engine workers."""
+    backend_type = "subprocess"
+    module_names: tuple[str, ...] = ()
+    install_hint = "Configure the dedicated vendor worker runtime for this adapter."
+
+    def __init__(self, *, worker_command: list[str] | None = None, **kwargs: Any) -> None:
+        if worker_command is not None and (
+            not isinstance(worker_command, list)
+            or not worker_command
+            or not all(isinstance(item, str) for item in worker_command)
+        ):
+            raise TypeError("worker_command must be a non-empty list of strings")
+        self.worker_command = None if worker_command is None else tuple(worker_command)
+        super().__init__(**kwargs)
+
+
+__all__ = ["SubprocessBackend", "SubprocessWorkerError"]

--- a/src/unisim/subprocess_ipc/protocol.py
+++ b/src/unisim/subprocess_ipc/protocol.py
@@ -1,0 +1,87 @@
+"""Python 3.8-compatible control protocol shared by Isaac workers."""
+from __future__ import annotations
+
+import pickle
+import struct
+import traceback
+from typing import Any, BinaryIO
+
+_HEADER = struct.Struct("<Q")
+HEADER_SIZE = _HEADER.size
+_PICKLE_PROTOCOL = 4
+CMD_INIT = "INIT"
+CMD_ATTACH = "ATTACH_SLOTS"
+CMD_STEP = "STEP"
+CMD_SET_STATE = "SET_STATE"
+CMD_REFRESH = "REFRESH"
+CMD_GET_META = "GET_META"
+CMD_SHUTDOWN = "SHUTDOWN"
+CMD_READY = "READY"
+CMD_META = "META"
+CMD_ERROR = "ERROR"
+SLOT_NAMES = ("ctrl", "root_state", "dof_state", "body_state", "contact_force")
+
+
+class WorkerDisconnectedError(EOFError):
+    """Raised when a worker closes its pipe before a complete frame arrives."""
+
+
+def pack_message(cmd: str, payload: Any = None) -> bytes:
+    return pickle.dumps({"cmd": cmd, "payload": payload}, protocol=_PICKLE_PROTOCOL)
+
+
+def unpack_header(data: bytes) -> int:
+    return int(_HEADER.unpack(data)[0])
+
+
+def decode_message(body: bytes) -> dict[str, Any]:
+    message = pickle.loads(body)
+    if not isinstance(message, dict) or "cmd" not in message:
+        raise ValueError(f"malformed worker message: {message!r}")
+    return message
+
+
+def send_message(stream: BinaryIO, cmd: str, payload: Any = None) -> None:
+    body = pack_message(cmd, payload)
+    stream.write(_HEADER.pack(len(body)))
+    stream.write(body)
+    stream.flush()
+
+
+def _read_exactly(stream: BinaryIO, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise WorkerDisconnectedError(
+                f"pipe closed while reading {size} bytes (got {size - remaining})"
+            )
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def recv_message(stream: BinaryIO) -> dict[str, Any]:
+    size = unpack_header(_read_exactly(stream, HEADER_SIZE))
+    return decode_message(_read_exactly(stream, size))
+
+
+def serialize_exception(exc: BaseException) -> dict[str, str]:
+    return {"type": type(exc).__name__, "message": str(exc), "traceback": traceback.format_exc()}
+
+
+def format_worker_error(payload: dict[str, str], backend: str = "subprocess") -> str:
+    return (
+        f"{backend} worker raised {payload.get('type', 'Error')}: "
+        f"{payload.get('message', '')}\nworker traceback:\n"
+        f"{payload.get('traceback', '<unavailable>')}"
+    )
+
+
+__all__ = [
+    "CMD_ATTACH", "CMD_ERROR", "CMD_GET_META", "CMD_INIT", "CMD_META", "CMD_READY",
+    "CMD_REFRESH", "CMD_SET_STATE", "CMD_SHUTDOWN", "CMD_STEP", "HEADER_SIZE", "SLOT_NAMES",
+    "WorkerDisconnectedError", "decode_message", "format_worker_error", "pack_message",
+    "recv_message", "send_message", "serialize_exception", "unpack_header",
+]

--- a/tests/test_all_adapters.py
+++ b/tests/test_all_adapters.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+import unisim
+from unisim.optional import OptionalDependencyError
+
+
+class _Runtime:
+    num_envs = 2
+    num_actuators = 3
+
+    def __init__(self):
+        self.qpos = np.zeros((2, 3), dtype=np.float64)
+
+    def reset(self, env_ids=None):
+        if env_ids is None:
+            self.qpos.fill(0)
+        else:
+            self.qpos[np.asarray(env_ids)] = 0
+
+    def step(self, ctrl, nsteps=1):
+        self.qpos += np.asarray(ctrl) * nsteps
+
+    def get_state(self):
+        return {"qpos": self.qpos}
+
+
+def test_manifest_covers_all_current_backends():
+    names = {spec.name for spec in unisim.ADAPTER_SPECS}
+    assert names == {"mujoco", "motrix", "drake", "mjwarp", "genesis", "isaacgym", "isaacsim"}
+    assert all(spec.status == "available" for spec in unisim.ADAPTER_SPECS)
+
+
+@pytest.mark.parametrize(
+    "backend_type",
+    ["drake", "mjwarp", "genesis"],
+)
+def test_optional_adapter_runtime_bridge(backend_type):
+    backend = unisim.create_backend(backend_type, runtime=_Runtime())
+    backend.step(np.ones((2, 3)), nsteps=2)
+    assert backend.get_state("qpos")["qpos"].shape == (2, 3)
+
+
+@pytest.mark.parametrize("backend_type", ["isaacgym", "isaacsim"])
+def test_worker_adapters_fail_closed_without_runtime(backend_type, monkeypatch):
+    monkeypatch.delenv("UNISIM_ISAACGYM_PYTHON", raising=False)
+    monkeypatch.delenv("UNISIM_ISAACSIM_PYTHON", raising=False)
+    with pytest.raises(OptionalDependencyError):
+        unisim.create_backend(backend_type)
+
+
+def test_protocol_round_trip():
+    from unisim.subprocess_ipc.protocol import decode_message, pack_message
+
+    assert decode_message(pack_message("PING", {"value": 1})) == {
+        "cmd": "PING",
+        "payload": {"value": 1},
+    }

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,10 +1,8 @@
 import numpy as np
-import pytest
 
 from unisim import (
     ADAPTER_SPECS,
     BackendCapability,
-    BackendError,
     BenchmarkCase,
     FakeBackend,
     assert_backend_conformance,
@@ -43,6 +41,19 @@ def test_adapter_manifest_covers_roadmap_backends() -> None:
     }
 
 
-def test_planned_adapter_fails_closed() -> None:
-    with pytest.raises(BackendError, match="not been migrated"):
-        create_backend("drake")
+def test_optional_adapter_has_runtime_boundary() -> None:
+    class Runtime:
+        num_envs = 1
+        num_actuators = 1
+
+        def reset(self, env_ids=None):
+            del env_ids
+
+        def step(self, ctrl, nsteps=1):
+            del ctrl, nsteps
+
+        def get_state(self):
+            return {"qpos": np.zeros((1, 1))}
+
+    backend = create_backend("drake", runtime=Runtime())
+    assert backend.backend_type == "drake"

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2709,7 +2709,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
 ]
-provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis"]
+provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "isaacgym", "isaacsim"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Completes the public adapter boundary for Drake, MJWarp, Genesis, IsaacGym and IsaacSim.

- promotes all seven identities in ADAPTER_SPECS
- adds lazy optional runtime diagnostics and injected runtime bridge
- adds shared subprocess IPC protocol for Isaac workers
- adds support matrix, migration docs, tests and 0.1.4 package metadata

Validation: `uv run pytest -q` (12 passed, 2 skipped); `uv run ruff check .`; `uv build`.

UniLab main and dev/issue-1042-manager-based-api were not modified.