### PR TITLE
docs: add TestPyPI release runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ uv run ruff check .
 uv build
 ```
 
+The TestPyPI and production release procedure is documented in
+[`docs/release.md`](docs/release.md).
+
 Engine adapters are optional extras and are loaded lazily. The MuJoCo adapter
 is available as `unisim.MuJoCoBackend` after installing the `mujoco` extra (or
 through `unisim.create_backend("mujoco", scene=...)`). Each adapter must

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,29 @@
+# Release Runbook
+
+This package is published as `unisim-core` and imported as `unisim`.
+Development and roadmap validation use TestPyPI only. Production PyPI remains
+a manual maintainer action after the UniLab roadmap handoff is accepted.
+
+## TestPyPI
+
+1. Update `project.version`, `CHANGELOG.md`, and the migration/support docs.
+2. Run `uv run pytest -q`, `uv run ruff check src tests`, and `uv build`.
+3. Run `uv run --with twine twine check dist/unisim_core-<version>*`.
+4. Upload the wheel and sdist to TestPyPI using credentials from `~/.pypirc`.
+   Never print, copy, or commit that file.
+5. Install the exact version in an isolated environment with TestPyPI as the
+   package index and verify `import unisim` without loading `unilab` or engine
+   SDK modules.
+6. Record the published URLs, artifact hashes, gate results, and rollback
+   decision in the release PR and the UniLab roadmap issue.
+
+Use the package-owned distribution and import names in all commands. Do not
+publish production PyPI while roadmap #1428 is open.
+
+## Production PyPI
+
+After the maintainer merges the final UniLab handoff PR and closes roadmap
+#1428, the maintainer may repeat the same artifact checks and publish the exact
+version to PyPI. Production publishing is intentionally not automated by this
+repository and is not performed by roadmap implementation agents.
+


### PR DESCRIPTION
Part of unilabsim/UniLab#1428.

Adds the missing release runbook covering TestPyPI-only roadmap releases, artifact checks, isolated import smoke, credential handling, rollback evidence, and maintainer-owned production PyPI publication.

Validation:
- `uv run pytest -q`: 31 passed
- `uv run ruff check src tests`: passed
- `uv run ruff format --check src tests`: passed
- `uv build`: wheel and sdist passed
