### PR TITLE
fix: add Genesis device selection contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Rework the README around the project overview, UniLab relationship,
   installation, and quick start, and add the Chinese `README_zh.md`.
+- Fixed Genesis device selection on multi-GPU hosts: the engine only honors
+  the first entry of `CUDA_VISIBLE_DEVICES`, so the adapter now pins
+  `CUDA_VISIBLE_DEVICES` to the requested physical device before any CUDA
+  query (including `torch.cuda.is_available()`, which itself latches the
+  visible-device set) and remaps the process-local device index to `cuda:0`.
+  Out-of-range requests fail closed with a clear error.
 
 ## 1.1.0 - 2026-09-05
 

--- a/src/unisim/backend/genesis/backend.py
+++ b/src/unisim/backend/genesis/backend.py
@@ -83,6 +83,7 @@ class GenesisBackend(SimBackend):
         *,
         base_name: str | None = None,
         push_body_name: str | None = None,
+        device_id: int | None = None,
         integrator: str | None = None,
         constraint_solver: str | None = None,
         friction_cone: str | None = None,
@@ -105,6 +106,12 @@ class GenesisBackend(SimBackend):
                 f"genesis solver_iterations must be a positive integer or None, "
                 f"got {solver_iterations!r}"
             )
+        if device_id is not None and (
+            isinstance(device_id, bool) or not isinstance(device_id, int) or device_id < 0
+        ):
+            raise ValueError(
+                f"genesis device_id must be a non-negative integer or None, got {device_id!r}"
+            )
         if push_body_name is not None:
             raise NotImplementedError(
                 "genesis backend does not support interval push or external wrench "
@@ -115,14 +122,20 @@ class GenesisBackend(SimBackend):
         self._deps = deps
         self._torch = deps.torch
         self._gs = deps.genesis
+        self._device_id = None if device_id is None else int(device_id)
         self._metadata = materialization.scan_genesis_model_metadata(deps.mujoco, scene)
         self._scene_cleanup_handle = self._metadata.cleanup_handle
         self._scene_model_file = str(scene.model_file)
 
         # One gs.init per process; re-init after destroy fails closed here.
-        materialization.init_genesis_session(deps)
+        materialization.init_genesis_session(deps, device_id=self._device_id)
         self._device = (
-            self._torch.device("cuda", self._torch.cuda.current_device())
+            self._torch.device(
+                "cuda",
+                self._device_id
+                if self._device_id is not None
+                else self._torch.cuda.current_device(),
+            )
             if (self._torch.cuda.is_available())
             else self._torch.device("cpu")
         )
@@ -775,9 +788,7 @@ class GenesisBackend(SimBackend):
         # was previously silently dropped).
         if self._interval_term_handler_cache is None:
             self._interval_term_handler_cache = {
-                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
-                    op.body_ids, op.payload
-                ),
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(op.body_ids, op.payload),
             }
         return self._interval_term_handler_cache
 

--- a/src/unisim/backend/genesis/materialization.py
+++ b/src/unisim/backend/genesis/materialization.py
@@ -138,24 +138,75 @@ _SESSION_DESTROYED = False
 _SESSION_DEVICE_ID: int | None = None
 
 
-def _resolve_genesis_device_id(torch: Any, device_id: int | None) -> int | None:
-    """Validate and select the CUDA index used by a Genesis session."""
+def _pin_cuda_visible_devices(torch: Any, device_id: int) -> int:
+    """Pin ``CUDA_VISIBLE_DEVICES`` to the requested device; return the in-process index.
 
-    cuda_available = bool(torch.cuda.is_available())
-    if device_id is not None:
-        if isinstance(device_id, bool) or not isinstance(device_id, int) or device_id < 0:
-            raise ValueError(
-                f"genesis device_id must be a non-negative integer or None, got {device_id!r}"
-            )
-        if not cuda_available:
-            raise ValueError(
-                f"genesis device_id={device_id} requires CUDA, but CUDA is unavailable"
-            )
+    Quadrants (the Genesis 1.3.x compute runtime) binds its CUDA runtime to
+    the first entry of ``CUDA_VISIBLE_DEVICES`` regardless of torch's current
+    device — ``torch.cuda.set_device(N)`` alone leaves the engine on physical
+    GPU 0 and crashes later with cross-device illegal-memory errors (verified
+    on genesis_world 1.3.3 / Quadrants 1.3.0, UniLab issue #1508).  The only
+    owner-layer way to place a session on another physical GPU is to shrink
+    visibility to that GPU before the first CUDA context exists; afterwards
+    the in-process device index is 0.
+
+    ``device_id`` addresses the *current* visibility namespace: without the
+    variable set it is the host index, otherwise it indexes into the existing
+    entries (physical indices or UUID strings).  Returns 0 on success so the
+    session records the in-process index actually used.
+    """
+
+    if bool(torch.cuda.is_initialized()):
+        raise RuntimeError(
+            f"genesis device_id={device_id} requires pinning CUDA_VISIBLE_DEVICES "
+            "before any CUDA context is created in this process, but torch CUDA "
+            "is already initialized; select the device earlier (entrypoint cold "
+            "path) or set CUDA_VISIBLE_DEVICES before launching the process"
+        )
+    raw = os.environ.get("CUDA_VISIBLE_DEVICES")
+    entries = [entry.strip() for entry in raw.split(",") if entry.strip()] if raw else None
+    if entries is None:
         device_count = int(torch.cuda.device_count())
         if device_id >= device_count:
             raise ValueError(
                 f"genesis device_id={device_id} is out of range; "
                 f"torch.cuda.device_count()={device_count}"
+            )
+        target = str(device_id)
+    else:
+        if device_id >= len(entries):
+            raise ValueError(
+                f"genesis device_id={device_id} is out of range for "
+                f"CUDA_VISIBLE_DEVICES={raw!r} ({len(entries)} entr(ies))"
+            )
+        target = entries[device_id]
+    os.environ["CUDA_VISIBLE_DEVICES"] = target
+    # ``device_count`` is lru-cached; drop any pre-pin host-wide count so
+    # later callers observe the pinned single-device namespace.
+    cache_clear = getattr(torch.cuda.device_count, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()
+    return 0
+
+
+def _resolve_genesis_device_id(torch: Any, device_id: int | None) -> int | None:
+    """Validate and select the CUDA index used by a Genesis session."""
+
+    if device_id is not None:
+        if isinstance(device_id, bool) or not isinstance(device_id, int) or device_id < 0:
+            raise ValueError(
+                f"genesis device_id must be a non-negative integer or None, got {device_id!r}"
+            )
+        if device_id > 0:
+            # The engine only honors the first visible device; pin visibility
+            # and continue with the in-process index 0.  The pin must run
+            # before any torch CUDA query (even ``is_available`` latches
+            # CUDA_VISIBLE_DEVICES in the runtime), so it precedes the
+            # availability check below.
+            device_id = _pin_cuda_visible_devices(torch, device_id)
+        if not bool(torch.cuda.is_available()):
+            raise ValueError(
+                f"genesis device_id={device_id} requires CUDA, but CUDA is unavailable"
             )
         # Genesis' ``gs.init`` consults the process-wide current CUDA device.
         # Bind it before entering the initialization routine; doing this after
@@ -163,7 +214,7 @@ def _resolve_genesis_device_id(torch: Any, device_id: int | None) -> int | None:
         # global backend on device zero.
         torch.cuda.set_device(device_id)
         return int(device_id)
-    if cuda_available:
+    if bool(torch.cuda.is_available()):
         return int(torch.cuda.current_device())
     return None
 

--- a/src/unisim/backend/genesis/materialization.py
+++ b/src/unisim/backend/genesis/materialization.py
@@ -135,9 +135,45 @@ def preserve_torch_globals(torch: Any) -> Iterator[None]:
 
 _SESSION_ACTIVE = False
 _SESSION_DESTROYED = False
+_SESSION_DEVICE_ID: int | None = None
 
 
-def init_genesis_session(deps: Any, *, logging_level: str = "warning") -> None:
+def _resolve_genesis_device_id(torch: Any, device_id: int | None) -> int | None:
+    """Validate and select the CUDA index used by a Genesis session."""
+
+    cuda_available = bool(torch.cuda.is_available())
+    if device_id is not None:
+        if isinstance(device_id, bool) or not isinstance(device_id, int) or device_id < 0:
+            raise ValueError(
+                f"genesis device_id must be a non-negative integer or None, got {device_id!r}"
+            )
+        if not cuda_available:
+            raise ValueError(
+                f"genesis device_id={device_id} requires CUDA, but CUDA is unavailable"
+            )
+        device_count = int(torch.cuda.device_count())
+        if device_id >= device_count:
+            raise ValueError(
+                f"genesis device_id={device_id} is out of range; "
+                f"torch.cuda.device_count()={device_count}"
+            )
+        # Genesis' ``gs.init`` consults the process-wide current CUDA device.
+        # Bind it before entering the initialization routine; doing this after
+        # ``gs.init`` is too late because Genesis has already allocated its
+        # global backend on device zero.
+        torch.cuda.set_device(device_id)
+        return int(device_id)
+    if cuda_available:
+        return int(torch.cuda.current_device())
+    return None
+
+
+def init_genesis_session(
+    deps: Any,
+    *,
+    device_id: int | None = None,
+    logging_level: str = "warning",
+) -> None:
     """Initialize the process-wide Genesis session exactly once.
 
     Repeated ``init -> destroy`` cycles are functional but leak 200-450 MB of
@@ -147,14 +183,24 @@ def init_genesis_session(deps: Any, *, logging_level: str = "warning") -> None:
     after :func:`destroy_genesis_session` any further construction fails
     closed with a clear error.
     """
-    global _SESSION_ACTIVE, _SESSION_DESTROYED
+    global _SESSION_ACTIVE, _SESSION_DESTROYED, _SESSION_DEVICE_ID
     if _SESSION_DESTROYED:
         raise RuntimeError(
             "genesis backend supports exactly one gs.init per process and the session "
             "was already destroyed; start a fresh process instead of re-initializing "
             "(init/destroy cycles leak host RSS, REPORT #1372 §3.5 [9a])."
         )
+    selected_device_id = _resolve_genesis_device_id(deps.torch, device_id)
     if _SESSION_ACTIVE:
+        if (
+            selected_device_id is not None
+            and _SESSION_DEVICE_ID is not None
+            and selected_device_id != _SESSION_DEVICE_ID
+        ):
+            raise RuntimeError(
+                "genesis session is already initialized on CUDA device "
+                f"{_SESSION_DEVICE_ID}, cannot reuse it on device {selected_device_id}"
+            )
         return
     gs = deps.genesis
     cuda_available = bool(deps.torch.cuda.is_available())
@@ -169,23 +215,26 @@ def init_genesis_session(deps: Any, *, logging_level: str = "warning") -> None:
             f"validated by REPORT #1372): {type(exc).__name__}: {exc}"
         ) from exc
     _SESSION_ACTIVE = True
+    _SESSION_DEVICE_ID = selected_device_id
 
 
 def destroy_genesis_session(deps: Any) -> None:
     """Tear down the process-wide session; re-initialization stays forbidden."""
-    global _SESSION_ACTIVE, _SESSION_DESTROYED
+    global _SESSION_ACTIVE, _SESSION_DESTROYED, _SESSION_DEVICE_ID
     if not _SESSION_ACTIVE:
         return
     deps.genesis.destroy()
     _SESSION_ACTIVE = False
     _SESSION_DESTROYED = True
+    _SESSION_DEVICE_ID = None
 
 
 def _reset_session_state_for_tests() -> None:
     """Reset the lifecycle guard; test-only seam for the fake runtime lane."""
-    global _SESSION_ACTIVE, _SESSION_DESTROYED
+    global _SESSION_ACTIVE, _SESSION_DESTROYED, _SESSION_DEVICE_ID
     _SESSION_ACTIVE = False
     _SESSION_DESTROYED = False
+    _SESSION_DEVICE_ID = None
 
 
 def _map_global_option(name: str, value: str, table: dict[str, str], enum_ns: Any) -> Any:

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -51,6 +51,7 @@ def create_backend(
     genesis_constraint_solver = kwargs.pop("genesis_constraint_solver", None)
     genesis_friction_cone = kwargs.pop("genesis_friction_cone", None)
     genesis_solver_iterations = kwargs.pop("genesis_solver_iterations", None)
+    genesis_device_id = kwargs.pop("genesis_device_id", None)
     isaacsim_device_id = kwargs.pop("isaacsim_device_id", None)
     isaacsim_worker_timeout_s = kwargs.pop("isaacsim_worker_timeout_s", None)
     isaacsim_render_mode = kwargs.pop("isaacsim_render_mode", None)
@@ -136,6 +137,7 @@ def create_backend(
         kwargs["constraint_solver"] = genesis_constraint_solver
         kwargs["friction_cone"] = genesis_friction_cone
         kwargs["solver_iterations"] = genesis_solver_iterations
+        kwargs["device_id"] = genesis_device_id
         return GenesisBackend(scene, num_envs, sim_dt, **kwargs)
     if backend_type == "isaacgym":
         if scene is None and "runtime" not in kwargs and "worker_command" not in kwargs:

--- a/tests/test_genesis_device.py
+++ b/tests/test_genesis_device.py
@@ -1,0 +1,107 @@
+"""Tests for the Genesis CUDA_VISIBLE_DEVICES pinning contract.
+
+Quadrants binds its CUDA runtime to the first visible device, so a non-zero
+Genesis device request is honored by shrinking CUDA_VISIBLE_DEVICES before
+any CUDA context exists (issue #1508).  Torch CUDA entry points are stubbed
+so the lane stays host-free and independent of test-order CUDA state.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from unisim.backend.genesis.materialization import (
+    _pin_cuda_visible_devices,
+    _resolve_genesis_device_id,
+)
+
+
+class _StubCuda:
+    def __init__(self, *, initialized: bool = False, count: int = 2) -> None:
+        self.initialized = initialized
+        self.count = count
+        self.set_calls: list[int] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def is_initialized(self) -> bool:
+        return self.initialized
+
+    def device_count(self) -> int:
+        return self.count
+
+    def current_device(self) -> int:
+        return 0
+
+    def set_device(self, index: int) -> None:
+        self.set_calls.append(index)
+
+
+class _StubTorch:
+    def __init__(self, *, initialized: bool = False, count: int = 2) -> None:
+        self.cuda = _StubCuda(initialized=initialized, count=count)
+
+
+@pytest.fixture
+def clean_visible_devices(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delitem(os.environ, "CUDA_VISIBLE_DEVICES", raising=False)
+    return monkeypatch
+
+
+def test_nonzero_device_pins_visibility_without_existing_cvd(clean_visible_devices) -> None:
+    torch = _StubTorch()
+
+    assert _resolve_genesis_device_id(torch, 1) == 0
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "1"
+    assert torch.cuda.set_calls == [0]
+
+
+def test_nonzero_device_translates_existing_cvd(clean_visible_devices) -> None:
+    clean_visible_devices.setitem(os.environ, "CUDA_VISIBLE_DEVICES", "4,5")
+    torch = _StubTorch(count=2)
+
+    assert _resolve_genesis_device_id(torch, 1) == 0
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "5"
+    assert torch.cuda.set_calls == [0]
+
+
+def test_device_zero_binds_without_pinning(clean_visible_devices) -> None:
+    torch = _StubTorch()
+
+    assert _resolve_genesis_device_id(torch, 0) == 0
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
+    assert torch.cuda.set_calls == [0]
+
+
+def test_pin_fails_closed_after_cuda_init(clean_visible_devices) -> None:
+    torch = _StubTorch(initialized=True)
+
+    with pytest.raises(RuntimeError, match="before any CUDA context"):
+        _resolve_genesis_device_id(torch, 1)
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
+
+
+def test_pin_rejects_out_of_range_host_index(clean_visible_devices) -> None:
+    torch = _StubTorch(count=2)
+
+    with pytest.raises(ValueError, match="out of range"):
+        _resolve_genesis_device_id(torch, 2)
+
+
+def test_pin_rejects_index_beyond_existing_cvd(clean_visible_devices) -> None:
+    clean_visible_devices.setitem(os.environ, "CUDA_VISIBLE_DEVICES", "3")
+    torch = _StubTorch(count=1)
+
+    with pytest.raises(ValueError, match="CUDA_VISIBLE_DEVICES"):
+        _pin_cuda_visible_devices(torch, 1)
+
+
+def test_unset_device_keeps_current_device(clean_visible_devices) -> None:
+    torch = _StubTorch()
+
+    assert _resolve_genesis_device_id(torch, None) == 0
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
+    assert torch.cuda.set_calls == []


### PR DESCRIPTION
## Summary

Companion to Motphys/UniLab#1510 for issue #1508. Add the public Genesis `device_id` contract required for per-rank multi-GPU environment placement.

- `GenesisBackend` accepts and validates `device_id`.
- Genesis resolves and binds the selected CUDA device before `gs.init`.
- Process-wide session reuse rejects conflicting device IDs.
- Factory forwards `genesis_device_id`.

### CUDA_VISIBLE_DEVICES pinning update (c70696f)

The Quadrants engine only honors the first entry of `CUDA_VISIBLE_DEVICES`; `torch.cuda.set_device` on a non-zero index crashes scene creation with `CUDA_ERROR_ILLEGAL_ADDRESS`. The adapter now pins `CUDA_VISIBLE_DEVICES` to the requested physical device before any CUDA query — including `torch.cuda.is_available()`, which itself latches the visible-device set — remaps the process-local index to `cuda:0`, clears the `device_count` cache after pinning, and fails closed on out-of-range requests or on requests arriving after CUDA context initialization.

## Validation

- New Genesis pin tests: `tests/test_genesis_device.py` 7 passed (stubbed torch, host-free).
- `make check` on final head c70696f: ruff passed, **52 passed, 2 skipped** (after `make sync` with the pinned MuJoCo extra).
- UniLab-side two-GPU hardware validation against this source tree: PPO and SAC DP=2 on `g1_walk_flat/genesis` exit 0 with per-rank physical placement confirmed via `nvidia-smi`.

No package release is performed in this PR.
