### PR TITLE
test: close package boundary and public exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.12 - 2026-09-02
+
+- Fix the root public export surface so wildcard imports resolve
+  `MjcfSubprocessBackend` and its historical `SubprocessBackend` alias.
+- Use package-owned `UNISIM_*` worker/cache environment variables and
+  `~/.cache/unisim` defaults, with read-only fallback to legacy `UNILAB_*`
+  overrides.
+- Expand adapter/factory/import-boundary tests for the complete seven-backend
+  manifest and package isolation.
+
 ## 0.1.11
 
 - Corrected the Drake adapter to consume the external `drake-uni` distribution

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ the factory and fail closed with actionable diagnostics when their runtime is
 absent. Every adapter exposes the same state/control/reset contract;
 engine-native model and data objects remain private.
 
+External worker roots can be configured with `UNISIM_ISAACGYM_HOME`,
+`UNISIM_ISAACGYM_PYTHON`, `UNISIM_ISAACSIM_HOME`, and
+`UNISIM_ISAACSIM_PYTHON`. The package also accepts the former `UNILAB_*`
+spellings as a migration fallback.
+
 ## Relationship to UniLab
 
 UniLab retains Hydra configuration, task/env/manager lifecycle, robot assets,

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,3 +18,8 @@ adapters: Drake (via the external `drake-uni` runtime), MJWarp, Genesis, IsaacGy
 `unisim.subprocess_ipc` and resolve their vendor workers without importing Kit
 or Python 3.8 modules into the host process. Missing SDKs are reported at
 construction time; no backend is silently downgraded to another engine.
+
+Runtime-owned caches and worker installations use the `UNISIM_*` environment
+variables and `~/.cache/unisim` defaults. The previous `UNILAB_*` names are
+accepted only as migration fallbacks so existing installations can move
+without losing cached state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "0.1.11"
+version = "0.1.12"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "IsaacSimDependencyError",
     "OptionalDependencyError",
     "SubprocessBackend",
+    "MjcfSubprocessBackend",
     "SubprocessWorkerError",
     "MuJoCoBackend",
     "MotrixBackend",
@@ -54,7 +55,11 @@ def __getattr__(name: str):
         "MjwarpBackend": (".backend.mjwarp", "MjwarpBackend"),
         "MotrixBackend": (".backend.motrix", "MotrixBackend"),
         "MuJoCoBackend": (".backend.mujoco", "MuJoCoBackend"),
-        "SubprocessBackend": (".backend.subprocess_ipc.backend", "SubprocessBackend"),
+        # ``SubprocessBackend`` was the name used by the first extraction
+        # draft. Keep it as a documented alias while the concrete shared host
+        # implementation is named ``MjcfSubprocessBackend`` internally.
+        "SubprocessBackend": (".backend.subprocess_ipc.backend", "MjcfSubprocessBackend"),
+        "MjcfSubprocessBackend": (".backend.subprocess_ipc.backend", "MjcfSubprocessBackend"),
         "SubprocessWorkerError": (".backend.subprocess_ipc.backend", "SubprocessWorkerError"),
     }
     target = modules.get(name)

--- a/src/unisim/backend/isaacgym/dependencies.py
+++ b/src/unisim/backend/isaacgym/dependencies.py
@@ -3,7 +3,7 @@
 IsaacGym only supports Python 3.6-3.8 and can never be installed into the
 main UniLab environment (Python >= 3.10).  Physics therefore runs in a
 dedicated conda env created by ``scripts/tools/setup_isaacgym_env.sh`` under
-``$UNILAB_ISAACGYM_HOME`` (default ``~/.unilab/isaacgym``):
+``$UNISIM_ISAACGYM_HOME`` (default ``~/.cache/unisim/isaacgym``):
 
 - ``miniconda3/envs/hsgym/bin/python3.8`` — the worker interpreter,
 - ``miniconda3/envs/hsgym/lib`` — prepended to the worker's
@@ -12,7 +12,9 @@ dedicated conda env created by ``scripts/tools/setup_isaacgym_env.sh`` under
   pip-installed ``ninja`` is reachable for the one-time gymtorch JIT compile,
 - ``isaacgym/python`` — appended to the worker's ``sys.path``.
 
-``UNILAB_ISAACGYM_PYTHON`` overrides the interpreter path explicitly.
+``UNISIM_ISAACGYM_PYTHON`` overrides the interpreter path explicitly.
+
+The former ``UNILAB_*`` names remain accepted as a migration fallback.
 """
 
 from __future__ import annotations
@@ -23,8 +25,10 @@ from pathlib import Path
 
 from unisim.optional import OptionalDependencyError
 
-ENV_PYTHON = "UNILAB_ISAACGYM_PYTHON"
-ENV_HOME = "UNILAB_ISAACGYM_HOME"
+ENV_PYTHON = "UNISIM_ISAACGYM_PYTHON"
+ENV_HOME = "UNISIM_ISAACGYM_HOME"
+_LEGACY_ENV_PYTHON = "UNILAB_ISAACGYM_PYTHON"
+_LEGACY_ENV_HOME = "UNILAB_ISAACGYM_HOME"
 
 _CONDA_ENV_REL = Path("miniconda3") / "envs" / "hsgym"
 _ISAACGYM_PYTHON_REL = Path("isaacgym") / "python"
@@ -50,8 +54,9 @@ class IsaacGymRuntime:
 
 
 def default_isaacgym_home() -> Path:
-    """Return the default IsaacGym install root (``UNILAB_ISAACGYM_HOME`` aware)."""
-    return Path(os.environ.get(ENV_HOME, "~/.unilab/isaacgym")).expanduser()
+    """Return the default IsaacGym install root (including legacy override)."""
+    value = os.environ.get(ENV_HOME) or os.environ.get(_LEGACY_ENV_HOME)
+    return Path(value or "~/.cache/unisim/isaacgym").expanduser()
 
 
 def _candidate_paths(home: Path) -> IsaacGymRuntime:
@@ -74,8 +79,8 @@ def resolve_isaacgym_runtime(python_override: str | None = None) -> IsaacGymRunt
 
     if python_override:
         python = Path(python_override).expanduser()
-    elif os.environ.get(ENV_PYTHON):
-        python = Path(os.environ[ENV_PYTHON]).expanduser()
+    elif os.environ.get(ENV_PYTHON) or os.environ.get(_LEGACY_ENV_PYTHON):
+        python = Path(os.environ.get(ENV_PYTHON) or os.environ[_LEGACY_ENV_PYTHON]).expanduser()
     else:
         python = runtime.python
     if not python.is_file():

--- a/src/unisim/backend/isaacsim/dependencies.py
+++ b/src/unisim/backend/isaacsim/dependencies.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from unisim.backend.subprocess_ipc.runtime import WorkerRuntime, build_worker_environment
 from unisim.optional import OptionalDependencyError
 
-ENV_HOME = "UNILAB_ISAACSIM_HOME"
-ENV_PYTHON = "UNILAB_ISAACSIM_PYTHON"
+ENV_HOME = "UNISIM_ISAACSIM_HOME"
+ENV_PYTHON = "UNISIM_ISAACSIM_PYTHON"
+_LEGACY_ENV_HOME = "UNILAB_ISAACSIM_HOME"
+_LEGACY_ENV_PYTHON = "UNILAB_ISAACSIM_PYTHON"
 
 _SETUP_HINT = (
     "Install the dedicated IsaacSim/IsaacLab worker environment with "
@@ -36,7 +38,8 @@ class IsaacSimRuntime(WorkerRuntime):
 
 
 def default_isaacsim_home() -> Path:
-    return Path(os.environ.get(ENV_HOME, "~/.unilab/isaacsim")).expanduser()
+    value = os.environ.get(ENV_HOME) or os.environ.get(_LEGACY_ENV_HOME)
+    return Path(value or "~/.cache/unisim/isaacsim").expanduser()
 
 
 def _candidate_paths(home: Path) -> IsaacSimRuntime:
@@ -53,7 +56,7 @@ def _candidate_paths(home: Path) -> IsaacSimRuntime:
 def _runtime_from_override(python: Path, home: Path) -> IsaacSimRuntime:
     """Build a runtime from an explicitly supplied interpreter.
 
-    ``UNILAB_ISAACSIM_PYTHON`` is intentionally a complete escape hatch for
+    ``UNISIM_ISAACSIM_PYTHON`` is intentionally a complete escape hatch for
     installations that do not use the helper script's directory layout.  If
     the interpreter looks like ``<venv>/bin/python``, we opportunistically
     discover its sibling library/site-packages directories; otherwise those
@@ -88,7 +91,7 @@ def resolve_isaacsim_runtime(python_override: str | None = None) -> IsaacSimRunt
     """Resolve the interpreter and package/source layout without importing Kit."""
     home = default_isaacsim_home()
     candidate = _candidate_paths(home)
-    override = python_override or os.environ.get(ENV_PYTHON)
+    override = python_override or os.environ.get(ENV_PYTHON) or os.environ.get(_LEGACY_ENV_PYTHON)
     if override:
         python = Path(override).expanduser()
         if not python.is_file():

--- a/src/unisim/backend/mujoco/chunk_tuner.py
+++ b/src/unisim/backend/mujoco/chunk_tuner.py
@@ -175,12 +175,17 @@ def make_cache_key(
 
 
 def cache_path() -> Path:
-    override = os.environ.get("UNILAB_CHUNK_SIZE_CACHE")
+    # Prefer package-owned names. Keep the old UniLab variable as a read-only
+    # compatibility fallback so existing training jobs reuse their cache while
+    # new consumers never need to know about the extracting repository.
+    override = os.environ.get("UNISIM_CHUNK_SIZE_CACHE") or os.environ.get(
+        "UNILAB_CHUNK_SIZE_CACHE"
+    )
     if override:
         return Path(override)
     xdg = os.environ.get("XDG_CACHE_HOME")
     root = Path(xdg) if xdg else Path.home() / ".cache"
-    return root / "unilab" / "chunk_size.json"
+    return root / "unisim" / "chunk_size.json"
 
 
 def load_cache(path: Path) -> dict:

--- a/tests/test_all_adapters.py
+++ b/tests/test_all_adapters.py
@@ -10,6 +10,27 @@ def test_manifest_covers_all_current_backends():
     assert all(spec.status == "available" for spec in unisim.ADAPTER_SPECS)
 
 
+@pytest.mark.parametrize(
+    ("backend_type", "export_name"),
+    [
+        ("mujoco", "MuJoCoBackend"),
+        ("motrix", "MotrixBackend"),
+        ("drake", "DrakeBackend"),
+        ("mjwarp", "MjwarpBackend"),
+        ("genesis", "GenesisBackend"),
+        ("isaacgym", "IsaacGymBackend"),
+        ("isaacsim", "IsaacSimBackend"),
+    ],
+)
+def test_every_manifest_adapter_has_a_lazy_public_class(backend_type: str, export_name: str):
+    spec = unisim.adapter_spec(backend_type)
+    adapter = getattr(unisim, export_name)
+
+    assert spec.status == "available"
+    assert isinstance(adapter, type)
+    assert adapter.__module__.startswith("unisim.backend.")
+
+
 @pytest.mark.parametrize("backend_type", ["mujoco", "motrix", "drake", "mjwarp", "genesis"])
 def test_in_process_adapters_require_scene(backend_type):
     with pytest.raises(ValueError, match="requires a SceneCfg"):

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -44,3 +44,14 @@ def test_adapter_manifest_covers_roadmap_backends() -> None:
 def test_unknown_backend_fails_closed() -> None:
     with np.testing.assert_raises_regex(ValueError, "unknown UniSim backend"):
         create_backend("missing")
+
+
+def test_factory_rejects_invalid_body_state_required() -> None:
+    with np.testing.assert_raises_regex(TypeError, "body_state_required must be bool"):
+        create_backend("fake", body_state_required=1)  # type: ignore[arg-type]
+
+
+def test_fake_factory_path_is_engine_independent() -> None:
+    backend = create_backend("fake", num_envs=2, num_actuators=1)
+    assert isinstance(backend, FakeBackend)
+    assert backend.backend_type == "fake"

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 
+import unisim
+
 
 def test_import_does_not_pull_unilab_or_engine_modules():
     code = (
@@ -13,3 +15,11 @@ def test_import_does_not_pull_unilab_or_engine_modules():
         [sys.executable, "-c", code], check=False, capture_output=True, text=True
     )
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_public_exports_are_resolvable_and_wildcard_import_is_safe():
+    namespace: dict[str, object] = {}
+    exec("from unisim import *", {}, namespace)
+
+    assert set(unisim.__all__).issubset(namespace)
+    assert namespace["SubprocessBackend"] is namespace["MjcfSubprocessBackend"]

--- a/tests/test_package_boundary.py
+++ b/tests/test_package_boundary.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from unisim.backend import process_device
+from unisim.backend.isaacgym import dependencies as isaacgym_dependencies
+from unisim.backend.isaacsim import dependencies as isaacsim_dependencies
+from unisim.backend.mujoco import chunk_tuner
+
+
+def test_chunk_cache_uses_unisim_namespace_by_default(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("UNISIM_CHUNK_SIZE_CACHE", raising=False)
+    monkeypatch.delenv("UNILAB_CHUNK_SIZE_CACHE", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+    assert chunk_tuner.cache_path() == tmp_path / "unisim" / "chunk_size.json"
+
+
+def test_chunk_cache_accepts_legacy_override(monkeypatch, tmp_path: Path) -> None:
+    legacy = tmp_path / "legacy.json"
+    monkeypatch.delenv("UNISIM_CHUNK_SIZE_CACHE", raising=False)
+    monkeypatch.setenv("UNILAB_CHUNK_SIZE_CACHE", str(legacy))
+
+    assert chunk_tuner.cache_path() == legacy
+
+
+def test_package_owned_worker_overrides_take_precedence(monkeypatch, tmp_path: Path) -> None:
+    package_home = tmp_path / "package-home"
+    legacy_home = tmp_path / "legacy-home"
+    monkeypatch.setenv("UNISIM_ISAACGYM_HOME", str(package_home))
+    monkeypatch.setenv("UNILAB_ISAACGYM_HOME", str(legacy_home))
+    assert isaacgym_dependencies.default_isaacgym_home() == package_home
+
+    monkeypatch.setenv("UNISIM_ISAACSIM_HOME", str(package_home))
+    monkeypatch.setenv("UNILAB_ISAACSIM_HOME", str(legacy_home))
+    assert isaacsim_dependencies.default_isaacsim_home() == package_home
+
+
+def test_backend_process_device_module_has_no_unilab_imports() -> None:
+    source = Path(process_device.__file__).read_text(encoding="utf-8")
+    assert "unilab" not in source.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -2620,7 +2620,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Part of unilabsim/UniLab#1428 and unilabsim/unisim#15.

## Result

- Fix the root `unisim.__all__` surface so `from unisim import *` resolves cleanly.
- Expose the canonical `MjcfSubprocessBackend` and retain the historical `SubprocessBackend` alias as a one-class API alias.
- Use package-owned `UNISIM_*` worker/cache environment variables with `~/.cache/unisim` defaults; legacy `UNILAB_*` overrides are read-only migration fallbacks.
- Add coverage for all seven manifest adapter exports, factory validation, wildcard imports, cache/worker names, and package import isolation.
- Bump the TestPyPI development release to `unisim-core==0.1.12`.

## Validation

- `uv run pytest -q` — 31 passed
- `uv run ruff check src tests` — passed
- `uv run ruff format --check src tests` — passed
- `uv lock --check` — passed
- `uv build` — wheel and sdist passed
- `uv run --with twine twine check /tmp/unisim-0.1.12/*` — passed

Production PyPI publication remains maintainer-owned after roadmap completion.
