### PR TITLE
feat(issue-25): add Newton backend adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   the existing MJWarp 3.10.0.3 extra.
 - Add fail-closed Newton nconmax/njmax capacity sampling and overflow
   diagnostics for the forthcoming adapter.
+- Add the Newton `SimBackend` adapter with explicit CUDA placement, cold-path
+  MJCF materialization/audits, host NumPy state caches, and fail-closed sensor
+  and geometry coverage.
 
 ## 1.1.0 - 2026-09-05
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ never escape the adapter. Drake, MJWarp and Genesis expose the same boundary
 through concrete engine adapters. IsaacGym and IsaacSim share the subprocess IPC
 framing and keep their Python 3.8/Kit workers outside the core wheel.
 
-`unisim.ADAPTER_SPECS` is the single migration manifest for all seven UniLab
+`unisim.ADAPTER_SPECS` is the single migration manifest for all eight UniLab
 backend identities. ``available`` means a public adapter and diagnostics exist;
 it does not claim that a proprietary SDK or GPU runtime is installed on every
 host. Runtime support is established by the adapter's optional-extra and

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -7,7 +7,7 @@
 | Drake | `unisim.DrakeBackend` | `uv sync --extra drake` (`drake-uni`) + native batch extension | available |
 | MJWarp | `unisim.MJWarpBackend` | `uv sync --extra mjwarp`, CUDA | available |
 | Genesis | `unisim.GenesisBackend` | `uv sync --extra genesis` | available |
-| Newton | `unisim.NewtonBackend` | `uv sync --extra newton`, Newton 1.5.1 / MuJoCo-Warp 3.11.0 | staged; adapter follows in #25 |
+| Newton | `unisim.NewtonBackend` | `uv sync --extra newton`, Newton 1.5.1 / MuJoCo-Warp 3.11.0 | available (CUDA) |
 | IsaacGym | `unisim.IsaacGymBackend` | `uv sync --extra isaacgym` (empty extra) + dedicated Python 3.8 worker | available |
 | IsaacSim | `unisim.IsaacSimBackend` | `uv sync --extra isaacsim` (empty extra) + dedicated IsaacSim/IsaacLab worker | available |
 

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -23,6 +23,8 @@ __all__ = [
     "DrakeBackend",
     "MJWarpBackend",
     "MjwarpBackend",
+    "NewtonBackend",
+    "NewtonDependencyError",
     "GenesisBackend",
     "IsaacGymBackend",
     "IsaacGymDependencyError",
@@ -53,6 +55,8 @@ def __getattr__(name: str):
         "IsaacSimDependencyError": (".backend.isaacsim.dependencies", "IsaacSimDependencyError"),
         "MJWarpBackend": (".backend.mjwarp", "MjwarpBackend"),
         "MjwarpBackend": (".backend.mjwarp", "MjwarpBackend"),
+        "NewtonBackend": (".backend.newton", "NewtonBackend"),
+        "NewtonDependencyError": (".backend.newton", "NewtonDependencyError"),
         "MotrixBackend": (".backend.motrix", "MotrixBackend"),
         "MuJoCoBackend": (".backend.mujoco", "MuJoCoBackend"),
         # ``SubprocessBackend`` was the name used by the first extraction

--- a/src/unisim/adapters.py
+++ b/src/unisim/adapters.py
@@ -28,6 +28,7 @@ ADAPTER_SPECS: tuple[AdapterSpec, ...] = (
     # dependency/worker diagnostic when the optional SDK is not installed.
     AdapterSpec("drake", "drake", "available"),
     AdapterSpec("mjwarp", "mjwarp", "available"),
+    AdapterSpec("newton", "newton", "available"),
     AdapterSpec("genesis", "genesis", "available"),
     AdapterSpec("isaacgym", "isaacgym", "available"),
     AdapterSpec("isaacsim", "isaacsim", "available"),

--- a/src/unisim/backend/newton/__init__.py
+++ b/src/unisim/backend/newton/__init__.py
@@ -1,8 +1,4 @@
-"""Newton adapter support modules.
-
-The concrete adapter is added in Child 3.  Capacity helpers are exported here
-so the implementation and its focused tests share one fail-closed contract.
-"""
+"""Independent optional Newton backend and its fail-closed support helpers."""
 
 from .capacity import (
     NewtonCapacityError,
@@ -12,11 +8,25 @@ from .capacity import (
     sample_capacity,
     validate_capacity_limits,
 )
+from .dependencies import NewtonDependencyError, newton_dependencies_available
+
+
+def __getattr__(name: str):
+    if name == "NewtonBackend":
+        from .backend import NewtonBackend
+
+        return NewtonBackend
+    if name == "NEWTON_AVAILABLE":
+        return newton_dependencies_available()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "NewtonCapacityError",
     "NewtonCapacityReport",
     "NewtonCapacitySample",
+    "NewtonBackend",
+    "NewtonDependencyError",
+    "NEWTON_AVAILABLE",
     "calibrate_capacity",
     "sample_capacity",
     "validate_capacity_limits",

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -1,0 +1,644 @@
+"""Newton 1.5.1 adapter implementing the host-NumPy SimBackend profile.
+
+All Newton/Warp transfers happen at explicit materialize, step, or set_state
+barriers. Public getters return stable NumPy cache views and never inspect
+MuJoCo's CPU data object. GPU execution is not bitwise deterministic; callers
+and tests must use numerical tolerances.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
+from unisim.scene import SceneCfg
+from unisim.utils.rotation import (
+    np_quat_apply_batched,
+    np_quat_apply_inverse_batched,
+    np_quat_conjugate_batched,
+    np_quat_mul_batched,
+)
+
+from .capacity import NewtonCapacityReport, calibrate_capacity, validate_capacity_limits
+from .dependencies import load_newton_dependencies
+from .materialization import (
+    NewtonModelAudit,
+    audit_newton_model,
+    scan_newton_model_metadata,
+)
+from .runtime import get_bound_newton_process_device
+
+_WORLD_Z = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+
+
+class NewtonBackend(SimBackend):
+    """In-process Newton/SolverMuJoCo adapter with explicit device placement."""
+
+    def __init__(
+        self,
+        scene: SceneCfg,
+        num_envs: int,
+        sim_dt: float,
+        *,
+        base_name: str | None = None,
+        device: str | None = None,
+        nconmax: int | None = None,
+        njmax: int | None = None,
+        capacity_check_steps: int = 1,
+        **unexpected_kwargs: Any,
+    ) -> None:
+        if unexpected_kwargs:
+            names = ", ".join(sorted(unexpected_kwargs))
+            raise TypeError(f"NewtonBackend does not accept backend options: {names}")
+        if isinstance(num_envs, bool) or not isinstance(num_envs, int) or num_envs <= 0:
+            raise ValueError(f"num_envs must be a positive integer, got {num_envs!r}")
+        if float(sim_dt) <= 0.0:
+            raise ValueError(f"sim_dt must be positive, got {sim_dt!r}")
+        self._nconmax = self._capacity(nconmax, "nconmax", 512)
+        self._njmax = self._capacity(njmax, "njmax", 512)
+        self._capacity_check_steps = self._capacity(
+            capacity_check_steps, "capacity_check_steps", 1
+        )
+
+        self._deps = load_newton_dependencies()
+        selected_device = device or get_bound_newton_process_device()
+        if selected_device is None:
+            raise ValueError(
+                "newton requires explicit device placement; pass newton_device='cuda:N' "
+                "or call configure_backend_process_device before construction"
+            )
+        self._deps.warp.set_device(str(selected_device))
+        resolved = self._deps.warp.get_device()
+        if not bool(resolved.is_cuda):
+            raise RuntimeError(f"newton backend requires a CUDA Warp device, got {resolved!s}")
+
+        self.backend_type = "newton"
+        self._pre_step_control_fn = None
+        self._num_envs = num_envs
+        self._sim_dt = float(sim_dt)
+        self._device = str(resolved)
+        self._scene_visual_model_file = str(scene.visual_model_file or scene.model_file)
+        self._metadata = scan_newton_model_metadata(self._deps.mujoco, scene)
+        if not self._metadata.root_qpos_dim:
+            raise NotImplementedError(
+                "newton backend currently requires a free root joint for the "
+                "SimBackend state contract"
+            )
+        self._scene_cleanup_handle = self._metadata.cleanup_handle
+        authored_root_name = next((name for name in self._metadata.body_names[1:] if name), None)
+        if base_name is not None and base_name != authored_root_name:
+            raise ValueError(
+                f"newton base_name must identify the authored free root body {authored_root_name!r}"
+            )
+        self._base_name = base_name or authored_root_name
+        self._body_names = self._metadata.body_names[1:]
+        self._body_ids = {name: index for index, name in enumerate(self._body_names) if name}
+        if self._base_name not in self._body_ids:
+            raise ValueError(f"Base body {self._base_name!r} not found in newton model")
+        self._base_body_id = self._body_ids[self._base_name]
+        self._joint_ids = dict(
+            zip(self._metadata.joint_names, range(len(self._metadata.joint_names)))
+        )
+        self._keyframes = dict(self._metadata.keyframes)
+        self._sensor_slots: dict[str, tuple[int, int]] = {}
+        address = 0
+        for plan in self._metadata.sensor_plans:
+            self._sensor_slots[plan.name] = (address, plan.dim)
+            address += plan.dim
+
+        self._model: Any | None = None
+        self._solver: Any | None = None
+        self._state: Any | None = None
+        self._state_out: Any | None = None
+        self._control: Any | None = None
+        self._contacts: Any | None = None
+        self._view: Any | None = None
+        self._audit: NewtonModelAudit | None = None
+        self._capacity_report: NewtonCapacityReport | None = None
+        self._closed = False
+
+        nbody = len(self._body_names)
+        self._qpos_cache = np.zeros((num_envs, self._metadata.nq), dtype=np.float32)
+        self._qvel_cache = np.zeros((num_envs, self._metadata.nv), dtype=np.float32)
+        self._body_pos_cache = np.zeros((num_envs, nbody, 3), dtype=np.float32)
+        self._body_quat_cache = np.zeros((num_envs, nbody, 4), dtype=np.float32)
+        self._body_lin_vel_cache = np.zeros((num_envs, nbody, 3), dtype=np.float32)
+        self._body_ang_vel_cache = np.zeros((num_envs, nbody, 3), dtype=np.float32)
+        self._sensor_cache = np.zeros((num_envs, address), dtype=np.float32)
+        self._previous_site_velocity: dict[str, np.ndarray] = {}
+        self._time_cache = np.zeros((num_envs,), dtype=np.float32)
+
+    @staticmethod
+    def _capacity(value: int | None, name: str, default: int) -> int:
+        resolved = default if value is None else value
+        validate_capacity_limits(
+            nconmax=resolved if name == "nconmax" else 1,
+            njmax=resolved if name != "nconmax" else 1,
+        )
+        return int(resolved)
+
+    def _require_state(self, operation: str) -> None:
+        if self._closed:
+            raise RuntimeError(f"newton backend is closed; cannot run {operation}")
+        self.materialize()
+
+    def materialize(self) -> None:
+        if self._model is not None:
+            return
+        newton = self._deps.newton
+        previous_layout = bool(newton.use_coord_layout_targets)
+        newton.use_coord_layout_targets = True
+        try:
+            template = newton.ModelBuilder()
+            newton.solvers.SolverMuJoCo.register_custom_attributes(template)
+            template.add_mjcf(self._metadata.source_model_file, ctrl_direct=False)
+            builder = newton.ModelBuilder()
+            builder.replicate(template, self._num_envs)
+            self._model = builder.finalize(device=self._device)
+        finally:
+            newton.use_coord_layout_targets = previous_layout
+            self.cleanup_scene_assets()
+
+        self._audit = audit_newton_model(self._model, self._metadata, self._num_envs)
+        self._solver = newton.solvers.SolverMuJoCo(
+            self._model,
+            separate_worlds=True,
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+            solver="newton",
+            integrator="implicitfast",
+            use_mujoco_cpu=False,
+            use_mujoco_contacts=True,
+            update_data_interval=0,
+        )
+        actual_nconmax = int(self._solver.mjw_data.naconmax)
+        actual_njmax = int(self._solver.mjw_data.njmax)
+        if actual_nconmax < self._nconmax or actual_njmax < self._njmax:
+            raise RuntimeError(
+                "Newton compiled solver capacity below the requested explicit limit: "
+                f"requested nconmax/njmax={self._nconmax}/{self._njmax}, "
+                f"compiled {actual_nconmax}/{actual_njmax}"
+            )
+        # SolverMuJoCo may raise a requested capacity to the initial-state
+        # requirement. Track the effective limits so every later check covers
+        # the actual allocation and cannot miss a runtime truncation.
+        self._nconmax = actual_nconmax
+        self._njmax = actual_njmax
+        self._view = newton.selection.ArticulationView(self._model, "*")
+        if int(self._view.count_per_world) != 1:
+            raise NotImplementedError(
+                "newton backend requires exactly one articulation per replicated world"
+            )
+        self._state = self._model.state()
+        self._state_out = self._model.state()
+        self._control = self._model.control()
+        self._contacts = newton.Contacts(
+            self._solver.get_max_contact_count(), 0, device=self._device
+        )
+        newton.eval_fk(
+            self._model, self._state.joint_q, self._state.joint_qd, self._state
+        )
+        self._refresh_host_cache()
+        self._capacity_report = calibrate_capacity(
+            self._advance_capacity_probe,
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+            sample_steps=self._capacity_check_steps,
+            context="Newton representative materialization rollout",
+        )
+        self._state = self._model.state()
+        self._state_out = self._model.state()
+        self._solver.reset(self._state)
+        newton.eval_fk(
+            self._model, self._state.joint_q, self._state.joint_qd, self._state
+        )
+        self._refresh_host_cache()
+
+    def _advance_capacity_probe(self) -> tuple[int, int]:
+        self._physics_substep(np.zeros((self._num_envs, self.num_actuators), np.float32))
+        return self._read_solver_counts()
+
+    def _read_solver_counts(self) -> tuple[int, int]:
+        self._deps.warp.synchronize_device(self._device)
+        ncon = int(np.max(np.asarray(self._solver.mjw_data.nacon.numpy())))
+        nefc = int(np.max(np.asarray(self._solver.mjw_data.nefc.numpy())))
+        return ncon, nefc
+
+    def _set_control(self, ctrl: np.ndarray) -> None:
+        namespace = getattr(self._control, "mujoco", None)
+        target = getattr(namespace, "ctrl", None) if namespace is not None else None
+        if target is not None:
+            target.assign(np.ascontiguousarray(ctrl.reshape(-1), dtype=np.float32))
+        target_q = getattr(self._control, "joint_target_q", None)
+        target_qd = getattr(self._control, "joint_target_qd", None)
+        if target_q is not None:
+            q_targets = np.zeros((self._num_envs, self._metadata.nq), dtype=np.float32)
+            for actuator_id, kind in enumerate(self._metadata.actuator_target_kinds):
+                if kind == "position":
+                    q_targets[:, self._metadata.actuator_target_qpos_adrs[actuator_id]] = ctrl[
+                        :, actuator_id
+                    ]
+            target_q.assign(np.ascontiguousarray(q_targets.reshape(-1)))
+        if target_qd is not None:
+            qd_targets = np.zeros((self._num_envs, self._metadata.nv), dtype=np.float32)
+            for actuator_id, kind in enumerate(self._metadata.actuator_target_kinds):
+                if kind == "velocity":
+                    qd_targets[:, self._metadata.actuator_target_qvel_adrs[actuator_id]] = ctrl[
+                        :, actuator_id
+                    ]
+            target_qd.assign(np.ascontiguousarray(qd_targets.reshape(-1)))
+
+    def _physics_substep(self, ctrl: np.ndarray) -> None:
+        self._set_control(ctrl)
+        self._state.clear_forces()
+        self._solver.step(
+            self._state, self._state_out, self._control, self._contacts, self._sim_dt
+        )
+        self._state, self._state_out = self._state_out, self._state
+
+    def _view_array(self, value: Any, width: int) -> np.ndarray:
+        self._deps.warp.synchronize_device(self._device)
+        return np.asarray(value.numpy(), dtype=np.float32).reshape(self._num_envs, width)
+
+    @staticmethod
+    def _xyzw_to_wxyz(value: np.ndarray) -> np.ndarray:
+        return value[..., [3, 0, 1, 2]]
+
+    @staticmethod
+    def _wxyz_to_xyzw(value: np.ndarray) -> np.ndarray:
+        return value[..., [1, 2, 3, 0]]
+
+    def _refresh_host_cache(self, *, sensor_dt: float | None = None) -> None:
+        qpos_raw = self._view_array(self._view.get_dof_positions(self._state), self._metadata.nq)
+        qvel_raw = self._view_array(self._view.get_dof_velocities(self._state), self._metadata.nv)
+        link_q = self._view_array(
+            self._view.get_link_transforms(self._state), len(self._body_names) * 7
+        ).reshape(self._num_envs, len(self._body_names), 7)
+        link_qd = self._view_array(
+            self._view.get_link_velocities(self._state), len(self._body_names) * 6
+        ).reshape(self._num_envs, len(self._body_names), 6)
+
+        self._qpos_cache[...] = qpos_raw
+        if self._metadata.root_qpos_dim:
+            self._qpos_cache[:, 3:7] = self._xyzw_to_wxyz(qpos_raw[:, 3:7])
+        self._body_pos_cache[...] = link_q[..., :3]
+        self._body_quat_cache[...] = self._xyzw_to_wxyz(link_q[..., 3:7])
+        self._body_ang_vel_cache[...] = link_qd[..., 3:6]
+        ipos = np.broadcast_to(
+            self._metadata.body_ipos[1:], self._body_pos_cache.shape
+        )
+        offset_w = np_quat_apply_batched(self._body_quat_cache, ipos)
+        self._body_lin_vel_cache[...] = link_qd[..., :3] - np.cross(
+            self._body_ang_vel_cache, offset_w
+        )
+        self._qvel_cache[...] = qvel_raw
+        if self._metadata.root_qvel_dim:
+            root_quat = self._body_quat_cache[:, self._base_body_id]
+            root_omega = self._body_ang_vel_cache[:, self._base_body_id]
+            root_offset = offset_w[:, self._base_body_id]
+            self._qvel_cache[:, :3] = qvel_raw[:, :3] - np.cross(root_omega, root_offset)
+            self._qvel_cache[:, 3:6] = np_quat_apply_inverse_batched(root_quat, root_omega)
+        self._refresh_sensor_cache(sensor_dt=sensor_dt)
+
+    def _refresh_sensor_cache(self, *, sensor_dt: float | None) -> None:
+        for plan in self._metadata.sensor_plans:
+            body_id = plan.body_id - 1
+            if body_id < 0:
+                raise RuntimeError(f"sensor {plan.name!r} is attached to the world body")
+            address, dim = self._sensor_slots[plan.name]
+            out = self._sensor_cache[:, address : address + dim]
+            body_quat = self._body_quat_cache[:, body_id]
+            site_quat = np_quat_mul_batched(
+                body_quat, np.broadcast_to(plan.site_quat, body_quat.shape)
+            )
+            offset_w = np_quat_apply_batched(
+                body_quat, np.broadcast_to(plan.site_pos, (self._num_envs, 3))
+            )
+            site_velocity = self._body_lin_vel_cache[:, body_id] + np.cross(
+                self._body_ang_vel_cache[:, body_id], offset_w
+            )
+            if plan.kind == "gyro":
+                out[...] = np_quat_apply_inverse_batched(
+                    site_quat, self._body_ang_vel_cache[:, body_id]
+                )
+            elif plan.kind == "velocimeter":
+                out[...] = np_quat_apply_inverse_batched(site_quat, site_velocity)
+            elif plan.kind == "framepos":
+                out[...] = self._body_pos_cache[:, body_id] + offset_w
+            elif plan.kind == "framequat":
+                out[...] = site_quat
+            elif plan.kind == "framezaxis":
+                out[...] = np_quat_apply_batched(
+                    site_quat, np.broadcast_to(_WORLD_Z, (self._num_envs, 3))
+                )
+            elif plan.kind == "accelerometer":
+                previous = self._previous_site_velocity.get(plan.name)
+                acceleration = np.zeros_like(site_velocity)
+                if previous is not None and sensor_dt is not None:
+                    acceleration = (site_velocity - previous) / sensor_dt
+                acceleration -= self._metadata.gravity
+                out[...] = np_quat_apply_inverse_batched(site_quat, acceleration)
+            self._previous_site_velocity[plan.name] = site_velocity.copy()
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def model(self) -> Any:
+        self._require_state("model")
+        return self._model
+
+    @property
+    def num_actuators(self) -> int:
+        return len(self._metadata.actuator_names)
+
+    @property
+    def num_dof_vel(self) -> int:
+        return self._metadata.nv - self._metadata.root_qvel_dim
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return self._metadata.actuator_ctrl_range.copy()
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return self._metadata.actuator_names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return self._metadata.actuator_joint_names
+
+    def get_scene_model_file(self) -> str | None:
+        return self._metadata.diagnostic_model_file
+
+    def get_scene_visual_model_file(self) -> str | None:
+        return self._scene_visual_model_file
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        try:
+            return self._keyframes[name].copy()
+        except KeyError as exc:
+            raise ValueError(f"Keyframe {name!r} not found") from exc
+
+    def get_default_qpos(self) -> np.ndarray:
+        return self._metadata.default_qpos.copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return self._metadata.default_qpos[self._metadata.root_qpos_dim :].copy()
+
+    def get_init_qvel(self) -> np.ndarray:
+        return np.zeros((self._metadata.nv,), dtype=np.float32)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        if root_body_name != self._base_name or not self._metadata.root_qpos_dim:
+            raise NotImplementedError(
+                f"backend 'newton' requires {self._base_name!r} as its free root body"
+            )
+        return BackendRootStateLayout(tuple(range(7)), tuple(range(6)))
+
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        try:
+            return np.asarray([self._body_ids[str(name)] for name in names], dtype=np.int32)
+        except KeyError as exc:
+            raise ValueError(f"Body {exc.args[0]!r} not found in newton model") from exc
+
+    def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:
+        root = int(root_body_id)
+        if root < 0 or root >= len(self._body_names):
+            raise ValueError(f"root_body_id out of range: {root}")
+        parents = self._metadata.body_parent_ids[1:] - 1
+        descendants = {root}
+        for body_id in range(root + 1, len(parents)):
+            if int(parents[body_id]) in descendants:
+                descendants.add(body_id)
+        return np.asarray(sorted(descendants), dtype=np.int32)
+
+    def get_gravity(self) -> np.ndarray:
+        return self._metadata.gravity.copy()
+
+    def get_body_mass(self) -> np.ndarray:
+        return self._metadata.body_mass.copy()
+
+    def get_body_ipos(self) -> np.ndarray:
+        return self._metadata.body_ipos.copy()
+
+    def get_dof_armature(self) -> np.ndarray:
+        return self._metadata.dof_armature.copy()
+
+    def get_joint_range(self) -> np.ndarray | None:
+        value = self._metadata.joint_range
+        return None if value is None else value.copy()
+
+    def get_joint_dof_indices(self, names: Sequence[str]) -> np.ndarray:
+        return np.asarray(
+            [self._metadata.joint_dof_adrs[self._joint_ids[str(name)]] for name in names],
+            dtype=np.int32,
+        )
+
+    def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
+        full = [self._metadata.joint_qpos_adrs[self._joint_ids[str(name)]] for name in names]
+        return np.asarray(full, dtype=np.int32) - self._metadata.root_qpos_dim
+
+    def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_indices(names) - self._metadata.root_qvel_dim
+
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names) + self._metadata.root_qpos_dim
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_vel_indices(names) + self._metadata.root_qvel_dim
+
+    def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
+        return self._metadata.actuator_kp.copy(), self._metadata.actuator_kd.copy()
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
+        self._require_state("step")
+        if isinstance(nsteps, bool) or not isinstance(nsteps, int) or nsteps <= 0:
+            raise ValueError(f"nsteps must be a positive integer, got {nsteps!r}")
+        ctrl_array = np.asarray(ctrl, dtype=np.float32)
+        expected = (self._num_envs, self.num_actuators)
+        if ctrl_array.shape != expected:
+            raise ValueError(f"ctrl must have shape {expected}, got {ctrl_array.shape}")
+        t0 = time.perf_counter()
+        for _ in range(nsteps):
+            native_ctrl = self._apply_pre_step_control(ctrl_array)
+            self._physics_substep(native_ctrl)
+        self._deps.warp.synchronize_device(self._device)
+        physics_ms = (time.perf_counter() - t0) * 1000.0
+        ncon, nefc = self._read_solver_counts()
+        validate_capacity_limits(
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+            peak_ncon=ncon,
+            peak_nefc=nefc,
+            context="Newton runtime step",
+        )
+        t0 = time.perf_counter()
+        self._refresh_host_cache(sensor_dt=nsteps * self._sim_dt)
+        self._time_cache += np.float32(nsteps * self._sim_dt)
+        cache_ms = (time.perf_counter() - t0) * 1000.0
+        return {"timing": {"physics_ms": physics_ms, "host_cache_refresh_ms": cache_ms}}
+
+    def set_state(
+        self,
+        env_indices: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization: ResetRandomizationPayload | None = None,
+    ) -> dict[str, dict[str, float]]:
+        self._require_state("set_state")
+        rows = np.asarray(env_indices, dtype=np.intp)
+        if rows.ndim != 1 or np.any(rows < 0) or np.any(rows >= self._num_envs):
+            raise ValueError("env_indices must be a one-dimensional in-range index array")
+        if np.unique(rows).size != rows.size:
+            raise ValueError("env_indices must not contain duplicates")
+        qpos_array = np.asarray(qpos, dtype=np.float32)
+        qvel_array = np.asarray(qvel, dtype=np.float32)
+        if qpos_array.shape != (rows.size, self._metadata.nq):
+            raise ValueError("qpos shape does not match selected Newton worlds")
+        if qvel_array.shape != (rows.size, self._metadata.nv):
+            raise ValueError("qvel shape does not match selected Newton worlds")
+        if randomization is not None and not randomization.is_empty():
+            raise NotImplementedError("newton backend does not yet support reset randomization")
+        if not rows.size:
+            return {"timing": {"set_state_upload_ms": 0.0, "set_state_cache_ms": 0.0}}
+
+        t0 = time.perf_counter()
+        full_qpos = self._qpos_cache.copy()
+        full_qvel = self._qvel_cache.copy()
+        full_qpos[rows] = qpos_array
+        full_qvel[rows] = qvel_array
+        if self._metadata.root_qpos_dim:
+            full_qpos[:, 3:7] = self._wxyz_to_xyzw(full_qpos[:, 3:7])
+            root_quat = qpos_array[:, 3:7]
+            omega_world = np_quat_apply_batched(root_quat, qvel_array[:, 3:6])
+            ipos = np.broadcast_to(
+                self._metadata.body_ipos[self._base_body_id + 1], (rows.size, 3)
+            )
+            offset_w = np_quat_apply_batched(root_quat, ipos)
+            full_qvel[rows, :3] = qvel_array[:, :3] + np.cross(omega_world, offset_w)
+            full_qvel[rows, 3:6] = omega_world
+        mask = np.zeros((self._num_envs,), dtype=np.bool_)
+        mask[rows] = True
+        warp_mask = self._deps.warp.array(mask, dtype=self._deps.warp.bool, device=self._device)
+        qpos_device = self._deps.warp.array(
+            full_qpos[:, None, :], dtype=self._deps.warp.float32, device=self._device
+        )
+        qvel_device = self._deps.warp.array(
+            full_qvel[:, None, :], dtype=self._deps.warp.float32, device=self._device
+        )
+        self._view.set_dof_positions(self._state, qpos_device, mask=mask)
+        self._view.set_dof_velocities(self._state, qvel_device, mask=mask)
+        self._deps.newton.eval_fk(
+            self._model, self._state.joint_q, self._state.joint_qd, self._state
+        )
+        self._solver.reset(self._state, warp_mask)
+        upload_ms = (time.perf_counter() - t0) * 1000.0
+        t0 = time.perf_counter()
+        self._refresh_host_cache()
+        self._time_cache[rows] = 0.0
+        cache_ms = (time.perf_counter() - t0) * 1000.0
+        return {
+            "timing": {"set_state_upload_ms": upload_ms, "set_state_cache_ms": cache_ms}
+        }
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        return DomainRandomizationCapabilities()
+
+    def get_base_pos(self) -> np.ndarray:
+        self._require_state("get_base_pos")
+        return self._qpos_cache[:, :3]
+
+    def get_base_quat(self) -> np.ndarray:
+        self._require_state("get_base_quat")
+        return self._qpos_cache[:, 3:7]
+
+    def get_base_lin_vel(self) -> np.ndarray:
+        self._require_state("get_base_lin_vel")
+        return self._qvel_cache[:, :3]
+
+    def get_base_ang_vel(self) -> np.ndarray:
+        self._require_state("get_base_ang_vel")
+        quat = self._qpos_cache[:, 3:7]
+        return np_quat_apply_batched(quat, self._qvel_cache[:, 3:6])
+
+    def get_dof_pos(self) -> np.ndarray:
+        self._require_state("get_dof_pos")
+        return self._qpos_cache[:, self._metadata.root_qpos_dim :]
+
+    def get_dof_vel(self) -> np.ndarray:
+        self._require_state("get_dof_vel")
+        return self._qvel_cache[:, self._metadata.root_qvel_dim :]
+
+    def _ids(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = np.asarray(body_ids, dtype=np.intp)
+        if ids.ndim != 1 or np.any(ids < 0) or np.any(ids >= len(self._body_names)):
+            raise ValueError("body_ids must be one-dimensional and in range")
+        return ids
+
+    def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_pos_w")
+        return self._body_pos_cache[:, self._ids(body_ids)]
+
+    def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_quat_w")
+        return self._body_quat_cache[:, self._ids(body_ids)]
+
+    def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_lin_vel_w")
+        return self._body_lin_vel_cache[:, self._ids(body_ids)]
+
+    def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_ang_vel_w")
+        return self._body_ang_vel_cache[:, self._ids(body_ids)]
+
+    def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = self._ids(body_ids)
+        delta = self.get_body_pos_w(ids) - self._body_pos_cache[:, self._base_body_id, None]
+        root = self._body_quat_cache[:, self._base_body_id, None]
+        return np_quat_apply_inverse_batched(root, delta)
+
+    def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = self._ids(body_ids)
+        root = self._body_quat_cache[:, self._base_body_id, None]
+        return np_quat_mul_batched(np_quat_conjugate_batched(root), self.get_body_quat_w(ids))
+
+    def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        quat = self.get_body_quat_w(body_ids)
+        return np_quat_apply_inverse_batched(quat, self.get_body_lin_vel_w(body_ids))
+
+    def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        quat = self.get_body_quat_w(body_ids)
+        return np_quat_apply_inverse_batched(quat, self.get_body_ang_vel_w(body_ids))
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        self._require_state("get_sensor_data")
+        try:
+            address, dim = self._sensor_slots[name]
+        except KeyError as exc:
+            raise KeyError(f"Sensor {name!r} not found in newton model") from exc
+        return self._sensor_cache[:, address : address + dim]
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]):
+        slices = [self._sensor_slots[name] for name in names]
+        contiguous = all(
+            slices[index][0] + slices[index][1] == slices[index + 1][0]
+            for index in range(len(slices) - 1)
+        )
+        if contiguous:
+            start = slices[0][0]
+            width = sum(dim for _, dim in slices)
+            return lambda: self._sensor_cache[:, start : start + width]
+        return lambda: np.concatenate(
+            [self._sensor_cache[:, address : address + dim] for address, dim in slices], axis=1
+        )
+
+    def close(self) -> None:
+        self._closed = True
+        self.cleanup_scene_assets()
+
+
+__all__ = ["NewtonBackend"]

--- a/src/unisim/backend/newton/capacity.py
+++ b/src/unisim/backend/newton/capacity.py
@@ -25,14 +25,19 @@ class NewtonCapacitySample:
     """Peak solver counts observed during one cold-path calibration window."""
 
     samples: int
+    peak_ncon: int
     peak_nefc: int
-    peak_nj: int
 
     def __post_init__(self) -> None:
-        for name in ("samples", "peak_nefc", "peak_nj"):
+        for name in ("samples", "peak_ncon", "peak_nefc"):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+
+    @property
+    def peak_nj(self) -> int:
+        """Compatibility spelling for the MuJoCo ``nefc`` constraint count."""
+        return self.peak_nefc
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,25 +59,25 @@ def validate_capacity_limits(
     *,
     nconmax: int,
     njmax: int,
+    peak_ncon: int | None = None,
     peak_nefc: int | None = None,
-    peak_nj: int | None = None,
     context: str = "Newton materialization",
 ) -> None:
     """Validate configured capacities against optional observed solver counts."""
     nconmax = _positive_int("nconmax", nconmax)
     njmax = _positive_int("njmax", njmax)
-    if peak_nefc is not None:
-        peak_nefc = _non_negative_int("peak_nefc", peak_nefc)
-        if peak_nefc > nconmax:
+    if peak_ncon is not None:
+        peak_ncon = _non_negative_int("peak_ncon", peak_ncon)
+        if peak_ncon > nconmax:
             raise NewtonCapacityError(
-                f"{context}: nconmax={nconmax} is below observed nefc={peak_nefc}; "
+                f"{context}: nconmax={nconmax} is below observed ncon={peak_ncon}; "
                 "increase newton_nconmax instead of allowing silent constraint truncation"
             )
-    if peak_nj is not None:
-        peak_nj = _non_negative_int("peak_nj", peak_nj)
-        if peak_nj > njmax:
+    if peak_nefc is not None:
+        peak_nefc = _non_negative_int("peak_nefc", peak_nefc)
+        if peak_nefc > njmax:
             raise NewtonCapacityError(
-                f"{context}: njmax={njmax} is below observed nj={peak_nj}; "
+                f"{context}: njmax={njmax} is below observed nefc={peak_nefc}; "
                 "increase newton_njmax instead of allowing silent solver truncation"
             )
 
@@ -88,24 +93,24 @@ def sample_capacity(
     *,
     sample_steps: int,
 ) -> NewtonCapacitySample:
-    """Sample ``(nefc, nj)`` after each representative cold-path step.
+    """Sample ``(ncon, nefc)`` after each representative cold-path step.
 
     The callback owns engine-specific state access and must return host integer
     counts.  It is deliberately invoked only on the materialization/calibration
     path; hot getters never call it.
     """
     sample_steps = _positive_int("sample_steps", sample_steps)
+    peak_ncon = 0
     peak_nefc = 0
-    peak_nj = 0
     for _ in range(sample_steps):
         counts = advance_and_read_counts()
         if not isinstance(counts, tuple) or len(counts) != 2:
-            raise TypeError("capacity reader must return a (nefc, nj) tuple")
-        nefc = _non_negative_int("nefc", counts[0])
-        nj = _non_negative_int("nj", counts[1])
+            raise TypeError("capacity reader must return a (ncon, nefc) tuple")
+        ncon = _non_negative_int("ncon", counts[0])
+        nefc = _non_negative_int("nefc", counts[1])
+        peak_ncon = max(peak_ncon, ncon)
         peak_nefc = max(peak_nefc, nefc)
-        peak_nj = max(peak_nj, nj)
-    return NewtonCapacitySample(sample_steps, peak_nefc, peak_nj)
+    return NewtonCapacitySample(sample_steps, peak_ncon, peak_nefc)
 
 
 def calibrate_capacity(
@@ -121,8 +126,8 @@ def calibrate_capacity(
     validate_capacity_limits(
         nconmax=nconmax,
         njmax=njmax,
+        peak_ncon=sample.peak_ncon,
         peak_nefc=sample.peak_nefc,
-        peak_nj=sample.peak_nj,
         context=context,
     )
     return NewtonCapacityReport(nconmax=int(nconmax), njmax=int(njmax), sample=sample)

--- a/src/unisim/backend/newton/dependencies.py
+++ b/src/unisim/backend/newton/dependencies.py
@@ -1,0 +1,84 @@
+"""Lazy optional-runtime boundary for the Newton backend."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib import metadata
+from importlib.util import find_spec
+from typing import Any
+
+from unisim.optional import OptionalDependencyError
+
+
+class NewtonDependencyError(OptionalDependencyError):
+    """Raised when the pinned Newton runtime cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class NewtonDependencies:
+    """Public modules used by the Newton adapter."""
+
+    newton: Any
+    warp: Any
+    mujoco: Any
+    mujoco_warp: Any
+
+
+PINNED_DISTRIBUTIONS: dict[str, str] = {
+    "newton": "1.5.1",
+    "mujoco-warp": "3.11.0",
+    "mujoco": "3.11.0",
+    "warp-lang": "1.16.0",
+}
+_MODULES = {
+    "newton": "newton",
+    "mujoco-warp": "mujoco_warp",
+    "mujoco": "mujoco",
+    "warp-lang": "warp",
+}
+_INSTALL_HINT = "Install the isolated runtime with `uv sync --extra newton`."
+
+
+def newton_dependencies_available() -> bool:
+    """Probe the Newton stack without importing any engine module."""
+    return all(find_spec(module_name) is not None for module_name in _MODULES.values())
+
+
+def load_newton_dependencies() -> NewtonDependencies:
+    """Validate exact versions, then import the public Newton runtime modules."""
+    for distribution, expected in PINNED_DISTRIBUTIONS.items():
+        try:
+            installed = metadata.version(distribution)
+        except metadata.PackageNotFoundError as exc:
+            raise NewtonDependencyError(
+                f"newton backend requires {distribution}=={expected}. {_INSTALL_HINT}"
+            ) from exc
+        if installed != expected:
+            raise NewtonDependencyError(
+                f"newton backend requires {distribution}=={expected}, found {installed}. "
+                f"{_INSTALL_HINT} Do not combine the newton extra with mujoco or mjwarp."
+            )
+    modules: dict[str, Any] = {}
+    try:
+        for distribution, module_name in _MODULES.items():
+            modules[distribution] = importlib.import_module(module_name)
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise NewtonDependencyError(
+            f"newton backend could not import its optional runtime: {exc}. {_INSTALL_HINT}"
+        ) from exc
+    return NewtonDependencies(
+        newton=modules["newton"],
+        warp=modules["warp-lang"],
+        mujoco=modules["mujoco"],
+        mujoco_warp=modules["mujoco-warp"],
+    )
+
+
+__all__ = [
+    "NewtonDependencies",
+    "NewtonDependencyError",
+    "PINNED_DISTRIBUTIONS",
+    "load_newton_dependencies",
+    "newton_dependencies_available",
+]

--- a/src/unisim/backend/newton/materialization.py
+++ b/src/unisim/backend/newton/materialization.py
@@ -1,0 +1,323 @@
+"""Cold-path MJCF scan and model audit for the Newton adapter."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from unisim.scene import SceneCfg
+
+
+class _TemporarySceneCleanup:
+    def __init__(self, *paths: str) -> None:
+        self._paths = paths
+        self._cleaned = False
+
+    def cleanup(self) -> None:
+        if self._cleaned:
+            return
+        self._cleaned = True
+        for path in self._paths:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonSensorPlan:
+    """One MJCF sensor reconstructed from public Newton state arrays."""
+
+    name: str
+    kind: str
+    dim: int
+    body_id: int
+    site_pos: np.ndarray
+    site_quat: np.ndarray
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonModelMetadata:
+    """Immutable authoring metadata scanned once with MuJoCo."""
+
+    source_model_file: str
+    diagnostic_model_file: str
+    cleanup_handle: Any | None
+    model_name: str
+    nq: int
+    nv: int
+    nbody: int
+    root_qpos_dim: int
+    root_qvel_dim: int
+    body_names: tuple[str, ...]
+    body_parent_ids: np.ndarray
+    body_mass: np.ndarray
+    body_ipos: np.ndarray
+    joint_names: tuple[str, ...]
+    joint_qpos_adrs: tuple[int, ...]
+    joint_dof_adrs: tuple[int, ...]
+    actuator_names: tuple[str, ...]
+    actuator_joint_names: tuple[str, ...]
+    actuator_target_kinds: tuple[str, ...]
+    actuator_target_qpos_adrs: tuple[int, ...]
+    actuator_target_qvel_adrs: tuple[int, ...]
+    actuator_ctrl_range: np.ndarray
+    actuator_kp: np.ndarray
+    actuator_kd: np.ndarray
+    keyframes: tuple[tuple[str, np.ndarray], ...]
+    default_qpos: np.ndarray
+    joint_range: np.ndarray | None
+    dof_armature: np.ndarray
+    gravity: np.ndarray
+    sensor_plans: tuple[NewtonSensorPlan, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonModelAudit:
+    """Successful authored-vs-compiled audit summary."""
+
+    worlds: int
+    bodies_per_world: int
+    qpos_per_world: int
+    qvel_per_world: int
+
+
+def _scan_sensors(mujoco: Any, model: Any) -> tuple[NewtonSensorPlan, ...]:
+    supported = {
+        mujoco.mjtSensor.mjSENS_GYRO: "gyro",
+        mujoco.mjtSensor.mjSENS_ACCELEROMETER: "accelerometer",
+        mujoco.mjtSensor.mjSENS_VELOCIMETER: "velocimeter",
+        mujoco.mjtSensor.mjSENS_FRAMEPOS: "framepos",
+        mujoco.mjtSensor.mjSENS_FRAMEQUAT: "framequat",
+        mujoco.mjtSensor.mjSENS_FRAMEZAXIS: "framezaxis",
+    }
+    plans: list[NewtonSensorPlan] = []
+    for sensor_id in range(int(model.nsensor)):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_SENSOR, sensor_id)
+        sensor_type = mujoco.mjtSensor(int(model.sensor_type[sensor_id]))
+        if not name:
+            raise NotImplementedError(
+                f"newton backend requires named MJCF sensors; sensor id {sensor_id} is unnamed"
+            )
+        kind = supported.get(sensor_type)
+        if kind is None:
+            raise NotImplementedError(
+                f"newton backend cannot reconstruct MJCF sensor {name!r} of type "
+                f"{sensor_type.name} from public Newton State arrays"
+            )
+        if int(model.sensor_objtype[sensor_id]) != int(mujoco.mjtObj.mjOBJ_SITE):
+            raise NotImplementedError(
+                f"newton backend reconstructs {kind} sensor {name!r} from sites only"
+            )
+        site_id = int(model.sensor_objid[sensor_id])
+        body_id = int(model.site_bodyid[site_id])
+        plans.append(
+            NewtonSensorPlan(
+                name=str(name),
+                kind=kind,
+                dim=int(model.sensor_dim[sensor_id]),
+                body_id=body_id,
+                site_pos=np.asarray(model.site_pos[site_id], dtype=np.float32).copy(),
+                site_quat=np.asarray(model.site_quat[site_id], dtype=np.float32).copy(),
+            )
+        )
+    return tuple(plans)
+
+
+def _reject_silent_geometry_gaps(mujoco: Any, model: Any) -> None:
+    geom_types = np.asarray(model.geom_type, dtype=np.int32)
+    cone_value = getattr(mujoco.mjtGeom, "mjGEOM_CONE", None)
+    if cone_value is not None and np.any(geom_types == int(cone_value)):
+        raise NotImplementedError(
+            "newton SolverMuJoCo does not map GeoType.CONE; replace cone geometry "
+            "before selecting the newton backend"
+        )
+    mesh = int(mujoco.mjtGeom.mjGEOM_MESH)
+    masks = np.asarray(model.geom_contype, dtype=np.int64) | np.asarray(
+        model.geom_conaffinity, dtype=np.int64
+    )
+    colliding_mesh_ids = np.flatnonzero((geom_types == mesh) & (masks != 0))
+    if colliding_mesh_ids.size:
+        names = [
+            str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, int(geom_id)) or geom_id)
+            for geom_id in colliding_mesh_ids
+        ]
+        raise NotImplementedError(
+            "newton SolverMuJoCo convexifies triangle-mesh collision geometry; "
+            f"colliding mesh geoms are rejected: {', '.join(names)}"
+        )
+
+
+def scan_newton_model_metadata(mujoco: Any, scene: SceneCfg) -> NewtonModelMetadata:
+    """Compose fragments, reject known silent gaps, and cache MJCF metadata."""
+    if scene is None or not scene.model_file:
+        raise ValueError("NewtonBackend requires SceneCfg.model_file")
+    if scene.terrain is not None:
+        raise NotImplementedError(
+            "newton backend does not yet support generated terrain or height-field scanners"
+        )
+    temp_paths: list[str] = []
+    source_model_file = str(scene.model_file)
+    if scene.fragment_files:
+        from unisim.backend.mujoco.xml import materialize_scene_fragments
+
+        source_model_file = materialize_scene_fragments(
+            source_model_file, fragment_files=scene.fragment_files
+        )
+        temp_paths.append(source_model_file)
+    model = mujoco.MjModel.from_xml_path(source_model_file)
+    _reject_silent_geometry_gaps(mujoco, model)
+
+    free = int(mujoco.mjtJoint.mjJNT_FREE)
+    single_dof = {int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE)}
+    supported_joints = single_dof | {free}
+    unsupported_joints = [
+        joint_id
+        for joint_id in range(int(model.njnt))
+        if int(model.jnt_type[joint_id]) not in supported_joints
+    ]
+    if unsupported_joints:
+        raise NotImplementedError(
+            "newton backend supports only free, hinge, and slide joints; unsupported "
+            f"MJCF joint ids: {unsupported_joints}"
+        )
+    root_qpos_dim, root_qvel_dim = (
+        (7, 6) if int(model.njnt) and int(model.jnt_type[0]) == free else (0, 0)
+    )
+    joint_names: list[str] = []
+    joint_qpos_adrs: list[int] = []
+    joint_dof_adrs: list[int] = []
+    for joint_id in range(int(model.njnt)):
+        if int(model.jnt_type[joint_id]) not in single_dof:
+            continue
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        if not name:
+            raise NotImplementedError(
+                f"newton backend requires named single-DoF joints; joint id {joint_id} is unnamed"
+            )
+        joint_names.append(str(name))
+        joint_qpos_adrs.append(int(model.jnt_qposadr[joint_id]))
+        joint_dof_adrs.append(int(model.jnt_dofadr[joint_id]))
+
+    actuator_names: list[str] = []
+    actuator_joint_names: list[str] = []
+    actuator_target_kinds: list[str] = []
+    actuator_target_qpos_adrs: list[int] = []
+    actuator_target_qvel_adrs: list[int] = []
+    for actuator_id in range(int(model.nu)):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, actuator_id)
+        joint_id = int(model.actuator_trnid[actuator_id, 0])
+        if (
+            not name
+            or int(model.actuator_trntype[actuator_id])
+            not in {int(mujoco.mjtTrn.mjTRN_JOINT), int(mujoco.mjtTrn.mjTRN_JOINTINPARENT)}
+            or joint_id < 0
+            or int(model.jnt_type[joint_id]) not in single_dof
+        ):
+            raise NotImplementedError(
+                "newton backend requires named actuators targeting single-DoF joints; "
+                f"actuator id {actuator_id} is unsupported"
+            )
+        joint_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        bias = np.asarray(model.actuator_biasprm[actuator_id], dtype=np.float32)
+        if abs(float(bias[1])) > 1e-8:
+            target_kind = "position"
+        elif abs(float(bias[2])) > 1e-8:
+            target_kind = "velocity"
+        else:
+            target_kind = "direct"
+        actuator_names.append(str(name))
+        actuator_joint_names.append(str(joint_name))
+        actuator_target_kinds.append(target_kind)
+        actuator_target_qpos_adrs.append(int(model.jnt_qposadr[joint_id]))
+        actuator_target_qvel_adrs.append(int(model.jnt_dofadr[joint_id]))
+
+    keyframes = tuple(
+        (
+            str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, key_id)),
+            np.asarray(model.key_qpos[key_id], dtype=np.float32).copy(),
+        )
+        for key_id in range(int(model.nkey))
+        if mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, key_id)
+    )
+    non_free = np.asarray(model.jnt_type, dtype=np.int32) != free
+    joint_range = np.asarray(model.jnt_range, dtype=np.float32)[non_free]
+    body_names = tuple(
+        str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id) or "")
+        for body_id in range(int(model.nbody))
+    )
+    raw_model_names = getattr(model, "names", b"")
+    model_name = (
+        raw_model_names.split(b"\0", 1)[0].decode("utf-8", errors="replace")
+        if isinstance(raw_model_names, bytes)
+        else str(raw_model_names)
+    )
+    return NewtonModelMetadata(
+        source_model_file=source_model_file,
+        diagnostic_model_file=str(scene.model_file),
+        cleanup_handle=_TemporarySceneCleanup(*temp_paths) if temp_paths else None,
+        model_name=model_name,
+        nq=int(model.nq),
+        nv=int(model.nv),
+        nbody=int(model.nbody),
+        root_qpos_dim=root_qpos_dim,
+        root_qvel_dim=root_qvel_dim,
+        body_names=body_names,
+        body_parent_ids=np.asarray(model.body_parentid, dtype=np.int32).copy(),
+        body_mass=np.asarray(model.body_mass, dtype=np.float32).copy(),
+        body_ipos=np.asarray(model.body_ipos, dtype=np.float32).copy(),
+        joint_names=tuple(joint_names),
+        joint_qpos_adrs=tuple(joint_qpos_adrs),
+        joint_dof_adrs=tuple(joint_dof_adrs),
+        actuator_names=tuple(actuator_names),
+        actuator_joint_names=tuple(actuator_joint_names),
+        actuator_target_kinds=tuple(actuator_target_kinds),
+        actuator_target_qpos_adrs=tuple(actuator_target_qpos_adrs),
+        actuator_target_qvel_adrs=tuple(actuator_target_qvel_adrs),
+        actuator_ctrl_range=np.asarray(model.actuator_ctrlrange, dtype=np.float32).copy(),
+        actuator_kp=np.asarray(model.actuator_gainprm[:, 0], dtype=np.float32).copy(),
+        actuator_kd=np.asarray(-model.actuator_biasprm[:, 2], dtype=np.float32).copy(),
+        keyframes=keyframes,
+        default_qpos=np.asarray(model.qpos0, dtype=np.float32).copy(),
+        joint_range=None if not joint_range.size else joint_range.copy(),
+        dof_armature=np.asarray(model.dof_armature, dtype=np.float32).copy(),
+        gravity=np.asarray(model.opt.gravity, dtype=np.float32).copy(),
+        sensor_plans=_scan_sensors(mujoco, model),
+    )
+
+
+def audit_newton_model(
+    model: Any, metadata: NewtonModelMetadata, num_envs: int
+) -> NewtonModelAudit:
+    """Compare authored gravity/mass/layout against the finalized Newton model."""
+    expected_bodies = metadata.nbody - 1
+    if int(model.world_count) != num_envs:
+        raise RuntimeError(
+            f"newton compiled world count {model.world_count} != authored request {num_envs}"
+        )
+    if int(model.joint_coord_count) != metadata.nq * num_envs:
+        raise RuntimeError("newton compiled qpos layout differs from the authored MJCF")
+    if int(model.joint_dof_count) != metadata.nv * num_envs:
+        raise RuntimeError("newton compiled qvel layout differs from the authored MJCF")
+    if int(model.body_count) != expected_bodies * num_envs:
+        raise RuntimeError("newton compiled body layout differs from the authored MJCF")
+
+    gravity = np.asarray(model.gravity.numpy(), dtype=np.float32).reshape(num_envs, 3)
+    if not np.allclose(gravity, metadata.gravity, rtol=1e-6, atol=1e-6):
+        raise RuntimeError("newton compiled gravity differs from the authored MJCF")
+    mass = np.asarray(model.body_mass.numpy(), dtype=np.float32).reshape(num_envs, expected_bodies)
+    if not np.allclose(mass, metadata.body_mass[1:], rtol=1e-5, atol=1e-6):
+        raise RuntimeError("newton compiled body masses differ from the authored MJCF")
+    return NewtonModelAudit(num_envs, expected_bodies, metadata.nq, metadata.nv)
+
+
+__all__ = [
+    "NewtonModelAudit",
+    "NewtonModelMetadata",
+    "NewtonSensorPlan",
+    "audit_newton_model",
+    "scan_newton_model_metadata",
+]

--- a/src/unisim/backend/newton/runtime.py
+++ b/src/unisim/backend/newton/runtime.py
@@ -1,0 +1,30 @@
+"""Process-global device binding owned by the Newton adapter."""
+
+from __future__ import annotations
+
+from .dependencies import load_newton_dependencies
+
+_BOUND_DEVICE: str | None = None
+
+
+def bind_newton_process_device(device: str) -> str:
+    """Select Newton's Warp device explicitly for the current process."""
+    global _BOUND_DEVICE
+    dependencies = load_newton_dependencies()
+    dependencies.warp.set_device(device)
+    selected = dependencies.warp.get_device()
+    if not bool(selected.is_cuda):
+        raise RuntimeError(
+            "newton backend requires an active CUDA Warp device; "
+            f"resolved {selected!s} from {device!r}"
+        )
+    _BOUND_DEVICE = str(selected)
+    return _BOUND_DEVICE
+
+
+def get_bound_newton_process_device() -> str | None:
+    """Return the explicitly selected device without probing Warp defaults."""
+    return _BOUND_DEVICE
+
+
+__all__ = ["bind_newton_process_device", "get_bound_newton_process_device"]

--- a/src/unisim/backend/process_device.py
+++ b/src/unisim/backend/process_device.py
@@ -19,15 +19,16 @@ def resolve_backend_process_device(
     device, so its collector must receive the exact CUDA device already
     assigned to the rank's learner.
     """
-    if backend_type != "mjwarp":
+    if backend_type not in {"mjwarp", "newton"}:
         return None
     if learner_device is None:
-        raise ValueError("mjwarp requires an explicit CUDA process device")
+        raise ValueError(f"{backend_type} requires an explicit CUDA process device")
 
     resolved = str(learner_device).strip()
     if resolved.split(":", 1)[0].lower() != "cuda":
         raise ValueError(
-            f"mjwarp requires a CUDA process device shared with its learner; got {resolved!r}"
+            f"{backend_type} requires a CUDA process device shared with its learner; "
+            f"got {resolved!r}"
         )
     return resolved
 
@@ -41,6 +42,10 @@ def configure_backend_process_device(
     if resolved is None:
         return None
 
+    if backend_type == "newton":
+        from .newton.runtime import bind_newton_process_device
+
+        return bind_newton_process_device(resolved)
     from .mjwarp.runtime import bind_mjwarp_process_device
 
     return bind_mjwarp_process_device(resolved)

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -43,6 +43,10 @@ def create_backend(
     bench_nsteps = kwargs.pop("bench_nsteps", 1)
     mjwarp_nconmax = kwargs.pop("mjwarp_nconmax", None)
     mjwarp_njmax = kwargs.pop("mjwarp_njmax", None)
+    newton_device = kwargs.pop("newton_device", None)
+    newton_nconmax = kwargs.pop("newton_nconmax", None)
+    newton_njmax = kwargs.pop("newton_njmax", None)
+    newton_capacity_check_steps = kwargs.pop("newton_capacity_check_steps", 1)
     drake_backend_mode = kwargs.pop("drake_backend_mode", "batch")
     drake_nthread = kwargs.pop("drake_nthread", None)
     isaacgym_device_id = kwargs.pop("isaacgym_device_id", None)
@@ -114,6 +118,31 @@ def create_backend(
         kwargs["nconmax"] = mjwarp_nconmax
         kwargs["njmax"] = mjwarp_njmax
         return MjwarpBackend(scene, num_envs, sim_dt, **kwargs)
+    if backend_type == "newton":
+        from .backend.newton.backend import NewtonBackend
+
+        if body_state_required:
+            raise NotImplementedError(
+                "newton does not support body-state sensor injection; define MJCF sensors"
+            )
+        if position_actuator_gains is not None:
+            raise ValueError(
+                "newton uses direct MJCF actuators; position_actuator_gains has no equivalent"
+            )
+        _warn_ignored_mujoco_options(
+            "newton",
+            post_step_forward_sensor=post_step_forward_sensor,
+            iterations=iterations,
+            chunk_size=chunk_size,
+            adaptive_chunk_size=adaptive_chunk_size,
+            cpu_ids=cpu_ids,
+            bench_nsteps=bench_nsteps,
+        )
+        kwargs["device"] = newton_device
+        kwargs["nconmax"] = newton_nconmax
+        kwargs["njmax"] = newton_njmax
+        kwargs["capacity_check_steps"] = newton_capacity_check_steps
+        return NewtonBackend(scene, num_envs, sim_dt, **kwargs)
     if backend_type == "genesis":
         from .backend.genesis.backend import GenesisBackend
 

--- a/tests/test_all_adapters.py
+++ b/tests/test_all_adapters.py
@@ -6,7 +6,16 @@ from unisim.optional import OptionalDependencyError
 
 def test_manifest_covers_all_current_backends():
     names = {spec.name for spec in unisim.ADAPTER_SPECS}
-    assert names == {"mujoco", "motrix", "drake", "mjwarp", "genesis", "isaacgym", "isaacsim"}
+    assert names == {
+        "mujoco",
+        "motrix",
+        "drake",
+        "mjwarp",
+        "newton",
+        "genesis",
+        "isaacgym",
+        "isaacsim",
+    }
     assert all(spec.status == "available" for spec in unisim.ADAPTER_SPECS)
 
 
@@ -17,6 +26,7 @@ def test_manifest_covers_all_current_backends():
         ("motrix", "MotrixBackend"),
         ("drake", "DrakeBackend"),
         ("mjwarp", "MjwarpBackend"),
+        ("newton", "NewtonBackend"),
         ("genesis", "GenesisBackend"),
         ("isaacgym", "IsaacGymBackend"),
         ("isaacsim", "IsaacSimBackend"),
@@ -31,7 +41,9 @@ def test_every_manifest_adapter_has_a_lazy_public_class(backend_type: str, expor
     assert adapter.__module__.startswith("unisim.backend.")
 
 
-@pytest.mark.parametrize("backend_type", ["mujoco", "motrix", "drake", "mjwarp", "genesis"])
+@pytest.mark.parametrize(
+    "backend_type", ["mujoco", "motrix", "drake", "mjwarp", "newton", "genesis"]
+)
 def test_in_process_adapters_require_scene(backend_type):
     with pytest.raises(ValueError, match="requires a SceneCfg"):
         unisim.create_backend(backend_type)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -35,6 +35,7 @@ def test_adapter_manifest_covers_roadmap_backends() -> None:
         "motrix",
         "drake",
         "mjwarp",
+        "newton",
         "genesis",
         "isaacgym",
         "isaacsim",

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -8,7 +8,8 @@ def test_import_does_not_pull_unilab_or_engine_modules():
     code = (
         "import sys, unisim; "
         "blocked = [name for name in sys.modules if name == 'unilab' or "
-        "name.startswith(('hydra', 'torch', 'gymnasium', 'mujoco', 'motrixsim'))]; "
+        "name.startswith(('hydra', 'torch', 'gymnasium', 'mujoco', 'motrixsim', "
+        "'newton', 'warp'))]; "
         "assert not blocked, blocked"
     )
     result = subprocess.run(

--- a/tests/test_newton_capacity.py
+++ b/tests/test_newton_capacity.py
@@ -14,15 +14,15 @@ def test_capacity_sample_tracks_peak_counts() -> None:
     values = iter(((3, 7), (12, 9), (8, 11)))
     sample = sample_capacity(lambda: next(values), sample_steps=3)
     assert sample.samples == 3
-    assert sample.peak_nefc == 12
-    assert sample.peak_nj == 11
+    assert sample.peak_ncon == 12
+    assert sample.peak_nefc == 11
 
 
 def test_capacity_overflow_fails_closed() -> None:
-    with pytest.raises(NewtonCapacityError, match="nconmax=8.*nefc=9"):
+    with pytest.raises(NewtonCapacityError, match="nconmax=8.*ncon=9"):
         calibrate_capacity(lambda: (9, 2), nconmax=8, njmax=4, sample_steps=1)
 
-    with pytest.raises(NewtonCapacityError, match="njmax=4.*nj=5"):
+    with pytest.raises(NewtonCapacityError, match="njmax=4.*nefc=5"):
         calibrate_capacity(lambda: (2, 5), nconmax=8, njmax=4, sample_steps=1)
 
 
@@ -38,8 +38,8 @@ def test_capacity_limits_require_positive_integers(name: str, value: object) -> 
 
 
 def test_capacity_reader_shape_is_validated() -> None:
-    with pytest.raises(TypeError, match=r"\(nefc, nj\)"):
+    with pytest.raises(TypeError, match=r"\(ncon, nefc\)"):
         sample_capacity(lambda: (1, 2, 3), sample_steps=1)  # type: ignore[return-value]
 
-    with pytest.raises(ValueError, match="nefc"):
+    with pytest.raises(ValueError, match="ncon"):
         sample_capacity(lambda: (-1, 0), sample_steps=1)

--- a/tests/test_newton_contract.py
+++ b/tests/test_newton_contract.py
@@ -1,0 +1,104 @@
+"""Static and optional-runtime boundary tests for the Newton adapter."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import unisim
+from unisim.backend.newton.backend import NewtonBackend
+from unisim.backend.newton.dependencies import (
+    NewtonDependencyError,
+    load_newton_dependencies,
+    newton_dependencies_available,
+)
+from unisim.conformance import assert_backend_conformance
+from unisim.scene import SceneCfg
+
+_MODEL = """
+<mujoco model="unisim-newton-test">
+  <option timestep="0.005" gravity="0 0 -9.81"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="2 2 0.1"/>
+    <body name="base" pos="0 0 0.5">
+      <joint name="root" type="free"/>
+      <geom name="base_geom" type="sphere" size="0.08" mass="1"/>
+      <body name="arm" pos="0 0 0.12">
+        <joint name="hinge" type="hinge" axis="0 1 0"/>
+        <geom name="arm_geom" type="capsule" fromto="0 0 0 0 0 0.2" size="0.03" mass="0.2"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><motor name="hinge_motor" joint="hinge" ctrlrange="-1 1"/></actuator>
+</mujoco>
+"""
+
+
+def test_newton_getters_do_not_materialize_warp_arrays() -> None:
+    tree = ast.parse(textwrap.dedent(inspect.getsource(NewtonBackend)))
+    backend = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    getter_nodes = [
+        node
+        for node in backend.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("get_")
+    ]
+    offenders = [
+        getter.name
+        for getter in getter_nodes
+        for node in ast.walk(getter)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "numpy"
+    ]
+    assert offenders == []
+
+
+def test_newton_import_boundary_does_not_load_optional_modules() -> None:
+    code = (
+        "import sys, unisim; "
+        "assert not [name for name in sys.modules if name == 'newton' or "
+        "name == 'warp' or name.startswith('mujoco_warp')]"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_newton_manifest_and_lazy_exports() -> None:
+    assert unisim.adapter_spec("newton").extra == "newton"
+    assert unisim.NewtonBackend is NewtonBackend
+    assert unisim.NewtonDependencyError is NewtonDependencyError
+
+
+def test_newton_dependency_probe_is_fail_closed_when_extra_is_absent() -> None:
+    if newton_dependencies_available():
+        pytest.skip("Newton optional runtime is installed in this environment")
+    with pytest.raises(NewtonDependencyError, match="newton backend requires"):
+        unisim.create_backend("newton", scene=object())
+
+
+def test_newton_conformance_when_cuda_runtime_is_available(tmp_path: Path) -> None:
+    try:
+        deps = load_newton_dependencies()
+    except NewtonDependencyError as exc:
+        pytest.skip(str(exc))
+    deps.warp.init()
+    device = deps.warp.get_device()
+    if not bool(device.is_cuda):
+        pytest.skip("Newton conformance requires a CUDA Warp device")
+    model_file = tmp_path / "newton.xml"
+    model_file.write_text(_MODEL, encoding="utf-8")
+    backend = NewtonBackend(
+        SceneCfg(model_file=str(model_file)),
+        num_envs=2,
+        sim_dt=0.005,
+        device=str(device),
+        capacity_check_steps=1,
+    )
+    assert_backend_conformance(backend)
+    backend.close()

--- a/tests/test_newton_materialization.py
+++ b/tests/test_newton_materialization.py
@@ -1,0 +1,64 @@
+"""Cold-path MJCF compensation and fail-closed asset checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim.backend.newton.materialization import scan_newton_model_metadata
+from unisim.scene import SceneCfg
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def _write_model(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "scene.xml"
+    path.write_text(
+        f"<mujoco model='metadata-test'><worldbody>{body}</worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_metadata_scans_keyframes_and_supported_sensors(tmp_path: Path) -> None:
+    path = tmp_path / "scene.xml"
+    path.write_text(
+        """
+        <mujoco model="metadata-test">
+          <worldbody>
+            <body name="base"><joint name="hinge" type="hinge"/>
+              <site name="imu" pos="0 0 0"/>
+              <geom type="sphere" size="0.1"/>
+            </body>
+          </worldbody>
+          <sensor><gyro name="gyro" site="imu"/></sensor>
+          <keyframe><key name="home" qpos="0.25"/></keyframe>
+        </mujoco>
+        """,
+        encoding="utf-8",
+    )
+    metadata = scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
+    assert metadata.joint_names == ("hinge",)
+    assert metadata.keyframes[0][0] == "home"
+    np.testing.assert_allclose(metadata.keyframes[0][1], [0.25])
+    assert metadata.sensor_plans[0].name == "gyro"
+    assert metadata.sensor_plans[0].dim == 3
+
+
+def test_metadata_rejects_cone_geometry(tmp_path: Path) -> None:
+    if not hasattr(mujoco.mjtGeom, "mjGEOM_CONE"):
+        pytest.skip("installed MuJoCo does not expose a cone geom type")
+    path = _write_model(
+        tmp_path,
+        "<body name='base'><joint name='hinge' type='hinge'/><geom type='cone' "
+        "size='0.1 0.2'/></body>",
+    )
+    with pytest.raises(NotImplementedError, match="CONE"):
+        scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
+
+
+def test_newton_warp_path_has_no_mj_data_access() -> None:
+    for path in Path(__file__).parents[1].joinpath("src/unisim/backend/newton").glob("*.py"):
+        assert "mj_data" not in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add the lazy, CUDA-explicit Newton `SimBackend` adapter and process-device binding
- materialize MJCF through Newton `SolverMuJoCo` with keyframe/sensor compensation, host NumPy caches, partial reset, and authored-vs-compiled audits
- wire the adapter into the manifest, factory, lazy exports, support docs, and fail-closed conformance/materialization tests
- preserve explicit nconmax/njmax capacity checks and reject unsupported cone/mesh/sensor/joint gaps

Fixes #25

## Validation

- `make check`
- `make package`
- `uv lock --check`

Result: 62 passed, 3 skipped (Newton/CUDA runtime conformance skips when the optional runtime is unavailable).
