### PR TITLE
feat: add Newton capacity overflow guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add the isolated Newton 1.5.1 runtime extra and a metadata/import probe;
   Newton's MuJoCo-Warp 3.11.0 line is documented as mutually exclusive with
   the existing MJWarp 3.10.0.3 extra.
+- Add fail-closed Newton nconmax/njmax capacity sampling and overflow
+  diagnostics for the forthcoming adapter.
 
 ## 1.1.0 - 2026-09-05
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -22,3 +22,6 @@ Newton uses a separate MuJoCo-Warp line from the existing MJWarp extra:
 These extras are intentionally mutually exclusive in one environment. Run
 `uv run scripts/check_newton_runtime.py` after installation for a metadata-only
 probe; add `--import` when the native runtime should be imported explicitly.
+The adapter's cold-path calibration samples solver counts and raises an explicit
+capacity error when `nconmax` or `njmax` is too small; it never accepts silent
+constraint truncation.

--- a/src/unisim/backend/newton/__init__.py
+++ b/src/unisim/backend/newton/__init__.py
@@ -1,0 +1,23 @@
+"""Newton adapter support modules.
+
+The concrete adapter is added in Child 3.  Capacity helpers are exported here
+so the implementation and its focused tests share one fail-closed contract.
+"""
+
+from .capacity import (
+    NewtonCapacityError,
+    NewtonCapacityReport,
+    NewtonCapacitySample,
+    calibrate_capacity,
+    sample_capacity,
+    validate_capacity_limits,
+)
+
+__all__ = [
+    "NewtonCapacityError",
+    "NewtonCapacityReport",
+    "NewtonCapacitySample",
+    "calibrate_capacity",
+    "sample_capacity",
+    "validate_capacity_limits",
+]

--- a/src/unisim/backend/newton/capacity.py
+++ b/src/unisim/backend/newton/capacity.py
@@ -1,0 +1,138 @@
+"""Fail-closed capacity calibration helpers for the Newton adapter.
+
+Newton delegates its rigid solver to MuJoCo-Warp.  That solver can silently
+truncate contact constraints when ``nconmax`` or ``njmax`` is too small, so
+the adapter must validate the explicit capacities on the cold path and check
+the observed counts at every sampled step.  This module contains only the
+backend-neutral bookkeeping; all Newton/Warp object access stays in the
+adapter-owned reader callback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from unisim.errors import BackendError
+
+
+class NewtonCapacityError(BackendError):
+    """Raised when configured Newton solver capacity is insufficient."""
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonCapacitySample:
+    """Peak solver counts observed during one cold-path calibration window."""
+
+    samples: int
+    peak_nefc: int
+    peak_nj: int
+
+    def __post_init__(self) -> None:
+        for name in ("samples", "peak_nefc", "peak_nj"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonCapacityReport:
+    """Configured limits and the largest counts observed against them."""
+
+    nconmax: int
+    njmax: int
+    sample: NewtonCapacitySample
+
+
+def _positive_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return int(value)
+
+
+def validate_capacity_limits(
+    *,
+    nconmax: int,
+    njmax: int,
+    peak_nefc: int | None = None,
+    peak_nj: int | None = None,
+    context: str = "Newton materialization",
+) -> None:
+    """Validate configured capacities against optional observed solver counts."""
+    nconmax = _positive_int("nconmax", nconmax)
+    njmax = _positive_int("njmax", njmax)
+    if peak_nefc is not None:
+        peak_nefc = _non_negative_int("peak_nefc", peak_nefc)
+        if peak_nefc > nconmax:
+            raise NewtonCapacityError(
+                f"{context}: nconmax={nconmax} is below observed nefc={peak_nefc}; "
+                "increase newton_nconmax instead of allowing silent constraint truncation"
+            )
+    if peak_nj is not None:
+        peak_nj = _non_negative_int("peak_nj", peak_nj)
+        if peak_nj > njmax:
+            raise NewtonCapacityError(
+                f"{context}: njmax={njmax} is below observed nj={peak_nj}; "
+                "increase newton_njmax instead of allowing silent solver truncation"
+            )
+
+
+def _non_negative_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+    return int(value)
+
+
+def sample_capacity(
+    advance_and_read_counts: Callable[[], tuple[int, int]],
+    *,
+    sample_steps: int,
+) -> NewtonCapacitySample:
+    """Sample ``(nefc, nj)`` after each representative cold-path step.
+
+    The callback owns engine-specific state access and must return host integer
+    counts.  It is deliberately invoked only on the materialization/calibration
+    path; hot getters never call it.
+    """
+    sample_steps = _positive_int("sample_steps", sample_steps)
+    peak_nefc = 0
+    peak_nj = 0
+    for _ in range(sample_steps):
+        counts = advance_and_read_counts()
+        if not isinstance(counts, tuple) or len(counts) != 2:
+            raise TypeError("capacity reader must return a (nefc, nj) tuple")
+        nefc = _non_negative_int("nefc", counts[0])
+        nj = _non_negative_int("nj", counts[1])
+        peak_nefc = max(peak_nefc, nefc)
+        peak_nj = max(peak_nj, nj)
+    return NewtonCapacitySample(sample_steps, peak_nefc, peak_nj)
+
+
+def calibrate_capacity(
+    advance_and_read_counts: Callable[[], tuple[int, int]],
+    *,
+    nconmax: int,
+    njmax: int,
+    sample_steps: int,
+    context: str = "Newton materialization",
+) -> NewtonCapacityReport:
+    """Sample and validate one explicit Newton solver capacity configuration."""
+    sample = sample_capacity(advance_and_read_counts, sample_steps=sample_steps)
+    validate_capacity_limits(
+        nconmax=nconmax,
+        njmax=njmax,
+        peak_nefc=sample.peak_nefc,
+        peak_nj=sample.peak_nj,
+        context=context,
+    )
+    return NewtonCapacityReport(nconmax=int(nconmax), njmax=int(njmax), sample=sample)
+
+
+__all__ = [
+    "NewtonCapacityError",
+    "NewtonCapacityReport",
+    "NewtonCapacitySample",
+    "calibrate_capacity",
+    "sample_capacity",
+    "validate_capacity_limits",
+]

--- a/tests/test_newton_capacity.py
+++ b/tests/test_newton_capacity.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from unisim.backend.newton.capacity import (
+    NewtonCapacityError,
+    calibrate_capacity,
+    sample_capacity,
+    validate_capacity_limits,
+)
+
+
+def test_capacity_sample_tracks_peak_counts() -> None:
+    values = iter(((3, 7), (12, 9), (8, 11)))
+    sample = sample_capacity(lambda: next(values), sample_steps=3)
+    assert sample.samples == 3
+    assert sample.peak_nefc == 12
+    assert sample.peak_nj == 11
+
+
+def test_capacity_overflow_fails_closed() -> None:
+    with pytest.raises(NewtonCapacityError, match="nconmax=8.*nefc=9"):
+        calibrate_capacity(lambda: (9, 2), nconmax=8, njmax=4, sample_steps=1)
+
+    with pytest.raises(NewtonCapacityError, match="njmax=4.*nj=5"):
+        calibrate_capacity(lambda: (2, 5), nconmax=8, njmax=4, sample_steps=1)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [("nconmax", 0), ("njmax", -1), ("nconmax", True)],
+)
+def test_capacity_limits_require_positive_integers(name: str, value: object) -> None:
+    kwargs = {"nconmax": 1, "njmax": 1}
+    kwargs[name] = value
+    with pytest.raises(ValueError, match=name):
+        validate_capacity_limits(**kwargs)
+
+
+def test_capacity_reader_shape_is_validated() -> None:
+    with pytest.raises(TypeError, match=r"\(nefc, nj\)"):
+        sample_capacity(lambda: (1, 2, 3), sample_steps=1)  # type: ignore[return-value]
+
+    with pytest.raises(ValueError, match="nefc"):
+        sample_capacity(lambda: (-1, 0), sample_steps=1)


### PR DESCRIPTION
## Summary

- add cold-path Newton capacity sampling for `(nefc, nj)` counts
- validate explicit `nconmax`/`njmax` limits and fail closed on overflow
- add regression coverage for deliberately undersized configurations

Parent roadmap: #22
Child issue: #24

## Validation

- `uv run --no-sync pytest -q tests/test_newton_capacity.py` (`6 passed`)
- `make check` (`54 passed, 1 skipped`)
