### PR TITLE
feat(dr): declarative interval term descriptors with generic backend dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@
 - Rework the README around the project overview, UniLab relationship,
   installation, and quick start, and add the Chinese `README_zh.md`.
 
+## 1.1.0 - 2026-09-05
+
+- Added the declarative interval domain-randomization term contract in
+  `unisim.dr.interval`: builtin term specs (`INTERVAL_TERM_SPECS`,
+  `interval_term_spec`), the pickle-safe `IntervalTermOp` descriptor with
+  builtin-contract validation, and the `ops` field on
+  `IntervalRandomizationPlan` (`iter_ops()` translates the legacy fields).
+- Added the `supported_interval_terms` capability set on
+  `DomainRandomizationCapabilities` with `supports_interval_term()` /
+  `get_unsupported_interval_terms()`, falling back to the legacy bools so old
+  constructor call sites keep their meaning.
+- Replaced the abstract per-backend `apply_interval_randomization`
+  implementations with generic `SimBackend` dispatch over the backend-owned
+  `_interval_term_handlers()` table; terms without a handler fail closed with
+  `NotImplementedError` naming the backend class and the term.
+- Deprecated the five legacy `IntervalRandomizationPlan` fields and the five
+  `supports_interval_*` capability bools; they remain functional and will be
+  removed in the next major release.
+- Fixed the mjwarp and genesis backends silently dropping unsupported
+  interval body-torque and body-angular-velocity randomization; both now fail
+  closed through the base dispatch.
+
 ## 1.0.0 - 2026-09-04
 
 - Promote the contract and seven-adapter manifest to the stable `1.0.x` line;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,3 +25,15 @@ worker smoke tests.
 All asset and model metadata resolution is a cold-path concern. Hot-path
 `step`/`reset` code receives validated arrays and cached identifiers; adapters
 must not probe private engine attributes dynamically.
+
+Interval domain randomization is declarative: UniLab's manager builds
+`IntervalRandomizationPlan.ops` from `IntervalTermOp` descriptors defined in
+`unisim.dr.interval` (term name, NumPy payload, optional body ids; stdlib +
+NumPy only so plans stay pickle-safe across spawn-based collector processes).
+Each backend owns its capability declaration (`supported_interval_terms`) and
+a cold-path-built `_interval_term_handlers()` table; the generic
+`SimBackend.apply_interval_randomization` dispatch validates each op against
+the builtin term specs, routes it to the matching handler, and fails closed
+with `NotImplementedError` for any term a backend does not declare. Custom
+terms are free-form strings owned by the registering backend and validated
+only against its capability set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "1.0.0"
+version = "1.1.0"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -10,6 +10,7 @@ from unisim.dr.types import (
     DomainRandomizationCapabilities,
     InitRandomizationPlan,
     IntervalRandomizationPlan,
+    IntervalTermOp,
     ResetRandomizationPayload,
 )
 
@@ -604,9 +605,39 @@ class SimBackend(abc.ABC):
     def materialize(self) -> None:
         """Finalize cold-path backend resources before reset/step."""
 
-    @abc.abstractmethod
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
-        """Apply a scheduled interval randomization plan."""
+        """Apply a scheduled interval randomization plan.
+
+        Generic dispatch: each op yielded by ``plan.iter_ops()`` is validated
+        against the builtin term specs (custom terms pass through) and routed
+        to the backend-owned handler table returned by
+        :meth:`_interval_term_handlers`.  A term without a handler fails
+        closed with ``NotImplementedError`` naming the backend class and the
+        term.  Backends that need per-plan prologue/epilogue semantics (for
+        example clearing staged external forces before the ops accumulate)
+        keep a thin override that calls this base implementation.
+        """
+        if plan.is_empty():
+            return
+        handlers = self._interval_term_handlers()
+        for op in plan.iter_ops():
+            op.validate()
+            handler = handlers.get(op.term)
+            if handler is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} does not support interval term '{op.term}'"
+                )
+            handler(op)
+
+    def _interval_term_handlers(self) -> dict[str, Callable[[IntervalTermOp], None]]:
+        """Return the backend-owned interval term handler table.
+
+        Backends build this dict once on the cold path (during init or lazily
+        cached on first use), keyed by term name; it must not be rebuilt per
+        call.  Any op whose term has no handler fails closed in
+        :meth:`apply_interval_randomization`.
+        """
+        return {}
 
     def apply_body_force(
         self,

--- a/src/unisim/backend/drake/backend.py
+++ b/src/unisim/backend/drake/backend.py
@@ -28,8 +28,10 @@ from unisim.backend.base import (
 )
 from unisim.backend.drake.playback import run_drake_playback
 from unisim.dr.types import (
+    INTERVAL_TERM_BODY_FORCE,
     DomainRandomizationCapabilities,
     IntervalRandomizationPlan,
+    IntervalTermOp,
     ResetRandomizationPayload,
 )
 from unisim.scene import SceneCfg
@@ -516,33 +518,31 @@ class DrakeBackend(SimBackend):
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         # Unsupported randomization knobs fail explicitly instead of silently
         # becoming no-ops.
-        return DomainRandomizationCapabilities(supports_interval_body_force=True)
+        return DomainRandomizationCapabilities(
+            supports_interval_body_force=True,
+            supported_interval_terms=frozenset({INTERVAL_TERM_BODY_FORCE}),
+        )
+
+    _interval_term_handler_cache: dict[str, Callable[[IntervalTermOp], None]] | None = None
 
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         if plan.is_empty():
             return
+        # A non-empty plan starts from cleared pending forces; the force
+        # handler then accumulates into ``_pending_body_forces``.
         self._pending_body_forces.fill(0.0)
-        if plan.push_perturbation_limit is not None:
-            raise NotImplementedError(
-                "DrakeBackend interval pushes require explicit body_ids and body_force"
-            )
-        if plan.body_torque is not None:
-            raise NotImplementedError(
-                "DrakeUni batch backend does not support interval body torque perturbation"
-            )
-        if plan.body_force is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-force perturbation requires body_ids")
-            self.apply_body_force(plan.body_ids, plan.body_force)
-        if plan.body_linear_velocity_delta is not None:
-            raise NotImplementedError(
-                "DrakeUni batch backend does not support interval body velocity perturbation"
-            )
-        if plan.body_angular_velocity_delta is not None:
-            raise NotImplementedError(
-                "DrakeUni batch backend does not support interval body angular velocity "
-                "perturbation"
-            )
+        super().apply_interval_randomization(plan)
+
+    def _interval_term_handlers(self) -> dict[str, Callable[[IntervalTermOp], None]]:
+        # Built lazily once; only body force has a handler.  Push, torque and
+        # velocity terms fail closed in the base dispatch.
+        if self._interval_term_handler_cache is None:
+            self._interval_term_handler_cache = {
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
+                    op.body_ids, op.payload
+                ),
+            }
+        return self._interval_term_handler_cache
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
         # Drake advances playback physics, while the shared playback helper

--- a/src/unisim/backend/genesis/backend.py
+++ b/src/unisim/backend/genesis/backend.py
@@ -32,12 +32,14 @@ from unisim.backend.base import (
     normalize_play_render_mode,
 )
 from unisim.dr.types import (
+    INTERVAL_TERM_BODY_FORCE,
     RESET_TERM_BASE_MASS,
     RESET_TERM_BODY_MASS,
     RESET_TERM_KD,
     RESET_TERM_KP,
     DomainRandomizationCapabilities,
     IntervalRandomizationPlan,
+    IntervalTermOp,
     ResetRandomizationPayload,
 )
 from unisim.scene import SceneCfg
@@ -692,6 +694,7 @@ class GenesisBackend(SimBackend):
                 {RESET_TERM_BODY_MASS, RESET_TERM_BASE_MASS, RESET_TERM_KP, RESET_TERM_KD}
             ),
             supports_interval_body_force=True,
+            supported_interval_terms=frozenset({INTERVAL_TERM_BODY_FORCE}),
         )
 
     _UNSUPPORTED_RESET_TERMS = (
@@ -760,28 +763,23 @@ class GenesisBackend(SimBackend):
                 envs_idx=envs_idx,
             )
 
+    _interval_term_handler_cache: dict[str, Callable[[IntervalTermOp], None]] | None = None
+
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         self._require_state("apply_interval_randomization")
-        if plan.is_empty():
-            return
-        if plan.push_perturbation_limit is not None:
-            raise NotImplementedError(
-                "genesis backend does not support interval push perturbation; disable "
-                "push_robots in the owner YAML."
-            )
-        if plan.body_linear_velocity_delta is not None:
-            raise NotImplementedError(
-                "genesis backend does not support interval body-velocity deltas; disable "
-                "the term in the owner YAML."
-            )
-        if plan.body_torque is not None:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support interval body torque perturbation"
-            )
-        if plan.body_force is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-force perturbation requires body_ids")
-            self.apply_body_force(plan.body_ids, plan.body_force)
+        super().apply_interval_randomization(plan)
+
+    def _interval_term_handlers(self) -> dict[str, Callable[[IntervalTermOp], None]]:
+        # Built lazily once; only body force has a handler.  Push, torque and
+        # velocity terms fail closed in the base dispatch (angular velocity
+        # was previously silently dropped).
+        if self._interval_term_handler_cache is None:
+            self._interval_term_handler_cache = {
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
+                    op.body_ids, op.payload
+                ),
+            }
+        return self._interval_term_handler_cache
 
     def apply_body_force(
         self,

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -28,6 +28,9 @@ from unisim.backend.base import (
     normalize_play_render_mode,
 )
 from unisim.dr.types import (
+    INTERVAL_TERM_BODY_FORCE,
+    INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+    INTERVAL_TERM_PUSH,
     RESET_TERM_BASE_COM,
     RESET_TERM_BASE_MASS,
     RESET_TERM_BODY_INERTIA,
@@ -39,7 +42,7 @@ from unisim.dr.types import (
     RESET_TERM_KD,
     RESET_TERM_KP,
     DomainRandomizationCapabilities,
-    IntervalRandomizationPlan,
+    IntervalTermOp,
     ResetRandomizationPayload,
 )
 from unisim.scene import SceneCfg
@@ -1257,6 +1260,15 @@ class MjwarpBackend(SimBackend):
                 self._interval_root_velocity_qvel_ids is not None
             ),
             supports_interval_body_force=True,
+            supported_interval_terms=frozenset(
+                {INTERVAL_TERM_BODY_FORCE}
+                | ({INTERVAL_TERM_PUSH} if self._push_body_id is not None else set())
+                | (
+                    {INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA}
+                    if self._interval_root_velocity_qvel_ids is not None
+                    else set()
+                )
+            ),
         )
 
     # ------------------------------------------------------------------ #
@@ -1398,19 +1410,23 @@ class MjwarpBackend(SimBackend):
     # Interval domain randomization                                       #
     # ------------------------------------------------------------------ #
 
-    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
-        if plan.is_empty():
-            return
-        if plan.push_perturbation_limit is not None:
-            self.push_robots(plan.push_perturbation_limit)
-        if plan.body_force is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-force perturbation requires body_ids")
-            self.apply_body_force(plan.body_ids, plan.body_force)
-        if plan.body_linear_velocity_delta is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-velocity perturbation requires body_ids")
-            self._apply_body_linear_velocity_delta(plan.body_ids, plan.body_linear_velocity_delta)
+    _interval_term_handler_cache: dict[str, Callable[[IntervalTermOp], None]] | None = None
+
+    def _interval_term_handlers(self) -> dict[str, Callable[[IntervalTermOp], None]]:
+        # Built lazily once.  Torque and angular-velocity terms intentionally
+        # have no handler and fail closed in the base dispatch (previously
+        # they were silently dropped).
+        if self._interval_term_handler_cache is None:
+            self._interval_term_handler_cache = {
+                INTERVAL_TERM_PUSH: lambda op: self.push_robots(op.payload),
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
+                    op.body_ids, op.payload
+                ),
+                INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA: (
+                    lambda op: self._apply_body_linear_velocity_delta(op.body_ids, op.payload)
+                ),
+            }
+        return self._interval_term_handler_cache
 
     def push_robots(self, force_range: Sequence[float] | np.ndarray) -> None:
         """Sample one world-frame push force per env and stage it for the next step."""

--- a/src/unisim/backend/motrix/backend.py
+++ b/src/unisim/backend/motrix/backend.py
@@ -8,6 +8,8 @@ from typing import Any, TypeVar, cast
 import numpy as np
 
 from unisim.dr.types import (
+    INTERVAL_TERM_BODY_FORCE,
+    INTERVAL_TERM_PUSH,
     RESET_TERM_BASE_COM,
     RESET_TERM_BASE_MASS,
     RESET_TERM_BODY_IPOS,
@@ -18,7 +20,7 @@ from unisim.dr.types import (
     RESET_TERM_KP,
     DomainRandomizationCapabilities,
     InitRandomizationPlan,
-    IntervalRandomizationPlan,
+    IntervalTermOp,
     ResetRandomizationPayload,
 )
 from unisim.scene import SceneCfg
@@ -875,6 +877,14 @@ class MotrixBackend(SimBackend):
             supports_interval_push=True,
             supports_interval_body_velocity_delta=False,
             supports_interval_body_force=getattr(self, "_supports_external_force", False),
+            supported_interval_terms=frozenset(
+                {INTERVAL_TERM_PUSH}
+                | (
+                    {INTERVAL_TERM_BODY_FORCE}
+                    if getattr(self, "_supports_external_force", False)
+                    else set()
+                )
+            ),
         )
 
     def apply_init_randomization(self, plan: InitRandomizationPlan) -> None:
@@ -924,42 +934,21 @@ class MotrixBackend(SimBackend):
         self._init_geom_size_overrides = geom_size_overrides
         self._apply_init_geom_size_overrides(self._data, np.arange(self._num_envs, dtype=np.int32))
 
-    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
-        if plan.is_empty():
-            return
-        if plan.push_perturbation_limit is not None:
-            self.push_robots(plan.push_perturbation_limit)
-        if plan.body_torque is not None:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support interval body torque perturbation"
-            )
-        if plan.body_force is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-force perturbation requires body_ids")
-            self.apply_body_force(plan.body_ids, plan.body_force)
-        if plan.body_linear_velocity_delta is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-velocity perturbation requires body_ids")
-            self._apply_body_linear_velocity_delta(plan.body_ids, plan.body_linear_velocity_delta)
-        if plan.body_angular_velocity_delta is not None:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support interval body angular velocity "
-                "perturbation"
-            )
+    _interval_term_handler_cache: dict[str, Callable[[IntervalTermOp], None]] | None = None
 
-    def _apply_body_linear_velocity_delta(
-        self,
-        body_ids: np.ndarray,
-        velocity_delta: np.ndarray,
-    ) -> None:
-        """Apply a world-frame linear-velocity delta to specific bodies.
-
-        Backend-internal hook for ``apply_interval_randomization``; it is not
-        part of the public ``SimBackend`` surface.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support interval body velocity perturbation"
-        )
+    def _interval_term_handlers(self) -> dict[str, Callable[[IntervalTermOp], None]]:
+        # Built lazily once.  Torque, angular-velocity and linear-velocity
+        # terms intentionally have no handler and fail closed in the base
+        # dispatch; body force stays gated inside ``apply_body_force`` on the
+        # runtime external-force API probe.
+        if self._interval_term_handler_cache is None:
+            self._interval_term_handler_cache = {
+                INTERVAL_TERM_PUSH: lambda op: self.push_robots(op.payload),
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
+                    op.body_ids, op.payload
+                ),
+            }
+        return self._interval_term_handler_cache
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
         return BackendPlayCapabilities(

--- a/src/unisim/backend/mujoco/backend.py
+++ b/src/unisim/backend/mujoco/backend.py
@@ -13,6 +13,11 @@ import numpy as np
 from mujoco_uni.batch_env import BatchEnvPool
 
 from unisim.dr.types import (
+    INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_FORCE,
+    INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_TORQUE,
+    INTERVAL_TERM_PUSH,
     RESET_TERM_BASE_COM,
     RESET_TERM_BASE_MASS,
     RESET_TERM_BODY_INERTIA,
@@ -27,6 +32,7 @@ from unisim.dr.types import (
     DomainRandomizationCapabilities,
     InitRandomizationPlan,
     IntervalRandomizationPlan,
+    IntervalTermOp,
     ModelVariantSpec,
     ResetRandomizationPayload,
 )
@@ -1175,6 +1181,18 @@ class MuJoCoBackend(SimBackend):
             ),
             supports_interval_body_force=True,
             supports_interval_body_torque=True,
+            supported_interval_terms=frozenset(
+                {INTERVAL_TERM_BODY_FORCE, INTERVAL_TERM_BODY_TORQUE}
+                | ({INTERVAL_TERM_PUSH} if self._push_body_id >= 0 else set())
+                | (
+                    {
+                        INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+                        INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA,
+                    }
+                    if self._interval_root_velocity_qvel_ids is not None
+                    else set()
+                )
+            ),
         )
 
     def apply_init_randomization(self, plan: InitRandomizationPlan) -> None:
@@ -1208,30 +1226,46 @@ class MuJoCoBackend(SimBackend):
             model_file=self._model_file,
         )
 
+    _interval_term_handler_cache: dict[str, Callable[[IntervalTermOp], None]] | None = None
+
     def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
         if plan.is_empty():
             return
+        # A non-empty plan starts from cleared external wrenches; the force and
+        # torque handlers then accumulate into ``_pending_xfrc_applied``.
         self._pending_xfrc_applied.fill(0.0)
-        if plan.push_perturbation_limit is not None:
-            self.push_robots(plan.push_perturbation_limit)
-        if plan.body_force is not None or plan.body_torque is not None:
-            if plan.body_ids is None:
-                raise ValueError("Interval body-force perturbation requires body_ids")
-            force = plan.body_force
-            if force is None:
-                force = np.zeros((self._num_envs, len(plan.body_ids), 3), dtype=np.float64)
-            self.apply_body_force(plan.body_ids, force, torque=plan.body_torque)
-        if (
-            plan.body_linear_velocity_delta is not None
-            or plan.body_angular_velocity_delta is not None
-        ):
-            if plan.body_ids is None:
-                raise ValueError("Interval body-velocity perturbation requires body_ids")
-            self._apply_body_velocity_delta(
-                plan.body_ids,
-                plan.body_linear_velocity_delta,
-                plan.body_angular_velocity_delta,
-            )
+        super().apply_interval_randomization(plan)
+
+    def _interval_term_handlers(self) -> dict[str, Callable[[IntervalTermOp], None]]:
+        # Built lazily once; the table only binds methods, so it is stable for
+        # the backend lifetime and is never rebuilt per plan.
+        if self._interval_term_handler_cache is None:
+            self._interval_term_handler_cache = {
+                INTERVAL_TERM_PUSH: lambda op: self.push_robots(op.payload),
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
+                    op.body_ids, op.payload
+                ),
+                INTERVAL_TERM_BODY_TORQUE: lambda op: self._apply_body_torque(
+                    op.body_ids, op.payload
+                ),
+                INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA: (
+                    lambda op: self._apply_body_velocity_delta(op.body_ids, op.payload, None)
+                ),
+                INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA: (
+                    lambda op: self._apply_body_velocity_delta(op.body_ids, None, op.payload)
+                ),
+            }
+        return self._interval_term_handler_cache
+
+    def _apply_body_torque(self, body_ids: np.ndarray, torque: np.ndarray) -> None:
+        """Accumulate a torque-only wrench through the shared xfrc staging.
+
+        ``apply_body_force`` accumulates force and torque channels
+        independently, so a zero force keeps a plan carrying separate force
+        and torque ops numerically identical to the legacy single-call form.
+        """
+        zero_force = np.zeros((self._num_envs, len(body_ids), 3), dtype=np.float64)
+        self.apply_body_force(body_ids, zero_force, torque=torque)
 
     def _validate_body_velocity_delta(
         self,

--- a/src/unisim/backend/subprocess_ipc/backend.py
+++ b/src/unisim/backend/subprocess_ipc/backend.py
@@ -39,7 +39,6 @@ from unisim.backend.base import (
 )
 from unisim.dr.types import (
     DomainRandomizationCapabilities,
-    IntervalRandomizationPlan,
     ResetRandomizationPayload,
 )
 from unisim.scene import SceneCfg
@@ -1109,14 +1108,6 @@ class MjcfSubprocessBackend(SimBackend):
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         """Advertise no DR until per-env model mutation is effect-tested."""
         return DomainRandomizationCapabilities()
-
-    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
-        if plan.is_empty():
-            return
-        raise NotImplementedError(
-            f"{self._BACKEND_LABEL} does not support interval randomization; disable "
-            "push/body-force/body-velocity terms in the owner YAML."
-        )
 
     # ------------------------------------------------------------------ #
     # Native rendering / playback (worker-owned viewer and camera sensor)

--- a/src/unisim/dr/__init__.py
+++ b/src/unisim/dr/__init__.py
@@ -1,3 +1,4 @@
 """Package-neutral domain-randomization request types."""
 
+from .interval import *  # noqa: F401,F403
 from .types import *  # noqa: F401,F403

--- a/src/unisim/dr/interval.py
+++ b/src/unisim/dr/interval.py
@@ -1,0 +1,136 @@
+"""Declarative interval domain-randomization term descriptors.
+
+An interval randomization plan is a tuple of :class:`IntervalTermOp` entries:
+a term name, a NumPy payload, and optional target body ids.  The builtin
+specs below pin the payload contract for the terms shared between UniLab's
+domain-randomization manager and the backend adapters.  Custom terms are
+free-form strings owned by a backend and validated only against that
+backend's declared capability set; there is intentionally no mutable global
+registry for them.
+
+The module is stdlib + NumPy only so ops and plans stay pickle-safe
+(protocol 4) across spawn-based collector processes; no engine SDK may be
+imported here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+INTERVAL_TERM_PUSH = "push"
+INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA = "body_linear_velocity_delta"
+INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA = "body_angular_velocity_delta"
+INTERVAL_TERM_BODY_FORCE = "body_force"
+INTERVAL_TERM_BODY_TORQUE = "body_torque"
+
+__all__ = [
+    "INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA",
+    "INTERVAL_TERM_BODY_FORCE",
+    "INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA",
+    "INTERVAL_TERM_BODY_TORQUE",
+    "INTERVAL_TERM_PUSH",
+    "INTERVAL_TERM_SPECS",
+    "IntervalTermOp",
+    "IntervalTermSpec",
+    "interval_term_spec",
+    "validate_interval_op",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class IntervalTermSpec:
+    """Declared payload contract for one interval randomization term."""
+
+    name: str
+    requires_body_ids: bool
+    payload_ndim: int
+    doc: str
+
+
+INTERVAL_TERM_SPECS: tuple[IntervalTermSpec, ...] = (
+    IntervalTermSpec(
+        name=INTERVAL_TERM_PUSH,
+        requires_body_ids=False,
+        payload_ndim=1,
+        doc=(
+            "Per-axis push force limit with shape (3,); the backend samples "
+            "the actual world-frame push force per environment."
+        ),
+    ),
+    IntervalTermSpec(
+        name=INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+        requires_body_ids=True,
+        payload_ndim=3,
+        doc=(
+            "World-frame linear velocity delta with shape "
+            "(num_envs, len(body_ids), 3)."
+        ),
+    ),
+    IntervalTermSpec(
+        name=INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA,
+        requires_body_ids=True,
+        payload_ndim=3,
+        doc=(
+            "World-frame angular velocity delta with shape "
+            "(num_envs, len(body_ids), 3)."
+        ),
+    ),
+    IntervalTermSpec(
+        name=INTERVAL_TERM_BODY_FORCE,
+        requires_body_ids=True,
+        payload_ndim=3,
+        doc="World-frame external force with shape (num_envs, len(body_ids), 3).",
+    ),
+    IntervalTermSpec(
+        name=INTERVAL_TERM_BODY_TORQUE,
+        requires_body_ids=True,
+        payload_ndim=3,
+        doc="World-frame external torque with shape (num_envs, len(body_ids), 3).",
+    ),
+)
+
+
+def interval_term_spec(name: str) -> IntervalTermSpec:
+    """Return the builtin spec for ``name`` or raise a stable ``KeyError``."""
+    for spec in INTERVAL_TERM_SPECS:
+        if spec.name == name:
+            return spec
+    raise KeyError(f"unknown interval randomization term: {name!r}")
+
+
+@dataclass(frozen=True)
+class IntervalTermOp:
+    """One interval randomization operation: term, payload, optional bodies."""
+
+    term: str
+    payload: np.ndarray
+    body_ids: np.ndarray | None = None
+
+    def validate(self) -> None:
+        """Check the builtin spec contract; custom terms pass through."""
+        validate_interval_op(self)
+
+
+def validate_interval_op(op: IntervalTermOp) -> None:
+    """Validate ``op`` against its builtin spec, ignoring custom terms.
+
+    Builtin terms must carry ``body_ids`` exactly when their spec requires
+    them, and their payload must have the declared ndim.  Unknown (custom)
+    terms are backend-owned and pass through untouched.
+    """
+    try:
+        spec = interval_term_spec(op.term)
+    except KeyError:
+        return
+    if spec.requires_body_ids and op.body_ids is None:
+        raise ValueError(f"interval term '{op.term}' requires body_ids")
+    if not spec.requires_body_ids and op.body_ids is not None:
+        raise ValueError(f"interval term '{op.term}' does not accept body_ids")
+    payload_ndim = np.asarray(op.payload).ndim
+    if payload_ndim != spec.payload_ndim:
+        raise ValueError(
+            f"interval term '{op.term}' payload must have ndim "
+            f"{spec.payload_ndim}, got {payload_ndim}"
+        )

--- a/src/unisim/dr/types.py
+++ b/src/unisim/dr/types.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
+
+from .interval import (
+    INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_FORCE,
+    INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_TORQUE,
+    INTERVAL_TERM_PUSH,
+    IntervalTermOp,
+)
 
 RESET_TERM_BASE_COM = "base_com_offset"
 RESET_TERM_BASE_MASS = "base_mass_delta"
@@ -35,15 +44,50 @@ class ModelVariantSpec:
 
 @dataclass(frozen=True)
 class DomainRandomizationCapabilities:
+    """Backend domain-randomization capability declaration.
+
+    ``supported_interval_terms`` is the authoritative set-based declaration of
+    interval term support.  The five ``supports_interval_*`` bools are
+    deprecated (kept for backward compatibility; removed in the next major
+    release): :meth:`supports_interval_term` consults them only as a fallback
+    when the term is absent from ``supported_interval_terms``, so old
+    constructor call sites keep their meaning.
+    """
+
     supported_reset_terms: frozenset[str] = field(default_factory=frozenset)
     supports_interval_push: bool = False
     supports_interval_body_velocity_delta: bool = False
     supports_interval_body_angular_velocity_delta: bool = False
     supports_interval_body_force: bool = False
     supports_interval_body_torque: bool = False
+    supported_interval_terms: frozenset[str] = field(default_factory=frozenset)
+
+    _LEGACY_INTERVAL_TERM_FLAGS: ClassVar[dict[str, str]] = {
+        INTERVAL_TERM_PUSH: "supports_interval_push",
+        INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA: "supports_interval_body_velocity_delta",
+        INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA: (
+            "supports_interval_body_angular_velocity_delta"
+        ),
+        INTERVAL_TERM_BODY_FORCE: "supports_interval_body_force",
+        INTERVAL_TERM_BODY_TORQUE: "supports_interval_body_torque",
+    }
 
     def supports_reset_term(self, term: str) -> bool:
         return term in self.supported_reset_terms
+
+    def supports_interval_term(self, term: str) -> bool:
+        """Return whether the backend declares support for one interval term.
+
+        Set membership in ``supported_interval_terms`` wins; otherwise the
+        deprecated legacy bool mapped to ``term`` decides.
+        """
+        if term in self.supported_interval_terms:
+            return True
+        flag = self._LEGACY_INTERVAL_TERM_FLAGS.get(term)
+        return bool(getattr(self, flag)) if flag is not None else False
+
+    def get_unsupported_interval_terms(self, terms: Iterable[str]) -> frozenset[str]:
+        return frozenset(term for term in terms if not self.supports_interval_term(term))
 
     def get_unsupported_reset_terms(self, requested_terms: frozenset[str]) -> frozenset[str]:
         return frozenset(term for term in requested_terms if not self.supports_reset_term(term))
@@ -135,15 +179,44 @@ class ResetRandomizationPayload:
 
 @dataclass
 class IntervalRandomizationPlan:
+    """Scheduled interval randomization request.
+
+    The five legacy fields (``push_perturbation_limit``, ``body_ids``,
+    ``body_linear_velocity_delta``, ``body_angular_velocity_delta``,
+    ``body_force``, ``body_torque``) are deprecated: they are kept for
+    backward compatibility and will be removed in the next major release.
+    New code should populate ``ops`` with :class:`IntervalTermOp` entries.
+    :meth:`iter_ops` translates each set legacy field into one op; mixing
+    legacy fields and explicit ops is allowed and both are yielded.
+    """
+
     push_perturbation_limit: Sequence[float] | np.ndarray | None = None
     body_ids: np.ndarray | None = None
     body_linear_velocity_delta: np.ndarray | None = None
     body_angular_velocity_delta: np.ndarray | None = None
     body_force: np.ndarray | None = None
     body_torque: np.ndarray | None = None
+    ops: tuple[IntervalTermOp, ...] = ()
+
+    def iter_ops(self) -> tuple[IntervalTermOp, ...]:
+        """Return ops derived 1:1 from set legacy fields, then explicit ops."""
+        derived: list[IntervalTermOp] = []
+        if self.push_perturbation_limit is not None:
+            derived.append(
+                IntervalTermOp(INTERVAL_TERM_PUSH, np.asarray(self.push_perturbation_limit))
+            )
+        for term, payload in (
+            (INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA, self.body_linear_velocity_delta),
+            (INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA, self.body_angular_velocity_delta),
+            (INTERVAL_TERM_BODY_FORCE, self.body_force),
+            (INTERVAL_TERM_BODY_TORQUE, self.body_torque),
+        ):
+            if payload is not None:
+                derived.append(IntervalTermOp(term, payload, body_ids=self.body_ids))
+        return (*derived, *self.ops)
 
     def is_empty(self) -> bool:
-        return (
+        return not self.ops and (
             self.push_perturbation_limit is None
             and self.body_linear_velocity_delta is None
             and self.body_angular_velocity_delta is None

--- a/src/unisim/dr/types.py
+++ b/src/unisim/dr/types.py
@@ -200,6 +200,15 @@ class IntervalRandomizationPlan:
 
     def iter_ops(self) -> tuple[IntervalTermOp, ...]:
         """Return ops derived 1:1 from set legacy fields, then explicit ops."""
+        if (
+            self.push_perturbation_limit is None
+            and self.body_linear_velocity_delta is None
+            and self.body_angular_velocity_delta is None
+            and self.body_force is None
+            and self.body_torque is None
+        ):
+            # Hot-path fast path: ops-only plans avoid per-call re-allocation.
+            return self.ops
         derived: list[IntervalTermOp] = []
         if self.push_perturbation_limit is not None:
             derived.append(

--- a/src/unisim/fake.py
+++ b/src/unisim/fake.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 import numpy as np
 
 from .contract import BackendCapability, SimBackend
-from .dr.types import DomainRandomizationCapabilities, IntervalRandomizationPlan
+from .dr.types import DomainRandomizationCapabilities
 
 
 class FakeBackend(SimBackend):
@@ -114,10 +114,6 @@ class FakeBackend(SimBackend):
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         return DomainRandomizationCapabilities()
-
-    def apply_interval_randomization(self, plan: IntervalRandomizationPlan) -> None:
-        if not plan.is_empty():
-            raise NotImplementedError("fake backend has no randomization")
 
     @property
     def capabilities(self) -> frozenset[BackendCapability]:

--- a/tests/test_dr_interval.py
+++ b/tests/test_dr_interval.py
@@ -1,0 +1,299 @@
+"""Tests for the declarative interval domain-randomization term contract."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim.dr import (
+    INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_FORCE,
+    INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_TORQUE,
+    INTERVAL_TERM_PUSH,
+    INTERVAL_TERM_SPECS,
+    DomainRandomizationCapabilities,
+    IntervalRandomizationPlan,
+    IntervalTermOp,
+    IntervalTermSpec,
+    interval_term_spec,
+    validate_interval_op,
+)
+from unisim.fake import FakeBackend
+
+BUILTIN_TERMS = (
+    INTERVAL_TERM_PUSH,
+    INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA,
+    INTERVAL_TERM_BODY_FORCE,
+    INTERVAL_TERM_BODY_TORQUE,
+)
+
+BODY_IDS = np.asarray([1], dtype=np.int32)
+
+
+def test_interval_term_spec_registry_covers_builtin_terms() -> None:
+    assert tuple(spec.name for spec in INTERVAL_TERM_SPECS) == BUILTIN_TERMS
+    for name in BUILTIN_TERMS:
+        assert interval_term_spec(name) is not None
+    assert isinstance(interval_term_spec(INTERVAL_TERM_PUSH), IntervalTermSpec)
+    with pytest.raises(KeyError):
+        interval_term_spec("no_such_term")
+
+
+def test_interval_term_op_validation_builtin_contract() -> None:
+    payload = np.zeros((2, 1, 3))
+    validate_interval_op(IntervalTermOp(INTERVAL_TERM_BODY_FORCE, payload, body_ids=BODY_IDS))
+    with pytest.raises(ValueError, match="body_force"):
+        IntervalTermOp(INTERVAL_TERM_BODY_FORCE, payload).validate()
+    with pytest.raises(ValueError, match="push"):
+        IntervalTermOp(INTERVAL_TERM_PUSH, np.zeros(3), body_ids=BODY_IDS).validate()
+    with pytest.raises(ValueError, match="body_force"):
+        IntervalTermOp(INTERVAL_TERM_BODY_FORCE, np.zeros(3), body_ids=BODY_IDS).validate()
+    with pytest.raises(ValueError, match="push"):
+        IntervalTermOp(INTERVAL_TERM_PUSH, np.zeros((2, 3))).validate()
+
+
+def test_interval_term_op_validation_passes_custom_terms() -> None:
+    # Custom terms are backend-owned: no spec, no validation.
+    op = IntervalTermOp("custom_spin", np.zeros((7, 2)))
+    op.validate()
+    validate_interval_op(op)
+
+
+def test_interval_term_op_and_plan_pickle_round_trip() -> None:
+    op = IntervalTermOp(INTERVAL_TERM_BODY_FORCE, np.ones((2, 1, 3)), body_ids=BODY_IDS)
+    plan = IntervalRandomizationPlan(ops=(op, IntervalTermOp("custom", np.zeros(4))))
+    restored = pickle.loads(pickle.dumps(plan, protocol=4))
+    assert [restored_op.term for restored_op in restored.ops] == ["body_force", "custom"]
+    np.testing.assert_array_equal(restored.ops[0].payload, op.payload)
+    np.testing.assert_array_equal(restored.ops[0].body_ids, BODY_IDS)
+
+
+def test_plan_iter_ops_derives_legacy_fields() -> None:
+    lin = np.zeros((2, 1, 3))
+    force = np.ones((2, 1, 3))
+    plan = IntervalRandomizationPlan(
+        push_perturbation_limit=[1.0, 2.0, 3.0],
+        body_ids=BODY_IDS,
+        body_linear_velocity_delta=lin,
+        body_force=force,
+    )
+    ops = plan.iter_ops()
+    assert [op.term for op in ops] == [
+        INTERVAL_TERM_PUSH,
+        INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA,
+        INTERVAL_TERM_BODY_FORCE,
+    ]
+    np.testing.assert_array_equal(ops[0].payload, np.asarray([1.0, 2.0, 3.0]))
+    assert ops[0].body_ids is None
+    assert ops[1].payload is lin
+    assert ops[1].body_ids is BODY_IDS
+    assert ops[2].payload is force
+    assert ops[2].body_ids is BODY_IDS
+
+
+def test_plan_is_empty_semantics() -> None:
+    assert IntervalRandomizationPlan().is_empty()
+    # body_ids alone does not make a plan non-empty.
+    assert IntervalRandomizationPlan(body_ids=BODY_IDS).is_empty()
+    assert not IntervalRandomizationPlan(push_perturbation_limit=[1.0, 1.0, 1.0]).is_empty()
+    ops_only = IntervalRandomizationPlan(ops=(IntervalTermOp("custom", np.zeros(1)),))
+    assert not ops_only.is_empty()
+    mixed = IntervalRandomizationPlan(
+        push_perturbation_limit=[1.0, 1.0, 1.0],
+        ops=(IntervalTermOp("custom", np.zeros(1)),),
+    )
+    assert not mixed.is_empty()
+    assert [op.term for op in mixed.iter_ops()] == [INTERVAL_TERM_PUSH, "custom"]
+
+
+def test_capabilities_supported_interval_terms_and_legacy_fallback() -> None:
+    legacy = DomainRandomizationCapabilities(
+        supports_interval_push=True,
+        supports_interval_body_force=True,
+    )
+    assert legacy.supports_interval_term(INTERVAL_TERM_PUSH)
+    assert legacy.supports_interval_term(INTERVAL_TERM_BODY_FORCE)
+    assert not legacy.supports_interval_term(INTERVAL_TERM_BODY_TORQUE)
+    assert not legacy.supports_interval_term("custom")
+
+    declared = DomainRandomizationCapabilities(
+        supported_interval_terms=frozenset({INTERVAL_TERM_PUSH, "custom"})
+    )
+    assert declared.supports_interval_term(INTERVAL_TERM_PUSH)
+    assert declared.supports_interval_term("custom")
+    assert not declared.supports_interval_term(INTERVAL_TERM_BODY_FORCE)
+
+    unsupported = legacy.get_unsupported_interval_terms(
+        [INTERVAL_TERM_PUSH, INTERVAL_TERM_BODY_TORQUE, "custom"]
+    )
+    assert unsupported == frozenset({INTERVAL_TERM_BODY_TORQUE, "custom"})
+
+
+def test_base_dispatch_fails_closed_and_empty_plan_is_noop() -> None:
+    backend = FakeBackend()
+    backend.apply_interval_randomization(IntervalRandomizationPlan())
+    plan = IntervalRandomizationPlan(ops=(IntervalTermOp("custom_spin", np.zeros(3)),))
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.apply_interval_randomization(plan)
+    message = str(excinfo.value)
+    assert "FakeBackend" in message
+    assert "custom_spin" in message
+
+
+class _CustomTermBackend(FakeBackend):
+    """Fake backend that registers one custom interval term handler."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received: list[IntervalTermOp] = []
+        self._handlers = {"custom_spin": self.received.append}
+
+    def _interval_term_handlers(self):
+        return self._handlers
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        return DomainRandomizationCapabilities(
+            supported_interval_terms=frozenset({"custom_spin"})
+        )
+
+
+def test_backend_custom_term_handler_dispatch() -> None:
+    backend = _CustomTermBackend()
+    assert backend.get_dr_capabilities().supports_interval_term("custom_spin")
+    op = IntervalTermOp("custom_spin", np.zeros(3))
+    backend.apply_interval_randomization(IntervalRandomizationPlan(ops=(op,)))
+    assert backend.received == [op]
+    # A builtin term without a handler still fails closed.
+    with pytest.raises(NotImplementedError, match="push"):
+        backend.apply_interval_randomization(
+            IntervalRandomizationPlan(push_perturbation_limit=[1.0, 1.0, 1.0])
+        )
+
+
+MUJOCO_MODEL = """<mujoco model='unisim-test'>
+  <option timestep='0.01'/>
+  <worldbody><body name='base'><joint name='slide' type='slide' axis='1 0 0'/>
+    <geom type='box' size='0.05 0.05 0.05'/></body></worldbody>
+  <actuator><motor joint='slide' ctrlrange='-1 1'/></actuator>
+</mujoco>"""
+
+MUJOCO_FREE_MODEL = """<mujoco model='unisim-free'>
+  <option timestep='0.01'/>
+  <worldbody><body name='base'><joint name='free' type='free'/>
+    <geom type='box' size='0.05 0.05 0.05'/></body></worldbody>
+</mujoco>"""
+
+
+def _mujoco_backend(tmp_path: Path, model: str, num_envs: int = 2):
+    pytest.importorskip("mujoco")
+    from unisim import MuJoCoBackend
+    from unisim.scene import SceneCfg
+
+    model_path = tmp_path / "model.xml"
+    model_path.write_text(model)
+    return MuJoCoBackend(
+        SceneCfg(model_file=str(model_path)), num_envs=num_envs, sim_dt=0.01, base_name="base"
+    )
+
+
+def test_mujoco_interval_term_capabilities(tmp_path: Path) -> None:
+    backend = _mujoco_backend(tmp_path, MUJOCO_FREE_MODEL)
+    caps = backend.get_dr_capabilities()
+    assert caps.supported_interval_terms == frozenset(BUILTIN_TERMS)
+    for term in BUILTIN_TERMS:
+        assert caps.supports_interval_term(term)
+
+
+def test_mujoco_force_and_torque_legacy_ops_parity(tmp_path: Path) -> None:
+    backend = _mujoco_backend(tmp_path, MUJOCO_MODEL)
+    force = np.arange(6, dtype=np.float64).reshape(2, 1, 3)
+    torque = np.full((2, 1, 3), 0.5)
+
+    backend.apply_interval_randomization(
+        IntervalRandomizationPlan(body_ids=BODY_IDS, body_force=force, body_torque=torque)
+    )
+    legacy = backend._pending_xfrc_applied.copy()
+    backend.apply_interval_randomization(
+        IntervalRandomizationPlan(
+            ops=(
+                IntervalTermOp(INTERVAL_TERM_BODY_FORCE, force, body_ids=BODY_IDS),
+                IntervalTermOp(INTERVAL_TERM_BODY_TORQUE, torque, body_ids=BODY_IDS),
+            )
+        )
+    )
+    np.testing.assert_array_equal(legacy, backend._pending_xfrc_applied)
+
+    # A torque-only plan matches the legacy zero-force single-call form.
+    backend.apply_interval_randomization(
+        IntervalRandomizationPlan(body_ids=BODY_IDS, body_torque=torque)
+    )
+    legacy_torque_only = backend._pending_xfrc_applied.copy()
+    backend.apply_interval_randomization(
+        IntervalRandomizationPlan(
+            ops=(IntervalTermOp(INTERVAL_TERM_BODY_TORQUE, torque, body_ids=BODY_IDS),)
+        )
+    )
+    np.testing.assert_array_equal(legacy_torque_only, backend._pending_xfrc_applied)
+
+
+def test_mujoco_push_legacy_ops_parity(tmp_path: Path) -> None:
+    backend = _mujoco_backend(tmp_path, MUJOCO_MODEL)
+    limit = np.asarray([1.0, 2.0, 3.0])
+    np.random.seed(0)
+    backend.apply_interval_randomization(IntervalRandomizationPlan(push_perturbation_limit=limit))
+    legacy = backend._pending_xfrc_applied.copy()
+    np.random.seed(0)
+    backend.apply_interval_randomization(
+        IntervalRandomizationPlan(ops=(IntervalTermOp(INTERVAL_TERM_PUSH, limit),))
+    )
+    np.testing.assert_array_equal(legacy, backend._pending_xfrc_applied)
+
+
+def test_mujoco_velocity_delta_legacy_ops_parity(tmp_path: Path) -> None:
+    legacy_backend = _mujoco_backend(tmp_path, MUJOCO_FREE_MODEL)
+    legacy_backend.materialize()
+    lin = np.zeros((2, 1, 3))
+    lin[:, 0, 0] = 0.5
+    ang = np.zeros((2, 1, 3))
+    ang[:, 0, 2] = 0.25
+    legacy_backend.apply_interval_randomization(
+        IntervalRandomizationPlan(
+            body_ids=BODY_IDS,
+            body_linear_velocity_delta=lin,
+            body_angular_velocity_delta=ang,
+        )
+    )
+    legacy_state = legacy_backend.get_state(("qpos", "qvel"))
+
+    ops_backend = _mujoco_backend(tmp_path, MUJOCO_FREE_MODEL)
+    ops_backend.materialize()
+    ops_backend.apply_interval_randomization(
+        IntervalRandomizationPlan(
+            ops=(
+                IntervalTermOp(
+                    INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA, lin, body_ids=BODY_IDS
+                ),
+                IntervalTermOp(
+                    INTERVAL_TERM_BODY_ANGULAR_VELOCITY_DELTA, ang, body_ids=BODY_IDS
+                ),
+            )
+        )
+    )
+    ops_state = ops_backend.get_state(("qpos", "qvel"))
+    np.testing.assert_allclose(legacy_state["qpos"], ops_state["qpos"])
+    np.testing.assert_allclose(legacy_state["qvel"], ops_state["qvel"])
+
+
+def test_mujoco_unknown_term_fails_closed(tmp_path: Path) -> None:
+    backend = _mujoco_backend(tmp_path, MUJOCO_MODEL)
+    plan = IntervalRandomizationPlan(ops=(IntervalTermOp("custom_spin", np.zeros(3)),))
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.apply_interval_randomization(plan)
+    message = str(excinfo.value)
+    assert "MuJoCoBackend" in message
+    assert "custom_spin" in message

--- a/uv.lock
+++ b/uv.lock
@@ -2620,7 +2620,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

unisim-core half of unilabsim/UniLab#1502 (approved approach A: descriptor/operation registry).

- New `unisim.dr.interval` module: `INTERVAL_TERM_*` constants, `IntervalTermSpec` + `INTERVAL_TERM_SPECS` + `interval_term_spec()` (mirroring the `ADAPTER_SPECS` idiom), and pickle-safe `IntervalTermOp` with spec validation. Custom terms are free-form strings validated against the backend capability set — no mutable global registry.
- `IntervalRandomizationPlan` gains `ops: tuple[IntervalTermOp, ...]` and `iter_ops()`; the five legacy fields are deprecated but fully supported (1:1 translation, mixing allowed).
- `DomainRandomizationCapabilities` gains `supported_interval_terms: frozenset[str]` with `supports_interval_term()` / `get_unsupported_interval_terms()`; the five legacy bools are deprecated and used only as fallback.
- `SimBackend.apply_interval_randomization` is now a concrete generic dispatch over the backend-owned `_interval_term_handlers()` table (cold-path-built, cached); unsupported terms fail closed with `NotImplementedError` naming the backend class and term.
- mujoco / motrix / mjwarp / drake / genesis migrated to handler tables with numerically identical behavior for supported terms (mujoco force+torque and velocity-delta parity verified by array/state equality tests).
- **Bug fix (fail-open → fail-closed)**: mjwarp silently dropped `body_torque` / `body_angular_velocity_delta` and genesis silently dropped `body_angular_velocity_delta`; all now raise explicitly.
- Version bump to 1.1.0 (additive contract + deprecations), CHANGELOG and `docs/architecture.md` updated.

## Validation

- `make check`: ruff clean; pytest 48 passed, 1 skipped (pre-existing platform-conditional skip).
- `make package`: `unisim_core-1.1.0` sdist + wheel build successfully.
- New `tests/test_dr_interval.py` (14 tests): spec registry, op validation, pickle protocol-4 round-trip, legacy↔ops equivalence, capability fallback equivalence, fail-closed dispatch (fake backend + custom term), custom-term extensibility without touching base dispatch, MuJoCo numeric parity (force+torque / torque-only / seeded push / velocity delta qpos+qvel).

## Downstream

UniLab PR will consume this via `unisim-core>=1.1.0`; UniLab CI requires the 1.1.0 release to be published first (maintainer action: tag `v1.1.0` after merge per docs/release.md).