### PR TITLE
feat: support pre-step control callbacks on the mjwarp backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Support `SimBackend.set_pre_step_control` on the `mjwarp` backend: a
+  registered converter now runs on the host before every physics substep with
+  the qpos/qvel cache refreshed to the substep-start state (matching the
+  MuJoCo backend's substep boundary and `callback_sensordata=False` sensor
+  semantics), and `None` unregisters it.  The callback path uses eager kernel
+  launches instead of captured step graphs.
+
 ## 0.1.14 - 2026-09-02
 
 - Update the trusted-publishing action to support the source distribution's

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -23,6 +23,7 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    PreStepControlFn,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -128,9 +129,10 @@ class MjwarpBackend(SimBackend):
     recomputes derived constants with the graded ``set_const*`` family;
     interval DR stages ``xfrc_applied`` pushes/body forces for the next step
     barrier or kicks root velocity through the reset upload+forward path.
-    Per-world gravity DR, native rendering, and host-substep-controller
-    combinations remain fail-closed. Detached host snapshots support finite
-    MuJoCo-based offline recording.
+    A registered pre-step control converter runs on the host before every
+    physics substep (see ``set_pre_step_control``); per-world gravity DR and
+    native rendering remain fail-closed. Detached host snapshots support
+    finite MuJoCo-based offline recording.
     """
 
     def __init__(
@@ -1061,13 +1063,74 @@ class MjwarpBackend(SimBackend):
             "host_cache_refresh_ms": host_cache_ms,
         }
 
-    def set_pre_step_control(self, fn: Any | None) -> None:
-        if fn is not None:
-            raise NotImplementedError(
-                "mjwarp host_numpy profile rejects host pre-step callbacks; a per-substep "
-                "CPU callback would introduce an implicit device synchronization."
-            )
-        self._pre_step_control_fn = None
+    def set_pre_step_control(self, fn: PreStepControlFn | None) -> None:
+        """Register or clear the env-owned per-substep control converter.
+
+        Semantics match the MuJoCo backend: the callback runs once before
+        every physics substep with the host qpos/qvel cache refreshed to the
+        substep-start state, and its return value becomes that substep's
+        device ctrl.  Each invocation costs one explicit device round trip,
+        so the callback path intentionally uses eager kernel launches instead
+        of replaying the captured step graph.  Passing ``None`` restores the
+        direct control path.
+        """
+        self._pre_step_control_fn = fn
+
+    def _execute_host_step_with_pre_step_control(
+        self,
+        ctrl: np.ndarray,
+        nsteps: int,
+    ) -> dict[str, float]:
+        """Advance one legacy step through the registered per-substep converter.
+
+        Mirrors the MuJoCo backend's ``_step_with_pre_step_control`` substep
+        boundary: before every substep the host qpos/qvel cache holds the
+        substep-start state (the previous step/reset barrier already covers
+        substep 0), the owner callback converts the policy control, and the
+        result is uploaded as that substep's device ctrl.  Sensordata stays on
+        the end-of-step barrier, matching the MuJoCo backend's
+        ``callback_sensordata=False`` decision: action terms read
+        physics-state-backed getters only.
+        """
+        control_upload_ms = 0.0
+        host_cache_ms = 0.0
+
+        if self._xfrc_pending:
+            # Staged interval push/body forces apply for the whole upcoming
+            # step (all substeps), matching the direct-control path.
+            self._upload(self._device_data.xfrc_applied, self._xfrc_staging)
+
+        t0 = time.perf_counter()
+        for substep in range(nsteps):
+            if substep > 0:
+                t1 = time.perf_counter()
+                self._download(self._device_data.qpos, self._qpos_cache_storage)
+                self._download(self._device_data.qvel, self._qvel_cache_storage)
+                self._synchronize()
+                host_cache_ms += (time.perf_counter() - t1) * 1000.0
+            t1 = time.perf_counter()
+            np.copyto(self._ctrl_staging, self._apply_pre_step_control(ctrl))
+            self._upload(self._device_data.ctrl, self._ctrl_staging)
+            control_upload_ms += (time.perf_counter() - t1) * 1000.0
+            # Eager launch: a captured step graph cannot observe the
+            # per-substep host ctrl upload between kernel boundaries.
+            self._mujoco_warp.step(self._device_model, self._device_data)
+        if self._xfrc_pending:
+            self._xfrc_staging.fill(0.0)
+            self._upload(self._device_data.xfrc_applied, self._xfrc_staging)
+            self._xfrc_pending = False
+        self._synchronize()
+        physics_ms = (time.perf_counter() - t0) * 1000.0
+
+        t0 = time.perf_counter()
+        self._refresh_host_cache()
+        self._time_cache += np.float32(nsteps * self._sim_dt)
+        host_cache_ms += (time.perf_counter() - t0) * 1000.0
+        return {
+            "control_upload_ms": control_upload_ms,
+            "physics_ms": physics_ms,
+            "host_cache_refresh_ms": host_cache_ms,
+        }
 
     def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
         if isinstance(nsteps, bool) or int(nsteps) <= 0:
@@ -1076,7 +1139,10 @@ class MjwarpBackend(SimBackend):
         expected = (self._num_envs, self._nu)
         if ctrl_array.shape != expected:
             raise ValueError(f"ctrl must have shape {expected}, got {ctrl_array.shape}")
-        timings = self._execute_host_step(ctrl_array, int(nsteps))
+        if self._pre_step_control_fn is not None:
+            timings = self._execute_host_step_with_pre_step_control(ctrl_array, int(nsteps))
+        else:
+            timings = self._execute_host_step(ctrl_array, int(nsteps))
         return {"timing": timings}
 
     # All backends report the same set_state key set for column stability;

--- a/tests/test_mjwarp.py
+++ b/tests/test_mjwarp.py
@@ -1,0 +1,99 @@
+"""Runtime tests for the CUDA ``mjwarp`` backend pre-step control contract."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco_warp")
+pytest.importorskip("warp")
+
+import warp
+
+from unisim import MjwarpBackend
+from unisim.scene import SceneCfg
+
+MODEL = """<mujoco model='unisim-test-mjwarp'>
+  <option timestep='0.01'/>
+  <worldbody><body name='base'><joint name='slide' type='slide' axis='1 0 0'/>
+    <geom type='box' size='0.05 0.05 0.05'/></body></worldbody>
+  <actuator><motor joint='slide' ctrlrange='-10 10'/></actuator>
+</mujoco>"""
+
+
+def _make_backend(tmp_path: Path, model_name: str = "model.xml") -> MjwarpBackend:
+    warp.init()
+    if not bool(warp.get_device().is_cuda):
+        pytest.skip("mjwarp runtime tests require an active CUDA Warp device")
+    model_path = tmp_path / model_name
+    model_path.write_text(MODEL)
+    return MjwarpBackend(SceneCfg(model_file=str(model_path)), num_envs=2, sim_dt=0.01)
+
+
+def test_mjwarp_pre_step_control_per_substep(tmp_path: Path) -> None:
+    backend = _make_backend(tmp_path)
+    nsteps = 4
+    step_calls = 8
+    target = 0.2
+    kp = 20.0
+    observed_qpos: list[np.ndarray] = []
+    observed_ctrl: list[np.ndarray] = []
+
+    def p_controller(owner: MjwarpBackend, ctrl: np.ndarray) -> np.ndarray:
+        observed_qpos.append(owner.get_dof_pos().copy())
+        observed_ctrl.append(ctrl.copy())
+        return (target - owner.get_dof_pos()) * kp
+
+    ctrl = np.zeros((2, 1), dtype=np.float32)
+    backend.set_pre_step_control(p_controller)
+    result = backend.step(ctrl, nsteps=nsteps)
+    assert set(result["timing"]) == {"control_upload_ms", "physics_ms", "host_cache_refresh_ms"}
+    for _ in range(step_calls - 1):
+        backend.step(ctrl, nsteps=nsteps)
+
+    # (a) The converter ran exactly once per physics substep and always
+    # received the policy-level ctrl, not a previously converted value.
+    assert len(observed_qpos) == step_calls * nsteps
+    for received in observed_ctrl:
+        np.testing.assert_array_equal(received, ctrl)
+    # The callback saw fresh substep-start state: later observations reflect
+    # the motion driven by earlier substep controls.
+    assert not np.allclose(observed_qpos[0], observed_qpos[-1])
+
+    # (b) The converted control drove the joint toward the P-law target.
+    final_qpos = backend.get_dof_pos().copy()
+    assert np.all(np.abs(final_qpos - target) < 0.05)
+
+    # (c) Unregistering restores the direct control path: no further
+    # callbacks, and zero ctrl applies no force (this model has no damping or
+    # friction, so the joint coasts at constant velocity instead of seeking
+    # the P-law target).
+    backend.set_pre_step_control(None)
+    coast_qvel = backend.get_dof_vel().copy()
+    backend.step(np.zeros((2, 1), dtype=np.float32), nsteps=nsteps)
+    assert len(observed_qpos) == step_calls * nsteps
+    np.testing.assert_allclose(backend.get_dof_vel(), coast_qvel, atol=1e-5)
+
+
+def test_mjwarp_pre_step_control_changes_trajectory(tmp_path: Path) -> None:
+    baseline = _make_backend(tmp_path, "baseline.xml")
+    driven = _make_backend(tmp_path, "driven.xml")
+    nsteps = 4
+    ctrl = np.zeros((2, 1), dtype=np.float32)
+    for _ in range(8):
+        baseline.step(ctrl, nsteps=nsteps)
+    driven.set_pre_step_control(lambda owner, c: (0.2 - owner.get_dof_pos()) * 20.0)
+    for _ in range(8):
+        driven.step(ctrl, nsteps=nsteps)
+    np.testing.assert_allclose(baseline.get_dof_pos(), 0.0, atol=1e-6)
+    assert np.all(np.abs(driven.get_dof_pos() - baseline.get_dof_pos()) > 1e-2)
+
+
+def test_mjwarp_pre_step_control_validates_return_shape(tmp_path: Path) -> None:
+    backend = _make_backend(tmp_path)
+    ctrl = np.zeros((2, 1), dtype=np.float32)
+    backend.set_pre_step_control(lambda owner, c: np.zeros((2, 2), dtype=c.dtype))
+    with pytest.raises(ValueError, match="pre-step control must return shape"):
+        backend.step(ctrl, nsteps=1)
+    backend.set_pre_step_control(None)
+    backend.step(ctrl, nsteps=1)


### PR DESCRIPTION
## Summary

The `SimBackend.set_pre_step_control` contract (per-substep control callback, used by UniLab's MicroDuck BAM voltage actuator term, `requires_substep_state_feedback=True`) was previously a stub on the mjwarp backend — the callback was silently discarded. This PR implements it for real:

- `set_pre_step_control(fn)` now registers/unregisters the callback (`None` unregisters, satisfying env teardown).
- `step()` branches to a new `_execute_host_step_with_pre_step_control` only when a callback is registered; the direct path is byte-for-byte unchanged otherwise.
- Injection point: inside the substep loop, before each kernel launch — point-for-point aligned with the mujoco backend's `_step_with_pre_step_control` (substep 0 sees the barrier-refreshed state; later substeps refresh qpos/qvel host cache before invoking `fn(backend, ctrl)`; sensordata stays barrier-only, matching `callback_sensordata=False`).
- The callback path always uses eager `mujoco_warp.step` (captured step graphs cannot observe host ctrl uploads between substeps); reset/forward graphs are untouched, and unregistering restores graph replay on the direct path.
- `xfrc_applied` pending semantics, `_time_cache` accumulation, and timing keys are unchanged.

## Tests

- New `tests/test_mjwarp.py` (3 runtime tests, `importorskip` style as `test_mujoco.py`): callback invocation count and state visibility per substep; P-controller trajectory diverges from no-callback control and converges to target; unregister stops invocation and a wrong-shape return raises `ValueError`.
- Cross-backend parity spot check (not committed): same model, same P controller, mujoco vs mjwarp final qpos max diff 3e-8.

## Validation

- `make check` on final head 6bda2b4: ruff clean, 34 passed, 1 skipped (pre-existing motrix SDK skip). mjwarp runtime tests executed on an RTX 4090 with CUDA graphs enabled.
- CHANGELOG.md `## Unreleased` entry added per repo policy.

Note: the callback path pays one host↔device round trip per substep (inherent to the contract semantics); a small-scale throughput benchmark is recommended before large BAM training runs.