### PR TITLE
chore: release unisim-core 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,7 @@
 - Added shared subprocess IPC framing used by Isaac worker integrations.
 - Promoted all seven UniLab backend identities to the adapter manifest; SDK
   availability remains lazy and fail-closed.
+## 0.1.5
+
+- Exported adapter-specific dependency diagnostics and the shared subprocess
+  backend types from the public `unisim` namespace.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "0.1.4"
+version = "0.1.5"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -17,11 +17,13 @@ from .drake import DrakeBackend
 from .factory import create_backend
 from .fake import FakeBackend
 from .genesis import GenesisBackend
-from .isaacgym import IsaacGymBackend
-from .isaacsim import IsaacSimBackend
+from .isaacgym import IsaacGymBackend, IsaacGymDependencyError
+from .isaacsim import IsaacSimBackend, IsaacSimDependencyError
 from .mjwarp import MJWarpBackend, MjwarpBackend
 from .motrix import MotrixBackend
 from .mujoco import MuJoCoBackend
+from .optional import OptionalDependencyError
+from .subprocess_ipc.backend import SubprocessBackend, SubprocessWorkerError
 
 __all__ = [
     "BackendCapability",
@@ -36,7 +38,12 @@ __all__ = [
     "MjwarpBackend",
     "GenesisBackend",
     "IsaacGymBackend",
+    "IsaacGymDependencyError",
     "IsaacSimBackend",
+    "IsaacSimDependencyError",
+    "OptionalDependencyError",
+    "SubprocessBackend",
+    "SubprocessWorkerError",
     "MuJoCoBackend",
     "MotrixBackend",
     "SimBackend",

--- a/uv.lock
+++ b/uv.lock
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Publishes the current adapter boundary with public dependency diagnostics and subprocess types exported from `unisim`.

TestPyPI: `unisim-core==0.1.5` uploaded successfully.
Validation: `uv run pytest -q` (13 passed, 2 skipped), `uv run ruff check .`, `uv build`, isolated TestPyPI import smoke.

Follow-up to roadmap #1428.