### PR TITLE
feat: integrate Newton backend roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   the existing MJWarp 3.10.0.3 extra.
 - Add fail-closed Newton nconmax/njmax capacity sampling and overflow
   diagnostics for the forthcoming adapter.
+- Add the Newton `SimBackend` adapter with explicit CUDA placement, cold-path
+  MJCF materialization/audits, host NumPy state caches, and fail-closed sensor
+  and geometry coverage.
 
 ## 1.1.0 - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add the isolated Newton 1.5.1 runtime extra and a metadata/import probe;
   Newton's MuJoCo-Warp 3.11.0 line is documented as mutually exclusive with
   the existing MJWarp 3.10.0.3 extra.
+- Add fail-closed Newton nconmax/njmax capacity sampling and overflow
+  diagnostics for the forthcoming adapter.
 
 ## 1.1.0 - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Add snapshot playback support to the Newton adapter: `get_physics_state` /
+  `set_physics_state` ([time, qpos, qvel] host-cache layout), record/none
+  `resolve_play_render_plan` semantics, and `run_playback` through the shared
+  offline MuJoCo snapshot renderer now in `unisim.backend.playback_common`
+  (mjwarp behavior and messages unchanged). Add a fail-closed
+  `SimBackend.set_physics_state` default.
+- Add MJCF contact-sensor (`mjSENS_CONTACT`) support to the Newton adapter for
+  the exact `data="found" num=1` named-geom-pair shape: per-env binary flags
+  are resolved once against `SolverMuJoCo.mjc_geom_to_newton_shape` at
+  materialization and refreshed through `SolverMuJoCo.update_contacts`; all
+  other contact-sensor configurations remain fail-closed.
 - Rework the README around the project overview, UniLab relationship,
   installation, and quick start, and add the Chinese `README_zh.md`.
 - Add the isolated Newton 1.5.1 runtime extra and a metadata/import probe;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Rework the README around the project overview, UniLab relationship,
   installation, and quick start, and add the Chinese `README_zh.md`.
+- Add the isolated Newton 1.5.1 runtime extra and a metadata/import probe;
+  Newton's MuJoCo-Warp 3.11.0 line is documented as mutually exclusive with
+  the existing MJWarp 3.10.0.3 extra.
 
 ## 1.1.0 - 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ pip install unisim-core                # base: contract, factory, fake backend
 pip install "unisim-core[mujoco]"      # plus an engine extra when needed
 ```
 
-Available extras: `mujoco`, `motrix`, `drake`, `mjwarp`, `genesis`,
+Available extras: `mujoco`, `motrix`, `drake`, `mjwarp`, `genesis`, `newton`,
 `isaacgym`, `isaacsim`. The Isaac extras are empty spellings because those
 vendor SDKs are not redistributable; their adapters discover dedicated worker
 installations at construction time. See
 [`docs/support-matrix.md`](docs/support-matrix.md) for the full adapter
 support matrix.
+
+The `newton` extra is isolated from `mjwarp`: it pins Newton 1.5.1 with the
+MuJoCo-Warp 3.11.0 line, while `mjwarp` uses 3.10.0.3. Install only one of
+these two extras in an environment.
 
 ## Quick start
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,7 +6,7 @@ UniSim 提供后端中立的物理仿真契约（contract）和可选引擎适�
 学习与仿真。PyPI 分发名为 `unisim-core`,Python 导入命名空间为 `unisim`。
 
 统一的 `SimBackend` 契约覆盖状态访问、控制、重置与域随机化边界，同一份任务
-代码无需引擎专属分支即可运行在 MuJoCo、Motrix、Drake、MJWarp、Genesis、
+代码无需引擎专属分支即可运行在 MuJoCo、Motrix、Drake、MJWarp、Genesis、Newton、
 IsaacGym 或 IsaacSim 之上。基础安装仅依赖 NumPy;所有引擎 SDK 都是懒加载的
 可选 extra,`import unisim` 不会导入任何引擎。
 
@@ -26,10 +26,15 @@ pip install unisim-core                # 基础包:契约、工厂、fake 后端
 pip install "unisim-core[mujoco]"      # 需要时再加装引擎 extra
 ```
 
-可用 extra:`mujoco`、`motrix`、`drake`、`mjwarp`、`genesis`、`isaacgym`、
+可用 extra:`mujoco`、`motrix`、`drake`、`mjwarp`、`genesis`、`newton`、`isaacgym`、
 `isaacsim`。Isaac 两个 extra 是空声明,因为这些厂商 SDK 不可再分发;对应
 适配器在构造时发现独立的 worker 安装。完整的适配器支持矩阵见
 [`docs/support-matrix.md`](docs/support-matrix.md)。
+
+`newton` extra 与 `mjwarp` 隔离：前者固定 Newton 1.5.1 和 MuJoCo-Warp
+3.11.0，后者仍使用 3.10.0.3；同一环境不要同时安装两个 extra。安装后可运行
+`uv run scripts/check_newton_runtime.py` 做元数据探针，必要时追加 `--import`
+显式导入原生运行时。
 
 ## 快速上手
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ never escape the adapter. Drake, MJWarp and Genesis expose the same boundary
 through concrete engine adapters. IsaacGym and IsaacSim share the subprocess IPC
 framing and keep their Python 3.8/Kit workers outside the core wheel.
 
-`unisim.ADAPTER_SPECS` is the single migration manifest for all seven UniLab
+`unisim.ADAPTER_SPECS` is the single migration manifest for all eight UniLab
 backend identities. ``available`` means a public adapter and diagnostics exist;
 it does not claim that a proprietary SDK or GPU runtime is installed on every
 host. Runtime support is established by the adapter's optional-extra and

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -7,6 +7,7 @@
 | Drake | `unisim.DrakeBackend` | `uv sync --extra drake` (`drake-uni`) + native batch extension | available |
 | MJWarp | `unisim.MJWarpBackend` | `uv sync --extra mjwarp`, CUDA | available |
 | Genesis | `unisim.GenesisBackend` | `uv sync --extra genesis` | available |
+| Newton | `unisim.NewtonBackend` | `uv sync --extra newton`, Newton 1.5.1 / MuJoCo-Warp 3.11.0 | staged; adapter follows in #25 |
 | IsaacGym | `unisim.IsaacGymBackend` | `uv sync --extra isaacgym` (empty extra) + dedicated Python 3.8 worker | available |
 | IsaacSim | `unisim.IsaacSimBackend` | `uv sync --extra isaacsim` (empty extra) + dedicated IsaacSim/IsaacLab worker | available |
 
@@ -14,3 +15,10 @@ The base wheel imports none of these SDKs. Construction performs cold-path
 runtime discovery and raises an adapter-specific, actionable error when the
 runtime is unavailable. The matrix is an adapter/API support statement, not a
 claim that every host has every vendor SDK or GPU capability.
+
+Newton uses a separate MuJoCo-Warp line from the existing MJWarp extra:
+`newton` pins `newton==1.5.1`, `mujoco-warp==3.11.0`, `mujoco==3.11.0`, and
+`warp-lang==1.16.0`, while `mjwarp` remains on `mujoco-warp==3.10.0.3`.
+These extras are intentionally mutually exclusive in one environment. Run
+`uv run scripts/check_newton_runtime.py` after installation for a metadata-only
+probe; add `--import` when the native runtime should be imported explicitly.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -22,3 +22,6 @@ Newton uses a separate MuJoCo-Warp line from the existing MJWarp extra:
 These extras are intentionally mutually exclusive in one environment. Run
 `uv run scripts/check_newton_runtime.py` after installation for a metadata-only
 probe; add `--import` when the native runtime should be imported explicitly.
+The adapter's cold-path calibration samples solver counts and raises an explicit
+capacity error when `nconmax` or `njmax` is too small; it never accepts silent
+constraint truncation.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -7,7 +7,7 @@
 | Drake | `unisim.DrakeBackend` | `uv sync --extra drake` (`drake-uni`) + native batch extension | available |
 | MJWarp | `unisim.MJWarpBackend` | `uv sync --extra mjwarp`, CUDA | available |
 | Genesis | `unisim.GenesisBackend` | `uv sync --extra genesis` | available |
-| Newton | `unisim.NewtonBackend` | `uv sync --extra newton`, Newton 1.5.1 / MuJoCo-Warp 3.11.0 | staged; adapter follows in #25 |
+| Newton | `unisim.NewtonBackend` | `uv sync --extra newton`, Newton 1.5.1 / MuJoCo-Warp 3.11.0 | available (CUDA) |
 | IsaacGym | `unisim.IsaacGymBackend` | `uv sync --extra isaacgym` (empty extra) + dedicated Python 3.8 worker | available |
 | IsaacSim | `unisim.IsaacSimBackend` | `uv sync --extra isaacsim` (empty extra) + dedicated IsaacSim/IsaacLab worker | available |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,16 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 module-name = "unisim"
 
+[tool.uv]
+# The Newton/MuJoCo-Warp 3.11 line cannot coexist with the historical MJWarp
+# 3.10.0.3 line in one environment. Keep both extras available while making
+# the resolver fail with an explicit, actionable conflict when selected
+# together.
+conflicts = [
+    [{ extra = "mjwarp" }, { extra = "newton" }],
+    [{ extra = "mujoco" }, { extra = "newton" }],
+]
+
 [project]
 name = "unisim-core"
 version = "1.1.0"
@@ -33,6 +43,16 @@ motrix = ["motrixsim-core==0.8.2"]
 drake = ["drake-uni==0.1.0"]
 mjwarp = ["mujoco-warp==3.10.0.3", "warp-lang>=1.14.0"]
 genesis = ["genesis-world==1.3.3"]
+# Newton 1.5.1's MuJoCo solver line is intentionally isolated from the
+# historical mjwarp extra above: Newton's sim extra requires the 3.11 line,
+# while mjwarp remains pinned to 3.10.0.3. Do not install both extras in one
+# environment.
+newton = [
+    "newton==1.5.1",
+    "mujoco-warp==3.11.0",
+    "mujoco==3.11.0",
+    "warp-lang==1.16.0",
+]
 # Isaac SDKs are vendor-managed and cannot be represented as redistributable
 # PyPI dependencies.  These empty extras provide a stable installation and
 # support-matrix spelling while runtime discovery uses dedicated workers.

--- a/scripts/check_newton_runtime.py
+++ b/scripts/check_newton_runtime.py
@@ -1,0 +1,83 @@
+"""Check the pinned Newton runtime boundary without importing engine SDKs.
+
+The default probe only inspects installed distribution metadata and module
+availability. Passing ``--import`` performs the optional imports explicitly;
+this may initialize CUDA-facing runtime code and is therefore not part of the
+base test path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import sys
+from importlib import metadata
+
+PINNED_DISTRIBUTIONS: dict[str, str] = {
+    "newton": "1.5.1",
+    "mujoco-warp": "3.11.0",
+    "mujoco": "3.11.0",
+    "warp-lang": "1.16.0",
+}
+MODULES: dict[str, str] = {
+    "newton": "newton",
+    "mujoco-warp": "mujoco_warp",
+    "mujoco": "mujoco",
+    "warp-lang": "warp",
+}
+
+
+def check_runtime(*, import_modules: bool = False) -> list[str]:
+    """Return human-readable diagnostics; an empty list means the probe passed."""
+    diagnostics: list[str] = []
+    if sys.version_info < (3, 10):
+        diagnostics.append(
+            f"Python >= 3.10 is required, found {sys.version_info.major}.{sys.version_info.minor}"
+        )
+
+    for distribution, expected in PINNED_DISTRIBUTIONS.items():
+        try:
+            found = metadata.version(distribution)
+        except metadata.PackageNotFoundError:
+            diagnostics.append(f"{distribution} is not installed (expected {expected})")
+            continue
+        if found != expected:
+            diagnostics.append(f"{distribution}=={found} is installed; expected {expected}")
+        module_name = MODULES[distribution]
+        if importlib.util.find_spec(module_name) is None:
+            diagnostics.append(f"module {module_name!r} is unavailable for {distribution}")
+            continue
+        if import_modules:
+            try:
+                importlib.import_module(module_name)
+            except Exception as exc:  # pragma: no cover - depends on native runtime
+                diagnostics.append(f"import {module_name!r} failed: {type(exc).__name__}: {exc}")
+    return diagnostics
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--import",
+        dest="import_modules",
+        action="store_true",
+        help="import the optional Newton stack after metadata checks",
+    )
+    args = parser.parse_args()
+    diagnostics = check_runtime(import_modules=args.import_modules)
+    if diagnostics:
+        print("Newton runtime probe: FAILED")
+        for diagnostic in diagnostics:
+            print(f"- {diagnostic}")
+        print("Install the isolated stack with: uv sync --extra newton")
+        print("Do not combine it with: uv sync --extra mjwarp")
+        return 1
+    print("Newton runtime probe: OK")
+    for distribution, version in PINNED_DISTRIBUTIONS.items():
+        print(f"- {distribution}=={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -23,6 +23,8 @@ __all__ = [
     "DrakeBackend",
     "MJWarpBackend",
     "MjwarpBackend",
+    "NewtonBackend",
+    "NewtonDependencyError",
     "GenesisBackend",
     "IsaacGymBackend",
     "IsaacGymDependencyError",
@@ -53,6 +55,8 @@ def __getattr__(name: str):
         "IsaacSimDependencyError": (".backend.isaacsim.dependencies", "IsaacSimDependencyError"),
         "MJWarpBackend": (".backend.mjwarp", "MjwarpBackend"),
         "MjwarpBackend": (".backend.mjwarp", "MjwarpBackend"),
+        "NewtonBackend": (".backend.newton", "NewtonBackend"),
+        "NewtonDependencyError": (".backend.newton", "NewtonDependencyError"),
         "MotrixBackend": (".backend.motrix", "MotrixBackend"),
         "MuJoCoBackend": (".backend.mujoco", "MuJoCoBackend"),
         # ``SubprocessBackend`` was the name used by the first extraction

--- a/src/unisim/adapters.py
+++ b/src/unisim/adapters.py
@@ -28,6 +28,7 @@ ADAPTER_SPECS: tuple[AdapterSpec, ...] = (
     # dependency/worker diagnostic when the optional SDK is not installed.
     AdapterSpec("drake", "drake", "available"),
     AdapterSpec("mjwarp", "mjwarp", "available"),
+    AdapterSpec("newton", "newton", "available"),
     AdapterSpec("genesis", "genesis", "available"),
     AdapterSpec("isaacgym", "isaacgym", "available"),
     AdapterSpec("isaacsim", "isaacsim", "available"),

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -750,6 +750,16 @@ class SimBackend(abc.ABC):
             f"{self.__class__.__name__} does not support physics-state playback"
         )
 
+    def set_physics_state(self, state: np.ndarray) -> None:
+        """Restore a snapshot produced by ``get_physics_state``.
+
+        Backends implementing this must refresh their host caches so state and
+        sensor getters stay consistent with the restored physics state.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support physics-state restore"
+        )
+
     def get_playback_model(self, env_index: int | None = None) -> Any:
         """Return the playback model for a specific env when variants exist.
 

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -1,15 +1,22 @@
-"""Cold-path MuJoCo offline playback bridge for ``mjwarp``."""
+"""Cold-path MuJoCo offline playback bridge for ``mjwarp``.
+
+The implementation lives in :mod:`unisim.backend.playback_common` so other
+snapshot-based adapters (Newton) share one offline MuJoCo pipeline; the
+wrappers below keep the historical mjwarp names, signatures, and messages.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from os import PathLike
-from pathlib import Path
 from typing import Any, TypeVar
 
 import numpy as np
 
-from unisim.backend.mujoco.playback import run_mujoco_playback
+from unisim.backend.playback_common import (
+    run_offline_snapshot_playback,
+    validate_offline_visual_model,
+)
 
 ObsT = TypeVar("ObsT")
 
@@ -21,48 +28,12 @@ def validate_mjwarp_visual_model(
     model_file: str | PathLike[str],
 ) -> str:
     """Validate the detached MuJoCo visual twin used for offline playback."""
-    path = Path(model_file)
-    if not path.is_file():
-        raise ValueError(
-            f"mjwarp offline playback visual model does not exist or is not a file: {path}"
-        )
-    try:
-        visual_model = mujoco.MjModel.from_xml_path(str(path))
-    except Exception as exc:
-        raise ValueError(
-            f"mjwarp offline playback could not load visual model {path}: "
-            f"{type(exc).__name__}: {exc}"
-        ) from exc
-
-    physics_dims = (int(physics_model.nq), int(physics_model.nv))
-    visual_dims = (int(visual_model.nq), int(visual_model.nv))
-    if visual_dims != physics_dims:
-        raise ValueError(
-            "mjwarp offline playback visual model state dimensions are incompatible: "
-            f"physics nq/nv={physics_dims}, visual nq/nv={visual_dims}."
-        )
-
-    joint_object = mujoco.mjtObj.mjOBJ_JOINT
-
-    def _joint_layout(model: Any) -> tuple[tuple[str | None, int, int, int], ...]:
-        return tuple(
-            (
-                mujoco.mj_id2name(model, joint_object, joint_id),
-                int(model.jnt_type[joint_id]),
-                int(model.jnt_qposadr[joint_id]),
-                int(model.jnt_dofadr[joint_id]),
-            )
-            for joint_id in range(int(model.njnt))
-        )
-
-    physics_layout = _joint_layout(physics_model)
-    visual_layout = _joint_layout(visual_model)
-    if visual_layout != physics_layout:
-        raise ValueError(
-            "mjwarp offline playback visual model joint layout is incompatible; "
-            "joint names, types, qpos addresses, and dof addresses must match physics."
-        )
-    return str(path)
+    return validate_offline_visual_model(
+        mujoco=mujoco,
+        physics_model=physics_model,
+        model_file=model_file,
+        backend_label="mjwarp",
+    )
 
 
 def run_mjwarp_playback(
@@ -82,64 +53,19 @@ def run_mjwarp_playback(
     extra_data_getter: Callable[[], np.ndarray | None] | None = None,
 ) -> str:
     """Render detached mjwarp host snapshots with the existing MuJoCo pipeline."""
-    if not headless:
-        raise NotImplementedError(
-            "mjwarp offline playback does not support interactive rendering; "
-            "use training.play_render_mode=record."
-        )
-    if not record_video:
-        raise ValueError("mjwarp offline playback requires record_video=true.")
-    if isinstance(num_steps, bool) or num_steps is None or int(num_steps) <= 0:
-        raise ValueError("mjwarp record playback requires a positive finite num_steps value.")
-    if output_video is None:
-        raise ValueError("mjwarp record playback requires an output_video path.")
-
-    # Both checks are playback-only cold-path work. Physics construction and
-    # step/reset never import the renderer or parse the visual model.
-    backend.get_playback_model()
-    try:
-        from unisim.visualization import render_many
-
-        renderer_usable = bool(render_many.render_backend_usable())
-    except Exception as exc:
-        raise RuntimeError(
-            "mjwarp offline playback could not initialize the MuJoCo renderer: "
-            f"{type(exc).__name__}: {exc}"
-        ) from exc
-    if not renderer_usable:
-        raise RuntimeError(
-            "mjwarp offline playback requires a usable MuJoCo off-screen renderer; "
-            "configure EGL, OSMesa, or GLFW before recording."
-        )
-
-    getter = frame_state_getter or env.get_physics_state_snapshot
-    expected_shape = snapshot_shape
-
-    def _validated_state_getter() -> np.ndarray:
-        state = np.asarray(getter(), dtype=np.float32)
-        if state.shape != expected_shape:
-            raise ValueError(
-                "mjwarp offline playback snapshot must use [time, qpos, qvel] layout "
-                f"with shape {expected_shape}, got {state.shape}."
-            )
-        return state
-
-    result = run_mujoco_playback(
+    return run_offline_snapshot_playback(
+        backend=backend,
         env=env,
         initialize=initialize,
         step=step,
-        num_steps=int(num_steps),
+        num_steps=num_steps,
         output_video=output_video,
         render_spacing=render_spacing,
-        headless=True,
-        record_video=True,
-        frame_state_getter=_validated_state_getter,
+        headless=headless,
+        record_video=record_video,
+        snapshot_shape=snapshot_shape,
+        frame_state_getter=frame_state_getter,
         camera_kwargs=camera_kwargs,
+        backend_label="mjwarp",
         extra_data_getter=extra_data_getter,
     )
-    if result is None:
-        raise RuntimeError(
-            "mjwarp offline playback produced no frames; the MuJoCo renderer or worker "
-            "failed after preflight."
-        )
-    return result

--- a/src/unisim/backend/newton/__init__.py
+++ b/src/unisim/backend/newton/__init__.py
@@ -1,0 +1,23 @@
+"""Newton adapter support modules.
+
+The concrete adapter is added in Child 3.  Capacity helpers are exported here
+so the implementation and its focused tests share one fail-closed contract.
+"""
+
+from .capacity import (
+    NewtonCapacityError,
+    NewtonCapacityReport,
+    NewtonCapacitySample,
+    calibrate_capacity,
+    sample_capacity,
+    validate_capacity_limits,
+)
+
+__all__ = [
+    "NewtonCapacityError",
+    "NewtonCapacityReport",
+    "NewtonCapacitySample",
+    "calibrate_capacity",
+    "sample_capacity",
+    "validate_capacity_limits",
+]

--- a/src/unisim/backend/newton/__init__.py
+++ b/src/unisim/backend/newton/__init__.py
@@ -1,8 +1,4 @@
-"""Newton adapter support modules.
-
-The concrete adapter is added in Child 3.  Capacity helpers are exported here
-so the implementation and its focused tests share one fail-closed contract.
-"""
+"""Independent optional Newton backend and its fail-closed support helpers."""
 
 from .capacity import (
     NewtonCapacityError,
@@ -12,11 +8,25 @@ from .capacity import (
     sample_capacity,
     validate_capacity_limits,
 )
+from .dependencies import NewtonDependencyError, newton_dependencies_available
+
+
+def __getattr__(name: str):
+    if name == "NewtonBackend":
+        from .backend import NewtonBackend
+
+        return NewtonBackend
+    if name == "NEWTON_AVAILABLE":
+        return newton_dependencies_available()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "NewtonCapacityError",
     "NewtonCapacityReport",
     "NewtonCapacitySample",
+    "NewtonBackend",
+    "NewtonDependencyError",
+    "NEWTON_AVAILABLE",
     "calibrate_capacity",
     "sample_capacity",
     "validate_capacity_limits",

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -1,0 +1,644 @@
+"""Newton 1.5.1 adapter implementing the host-NumPy SimBackend profile.
+
+All Newton/Warp transfers happen at explicit materialize, step, or set_state
+barriers. Public getters return stable NumPy cache views and never inspect
+MuJoCo's CPU data object. GPU execution is not bitwise deterministic; callers
+and tests must use numerical tolerances.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
+from unisim.scene import SceneCfg
+from unisim.utils.rotation import (
+    np_quat_apply_batched,
+    np_quat_apply_inverse_batched,
+    np_quat_conjugate_batched,
+    np_quat_mul_batched,
+)
+
+from .capacity import NewtonCapacityReport, calibrate_capacity, validate_capacity_limits
+from .dependencies import load_newton_dependencies
+from .materialization import (
+    NewtonModelAudit,
+    audit_newton_model,
+    scan_newton_model_metadata,
+)
+from .runtime import get_bound_newton_process_device
+
+_WORLD_Z = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+
+
+class NewtonBackend(SimBackend):
+    """In-process Newton/SolverMuJoCo adapter with explicit device placement."""
+
+    def __init__(
+        self,
+        scene: SceneCfg,
+        num_envs: int,
+        sim_dt: float,
+        *,
+        base_name: str | None = None,
+        device: str | None = None,
+        nconmax: int | None = None,
+        njmax: int | None = None,
+        capacity_check_steps: int = 1,
+        **unexpected_kwargs: Any,
+    ) -> None:
+        if unexpected_kwargs:
+            names = ", ".join(sorted(unexpected_kwargs))
+            raise TypeError(f"NewtonBackend does not accept backend options: {names}")
+        if isinstance(num_envs, bool) or not isinstance(num_envs, int) or num_envs <= 0:
+            raise ValueError(f"num_envs must be a positive integer, got {num_envs!r}")
+        if float(sim_dt) <= 0.0:
+            raise ValueError(f"sim_dt must be positive, got {sim_dt!r}")
+        self._nconmax = self._capacity(nconmax, "nconmax", 512)
+        self._njmax = self._capacity(njmax, "njmax", 512)
+        self._capacity_check_steps = self._capacity(
+            capacity_check_steps, "capacity_check_steps", 1
+        )
+
+        self._deps = load_newton_dependencies()
+        selected_device = device or get_bound_newton_process_device()
+        if selected_device is None:
+            raise ValueError(
+                "newton requires explicit device placement; pass newton_device='cuda:N' "
+                "or call configure_backend_process_device before construction"
+            )
+        self._deps.warp.set_device(str(selected_device))
+        resolved = self._deps.warp.get_device()
+        if not bool(resolved.is_cuda):
+            raise RuntimeError(f"newton backend requires a CUDA Warp device, got {resolved!s}")
+
+        self.backend_type = "newton"
+        self._pre_step_control_fn = None
+        self._num_envs = num_envs
+        self._sim_dt = float(sim_dt)
+        self._device = str(resolved)
+        self._scene_visual_model_file = str(scene.visual_model_file or scene.model_file)
+        self._metadata = scan_newton_model_metadata(self._deps.mujoco, scene)
+        if not self._metadata.root_qpos_dim:
+            raise NotImplementedError(
+                "newton backend currently requires a free root joint for the "
+                "SimBackend state contract"
+            )
+        self._scene_cleanup_handle = self._metadata.cleanup_handle
+        authored_root_name = next((name for name in self._metadata.body_names[1:] if name), None)
+        if base_name is not None and base_name != authored_root_name:
+            raise ValueError(
+                f"newton base_name must identify the authored free root body {authored_root_name!r}"
+            )
+        self._base_name = base_name or authored_root_name
+        self._body_names = self._metadata.body_names[1:]
+        self._body_ids = {name: index for index, name in enumerate(self._body_names) if name}
+        if self._base_name not in self._body_ids:
+            raise ValueError(f"Base body {self._base_name!r} not found in newton model")
+        self._base_body_id = self._body_ids[self._base_name]
+        self._joint_ids = dict(
+            zip(self._metadata.joint_names, range(len(self._metadata.joint_names)))
+        )
+        self._keyframes = dict(self._metadata.keyframes)
+        self._sensor_slots: dict[str, tuple[int, int]] = {}
+        address = 0
+        for plan in self._metadata.sensor_plans:
+            self._sensor_slots[plan.name] = (address, plan.dim)
+            address += plan.dim
+
+        self._model: Any | None = None
+        self._solver: Any | None = None
+        self._state: Any | None = None
+        self._state_out: Any | None = None
+        self._control: Any | None = None
+        self._contacts: Any | None = None
+        self._view: Any | None = None
+        self._audit: NewtonModelAudit | None = None
+        self._capacity_report: NewtonCapacityReport | None = None
+        self._closed = False
+
+        nbody = len(self._body_names)
+        self._qpos_cache = np.zeros((num_envs, self._metadata.nq), dtype=np.float32)
+        self._qvel_cache = np.zeros((num_envs, self._metadata.nv), dtype=np.float32)
+        self._body_pos_cache = np.zeros((num_envs, nbody, 3), dtype=np.float32)
+        self._body_quat_cache = np.zeros((num_envs, nbody, 4), dtype=np.float32)
+        self._body_lin_vel_cache = np.zeros((num_envs, nbody, 3), dtype=np.float32)
+        self._body_ang_vel_cache = np.zeros((num_envs, nbody, 3), dtype=np.float32)
+        self._sensor_cache = np.zeros((num_envs, address), dtype=np.float32)
+        self._previous_site_velocity: dict[str, np.ndarray] = {}
+        self._time_cache = np.zeros((num_envs,), dtype=np.float32)
+
+    @staticmethod
+    def _capacity(value: int | None, name: str, default: int) -> int:
+        resolved = default if value is None else value
+        validate_capacity_limits(
+            nconmax=resolved if name == "nconmax" else 1,
+            njmax=resolved if name != "nconmax" else 1,
+        )
+        return int(resolved)
+
+    def _require_state(self, operation: str) -> None:
+        if self._closed:
+            raise RuntimeError(f"newton backend is closed; cannot run {operation}")
+        self.materialize()
+
+    def materialize(self) -> None:
+        if self._model is not None:
+            return
+        newton = self._deps.newton
+        previous_layout = bool(newton.use_coord_layout_targets)
+        newton.use_coord_layout_targets = True
+        try:
+            template = newton.ModelBuilder()
+            newton.solvers.SolverMuJoCo.register_custom_attributes(template)
+            template.add_mjcf(self._metadata.source_model_file, ctrl_direct=False)
+            builder = newton.ModelBuilder()
+            builder.replicate(template, self._num_envs)
+            self._model = builder.finalize(device=self._device)
+        finally:
+            newton.use_coord_layout_targets = previous_layout
+            self.cleanup_scene_assets()
+
+        self._audit = audit_newton_model(self._model, self._metadata, self._num_envs)
+        self._solver = newton.solvers.SolverMuJoCo(
+            self._model,
+            separate_worlds=True,
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+            solver="newton",
+            integrator="implicitfast",
+            use_mujoco_cpu=False,
+            use_mujoco_contacts=True,
+            update_data_interval=0,
+        )
+        actual_nconmax = int(self._solver.mjw_data.naconmax)
+        actual_njmax = int(self._solver.mjw_data.njmax)
+        if actual_nconmax < self._nconmax or actual_njmax < self._njmax:
+            raise RuntimeError(
+                "Newton compiled solver capacity below the requested explicit limit: "
+                f"requested nconmax/njmax={self._nconmax}/{self._njmax}, "
+                f"compiled {actual_nconmax}/{actual_njmax}"
+            )
+        # SolverMuJoCo may raise a requested capacity to the initial-state
+        # requirement. Track the effective limits so every later check covers
+        # the actual allocation and cannot miss a runtime truncation.
+        self._nconmax = actual_nconmax
+        self._njmax = actual_njmax
+        self._view = newton.selection.ArticulationView(self._model, "*")
+        if int(self._view.count_per_world) != 1:
+            raise NotImplementedError(
+                "newton backend requires exactly one articulation per replicated world"
+            )
+        self._state = self._model.state()
+        self._state_out = self._model.state()
+        self._control = self._model.control()
+        self._contacts = newton.Contacts(
+            self._solver.get_max_contact_count(), 0, device=self._device
+        )
+        newton.eval_fk(
+            self._model, self._state.joint_q, self._state.joint_qd, self._state
+        )
+        self._refresh_host_cache()
+        self._capacity_report = calibrate_capacity(
+            self._advance_capacity_probe,
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+            sample_steps=self._capacity_check_steps,
+            context="Newton representative materialization rollout",
+        )
+        self._state = self._model.state()
+        self._state_out = self._model.state()
+        self._solver.reset(self._state)
+        newton.eval_fk(
+            self._model, self._state.joint_q, self._state.joint_qd, self._state
+        )
+        self._refresh_host_cache()
+
+    def _advance_capacity_probe(self) -> tuple[int, int]:
+        self._physics_substep(np.zeros((self._num_envs, self.num_actuators), np.float32))
+        return self._read_solver_counts()
+
+    def _read_solver_counts(self) -> tuple[int, int]:
+        self._deps.warp.synchronize_device(self._device)
+        ncon = int(np.max(np.asarray(self._solver.mjw_data.nacon.numpy())))
+        nefc = int(np.max(np.asarray(self._solver.mjw_data.nefc.numpy())))
+        return ncon, nefc
+
+    def _set_control(self, ctrl: np.ndarray) -> None:
+        namespace = getattr(self._control, "mujoco", None)
+        target = getattr(namespace, "ctrl", None) if namespace is not None else None
+        if target is not None:
+            target.assign(np.ascontiguousarray(ctrl.reshape(-1), dtype=np.float32))
+        target_q = getattr(self._control, "joint_target_q", None)
+        target_qd = getattr(self._control, "joint_target_qd", None)
+        if target_q is not None:
+            q_targets = np.zeros((self._num_envs, self._metadata.nq), dtype=np.float32)
+            for actuator_id, kind in enumerate(self._metadata.actuator_target_kinds):
+                if kind == "position":
+                    q_targets[:, self._metadata.actuator_target_qpos_adrs[actuator_id]] = ctrl[
+                        :, actuator_id
+                    ]
+            target_q.assign(np.ascontiguousarray(q_targets.reshape(-1)))
+        if target_qd is not None:
+            qd_targets = np.zeros((self._num_envs, self._metadata.nv), dtype=np.float32)
+            for actuator_id, kind in enumerate(self._metadata.actuator_target_kinds):
+                if kind == "velocity":
+                    qd_targets[:, self._metadata.actuator_target_qvel_adrs[actuator_id]] = ctrl[
+                        :, actuator_id
+                    ]
+            target_qd.assign(np.ascontiguousarray(qd_targets.reshape(-1)))
+
+    def _physics_substep(self, ctrl: np.ndarray) -> None:
+        self._set_control(ctrl)
+        self._state.clear_forces()
+        self._solver.step(
+            self._state, self._state_out, self._control, self._contacts, self._sim_dt
+        )
+        self._state, self._state_out = self._state_out, self._state
+
+    def _view_array(self, value: Any, width: int) -> np.ndarray:
+        self._deps.warp.synchronize_device(self._device)
+        return np.asarray(value.numpy(), dtype=np.float32).reshape(self._num_envs, width)
+
+    @staticmethod
+    def _xyzw_to_wxyz(value: np.ndarray) -> np.ndarray:
+        return value[..., [3, 0, 1, 2]]
+
+    @staticmethod
+    def _wxyz_to_xyzw(value: np.ndarray) -> np.ndarray:
+        return value[..., [1, 2, 3, 0]]
+
+    def _refresh_host_cache(self, *, sensor_dt: float | None = None) -> None:
+        qpos_raw = self._view_array(self._view.get_dof_positions(self._state), self._metadata.nq)
+        qvel_raw = self._view_array(self._view.get_dof_velocities(self._state), self._metadata.nv)
+        link_q = self._view_array(
+            self._view.get_link_transforms(self._state), len(self._body_names) * 7
+        ).reshape(self._num_envs, len(self._body_names), 7)
+        link_qd = self._view_array(
+            self._view.get_link_velocities(self._state), len(self._body_names) * 6
+        ).reshape(self._num_envs, len(self._body_names), 6)
+
+        self._qpos_cache[...] = qpos_raw
+        if self._metadata.root_qpos_dim:
+            self._qpos_cache[:, 3:7] = self._xyzw_to_wxyz(qpos_raw[:, 3:7])
+        self._body_pos_cache[...] = link_q[..., :3]
+        self._body_quat_cache[...] = self._xyzw_to_wxyz(link_q[..., 3:7])
+        self._body_ang_vel_cache[...] = link_qd[..., 3:6]
+        ipos = np.broadcast_to(
+            self._metadata.body_ipos[1:], self._body_pos_cache.shape
+        )
+        offset_w = np_quat_apply_batched(self._body_quat_cache, ipos)
+        self._body_lin_vel_cache[...] = link_qd[..., :3] - np.cross(
+            self._body_ang_vel_cache, offset_w
+        )
+        self._qvel_cache[...] = qvel_raw
+        if self._metadata.root_qvel_dim:
+            root_quat = self._body_quat_cache[:, self._base_body_id]
+            root_omega = self._body_ang_vel_cache[:, self._base_body_id]
+            root_offset = offset_w[:, self._base_body_id]
+            self._qvel_cache[:, :3] = qvel_raw[:, :3] - np.cross(root_omega, root_offset)
+            self._qvel_cache[:, 3:6] = np_quat_apply_inverse_batched(root_quat, root_omega)
+        self._refresh_sensor_cache(sensor_dt=sensor_dt)
+
+    def _refresh_sensor_cache(self, *, sensor_dt: float | None) -> None:
+        for plan in self._metadata.sensor_plans:
+            body_id = plan.body_id - 1
+            if body_id < 0:
+                raise RuntimeError(f"sensor {plan.name!r} is attached to the world body")
+            address, dim = self._sensor_slots[plan.name]
+            out = self._sensor_cache[:, address : address + dim]
+            body_quat = self._body_quat_cache[:, body_id]
+            site_quat = np_quat_mul_batched(
+                body_quat, np.broadcast_to(plan.site_quat, body_quat.shape)
+            )
+            offset_w = np_quat_apply_batched(
+                body_quat, np.broadcast_to(plan.site_pos, (self._num_envs, 3))
+            )
+            site_velocity = self._body_lin_vel_cache[:, body_id] + np.cross(
+                self._body_ang_vel_cache[:, body_id], offset_w
+            )
+            if plan.kind == "gyro":
+                out[...] = np_quat_apply_inverse_batched(
+                    site_quat, self._body_ang_vel_cache[:, body_id]
+                )
+            elif plan.kind == "velocimeter":
+                out[...] = np_quat_apply_inverse_batched(site_quat, site_velocity)
+            elif plan.kind == "framepos":
+                out[...] = self._body_pos_cache[:, body_id] + offset_w
+            elif plan.kind == "framequat":
+                out[...] = site_quat
+            elif plan.kind == "framezaxis":
+                out[...] = np_quat_apply_batched(
+                    site_quat, np.broadcast_to(_WORLD_Z, (self._num_envs, 3))
+                )
+            elif plan.kind == "accelerometer":
+                previous = self._previous_site_velocity.get(plan.name)
+                acceleration = np.zeros_like(site_velocity)
+                if previous is not None and sensor_dt is not None:
+                    acceleration = (site_velocity - previous) / sensor_dt
+                acceleration -= self._metadata.gravity
+                out[...] = np_quat_apply_inverse_batched(site_quat, acceleration)
+            self._previous_site_velocity[plan.name] = site_velocity.copy()
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def model(self) -> Any:
+        self._require_state("model")
+        return self._model
+
+    @property
+    def num_actuators(self) -> int:
+        return len(self._metadata.actuator_names)
+
+    @property
+    def num_dof_vel(self) -> int:
+        return self._metadata.nv - self._metadata.root_qvel_dim
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return self._metadata.actuator_ctrl_range.copy()
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return self._metadata.actuator_names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return self._metadata.actuator_joint_names
+
+    def get_scene_model_file(self) -> str | None:
+        return self._metadata.diagnostic_model_file
+
+    def get_scene_visual_model_file(self) -> str | None:
+        return self._scene_visual_model_file
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        try:
+            return self._keyframes[name].copy()
+        except KeyError as exc:
+            raise ValueError(f"Keyframe {name!r} not found") from exc
+
+    def get_default_qpos(self) -> np.ndarray:
+        return self._metadata.default_qpos.copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return self._metadata.default_qpos[self._metadata.root_qpos_dim :].copy()
+
+    def get_init_qvel(self) -> np.ndarray:
+        return np.zeros((self._metadata.nv,), dtype=np.float32)
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        if root_body_name != self._base_name or not self._metadata.root_qpos_dim:
+            raise NotImplementedError(
+                f"backend 'newton' requires {self._base_name!r} as its free root body"
+            )
+        return BackendRootStateLayout(tuple(range(7)), tuple(range(6)))
+
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        try:
+            return np.asarray([self._body_ids[str(name)] for name in names], dtype=np.int32)
+        except KeyError as exc:
+            raise ValueError(f"Body {exc.args[0]!r} not found in newton model") from exc
+
+    def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:
+        root = int(root_body_id)
+        if root < 0 or root >= len(self._body_names):
+            raise ValueError(f"root_body_id out of range: {root}")
+        parents = self._metadata.body_parent_ids[1:] - 1
+        descendants = {root}
+        for body_id in range(root + 1, len(parents)):
+            if int(parents[body_id]) in descendants:
+                descendants.add(body_id)
+        return np.asarray(sorted(descendants), dtype=np.int32)
+
+    def get_gravity(self) -> np.ndarray:
+        return self._metadata.gravity.copy()
+
+    def get_body_mass(self) -> np.ndarray:
+        return self._metadata.body_mass.copy()
+
+    def get_body_ipos(self) -> np.ndarray:
+        return self._metadata.body_ipos.copy()
+
+    def get_dof_armature(self) -> np.ndarray:
+        return self._metadata.dof_armature.copy()
+
+    def get_joint_range(self) -> np.ndarray | None:
+        value = self._metadata.joint_range
+        return None if value is None else value.copy()
+
+    def get_joint_dof_indices(self, names: Sequence[str]) -> np.ndarray:
+        return np.asarray(
+            [self._metadata.joint_dof_adrs[self._joint_ids[str(name)]] for name in names],
+            dtype=np.int32,
+        )
+
+    def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
+        full = [self._metadata.joint_qpos_adrs[self._joint_ids[str(name)]] for name in names]
+        return np.asarray(full, dtype=np.int32) - self._metadata.root_qpos_dim
+
+    def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_indices(names) - self._metadata.root_qvel_dim
+
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names) + self._metadata.root_qpos_dim
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_vel_indices(names) + self._metadata.root_qvel_dim
+
+    def get_actuator_gains(self) -> tuple[np.ndarray, np.ndarray]:
+        return self._metadata.actuator_kp.copy(), self._metadata.actuator_kd.copy()
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> dict[str, dict[str, float]]:
+        self._require_state("step")
+        if isinstance(nsteps, bool) or not isinstance(nsteps, int) or nsteps <= 0:
+            raise ValueError(f"nsteps must be a positive integer, got {nsteps!r}")
+        ctrl_array = np.asarray(ctrl, dtype=np.float32)
+        expected = (self._num_envs, self.num_actuators)
+        if ctrl_array.shape != expected:
+            raise ValueError(f"ctrl must have shape {expected}, got {ctrl_array.shape}")
+        t0 = time.perf_counter()
+        for _ in range(nsteps):
+            native_ctrl = self._apply_pre_step_control(ctrl_array)
+            self._physics_substep(native_ctrl)
+        self._deps.warp.synchronize_device(self._device)
+        physics_ms = (time.perf_counter() - t0) * 1000.0
+        ncon, nefc = self._read_solver_counts()
+        validate_capacity_limits(
+            nconmax=self._nconmax,
+            njmax=self._njmax,
+            peak_ncon=ncon,
+            peak_nefc=nefc,
+            context="Newton runtime step",
+        )
+        t0 = time.perf_counter()
+        self._refresh_host_cache(sensor_dt=nsteps * self._sim_dt)
+        self._time_cache += np.float32(nsteps * self._sim_dt)
+        cache_ms = (time.perf_counter() - t0) * 1000.0
+        return {"timing": {"physics_ms": physics_ms, "host_cache_refresh_ms": cache_ms}}
+
+    def set_state(
+        self,
+        env_indices: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization: ResetRandomizationPayload | None = None,
+    ) -> dict[str, dict[str, float]]:
+        self._require_state("set_state")
+        rows = np.asarray(env_indices, dtype=np.intp)
+        if rows.ndim != 1 or np.any(rows < 0) or np.any(rows >= self._num_envs):
+            raise ValueError("env_indices must be a one-dimensional in-range index array")
+        if np.unique(rows).size != rows.size:
+            raise ValueError("env_indices must not contain duplicates")
+        qpos_array = np.asarray(qpos, dtype=np.float32)
+        qvel_array = np.asarray(qvel, dtype=np.float32)
+        if qpos_array.shape != (rows.size, self._metadata.nq):
+            raise ValueError("qpos shape does not match selected Newton worlds")
+        if qvel_array.shape != (rows.size, self._metadata.nv):
+            raise ValueError("qvel shape does not match selected Newton worlds")
+        if randomization is not None and not randomization.is_empty():
+            raise NotImplementedError("newton backend does not yet support reset randomization")
+        if not rows.size:
+            return {"timing": {"set_state_upload_ms": 0.0, "set_state_cache_ms": 0.0}}
+
+        t0 = time.perf_counter()
+        full_qpos = self._qpos_cache.copy()
+        full_qvel = self._qvel_cache.copy()
+        full_qpos[rows] = qpos_array
+        full_qvel[rows] = qvel_array
+        if self._metadata.root_qpos_dim:
+            full_qpos[:, 3:7] = self._wxyz_to_xyzw(full_qpos[:, 3:7])
+            root_quat = qpos_array[:, 3:7]
+            omega_world = np_quat_apply_batched(root_quat, qvel_array[:, 3:6])
+            ipos = np.broadcast_to(
+                self._metadata.body_ipos[self._base_body_id + 1], (rows.size, 3)
+            )
+            offset_w = np_quat_apply_batched(root_quat, ipos)
+            full_qvel[rows, :3] = qvel_array[:, :3] + np.cross(omega_world, offset_w)
+            full_qvel[rows, 3:6] = omega_world
+        mask = np.zeros((self._num_envs,), dtype=np.bool_)
+        mask[rows] = True
+        warp_mask = self._deps.warp.array(mask, dtype=self._deps.warp.bool, device=self._device)
+        qpos_device = self._deps.warp.array(
+            full_qpos[:, None, :], dtype=self._deps.warp.float32, device=self._device
+        )
+        qvel_device = self._deps.warp.array(
+            full_qvel[:, None, :], dtype=self._deps.warp.float32, device=self._device
+        )
+        self._view.set_dof_positions(self._state, qpos_device, mask=mask)
+        self._view.set_dof_velocities(self._state, qvel_device, mask=mask)
+        self._deps.newton.eval_fk(
+            self._model, self._state.joint_q, self._state.joint_qd, self._state
+        )
+        self._solver.reset(self._state, warp_mask)
+        upload_ms = (time.perf_counter() - t0) * 1000.0
+        t0 = time.perf_counter()
+        self._refresh_host_cache()
+        self._time_cache[rows] = 0.0
+        cache_ms = (time.perf_counter() - t0) * 1000.0
+        return {
+            "timing": {"set_state_upload_ms": upload_ms, "set_state_cache_ms": cache_ms}
+        }
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        return DomainRandomizationCapabilities()
+
+    def get_base_pos(self) -> np.ndarray:
+        self._require_state("get_base_pos")
+        return self._qpos_cache[:, :3]
+
+    def get_base_quat(self) -> np.ndarray:
+        self._require_state("get_base_quat")
+        return self._qpos_cache[:, 3:7]
+
+    def get_base_lin_vel(self) -> np.ndarray:
+        self._require_state("get_base_lin_vel")
+        return self._qvel_cache[:, :3]
+
+    def get_base_ang_vel(self) -> np.ndarray:
+        self._require_state("get_base_ang_vel")
+        quat = self._qpos_cache[:, 3:7]
+        return np_quat_apply_batched(quat, self._qvel_cache[:, 3:6])
+
+    def get_dof_pos(self) -> np.ndarray:
+        self._require_state("get_dof_pos")
+        return self._qpos_cache[:, self._metadata.root_qpos_dim :]
+
+    def get_dof_vel(self) -> np.ndarray:
+        self._require_state("get_dof_vel")
+        return self._qvel_cache[:, self._metadata.root_qvel_dim :]
+
+    def _ids(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = np.asarray(body_ids, dtype=np.intp)
+        if ids.ndim != 1 or np.any(ids < 0) or np.any(ids >= len(self._body_names)):
+            raise ValueError("body_ids must be one-dimensional and in range")
+        return ids
+
+    def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_pos_w")
+        return self._body_pos_cache[:, self._ids(body_ids)]
+
+    def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_quat_w")
+        return self._body_quat_cache[:, self._ids(body_ids)]
+
+    def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_lin_vel_w")
+        return self._body_lin_vel_cache[:, self._ids(body_ids)]
+
+    def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        self._require_state("get_body_ang_vel_w")
+        return self._body_ang_vel_cache[:, self._ids(body_ids)]
+
+    def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = self._ids(body_ids)
+        delta = self.get_body_pos_w(ids) - self._body_pos_cache[:, self._base_body_id, None]
+        root = self._body_quat_cache[:, self._base_body_id, None]
+        return np_quat_apply_inverse_batched(root, delta)
+
+    def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
+        ids = self._ids(body_ids)
+        root = self._body_quat_cache[:, self._base_body_id, None]
+        return np_quat_mul_batched(np_quat_conjugate_batched(root), self.get_body_quat_w(ids))
+
+    def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        quat = self.get_body_quat_w(body_ids)
+        return np_quat_apply_inverse_batched(quat, self.get_body_lin_vel_w(body_ids))
+
+    def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        quat = self.get_body_quat_w(body_ids)
+        return np_quat_apply_inverse_batched(quat, self.get_body_ang_vel_w(body_ids))
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        self._require_state("get_sensor_data")
+        try:
+            address, dim = self._sensor_slots[name]
+        except KeyError as exc:
+            raise KeyError(f"Sensor {name!r} not found in newton model") from exc
+        return self._sensor_cache[:, address : address + dim]
+
+    def _bind_sensor_data_reader(self, names: tuple[str, ...]):
+        slices = [self._sensor_slots[name] for name in names]
+        contiguous = all(
+            slices[index][0] + slices[index][1] == slices[index + 1][0]
+            for index in range(len(slices) - 1)
+        )
+        if contiguous:
+            start = slices[0][0]
+            width = sum(dim for _, dim in slices)
+            return lambda: self._sensor_cache[:, start : start + width]
+        return lambda: np.concatenate(
+            [self._sensor_cache[:, address : address + dim] for address, dim in slices], axis=1
+        )
+
+    def close(self) -> None:
+        self._closed = True
+        self.cleanup_scene_assets()
+
+
+__all__ = ["NewtonBackend"]

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -10,11 +10,22 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from os import PathLike
 from typing import Any
 
 import numpy as np
 
-from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.backend.base import (
+    BackendPlayCapabilities,
+    BackendPlayRenderPlan,
+    BackendRootStateLayout,
+    SimBackend,
+    normalize_play_render_mode,
+)
+from unisim.backend.playback_common import (
+    run_offline_snapshot_playback,
+    validate_offline_visual_model,
+)
 from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
 from unisim.scene import SceneCfg
 from unisim.utils.rotation import (
@@ -28,7 +39,9 @@ from .capacity import NewtonCapacityReport, calibrate_capacity, validate_capacit
 from .dependencies import load_newton_dependencies
 from .materialization import (
     NewtonModelAudit,
+    NewtonSensorPlan,
     audit_newton_model,
+    compute_contact_found_flags,
     scan_newton_model_metadata,
 )
 from .runtime import get_bound_newton_process_device
@@ -118,8 +131,11 @@ class NewtonBackend(SimBackend):
         self._control: Any | None = None
         self._contacts: Any | None = None
         self._view: Any | None = None
+        self._shape_world: np.ndarray | None = None
+        self._contact_sensor_pairs: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         self._audit: NewtonModelAudit | None = None
         self._capacity_report: NewtonCapacityReport | None = None
+        self._playback_model_validated = False
         self._closed = False
 
         nbody = len(self._body_names)
@@ -200,6 +216,8 @@ class NewtonBackend(SimBackend):
         self._contacts = newton.Contacts(
             self._solver.get_max_contact_count(), 0, device=self._device
         )
+        self._shape_world = np.asarray(self._model.shape_world.numpy(), dtype=np.int64)
+        self._contact_sensor_pairs = self._resolve_contact_sensor_pairs()
         newton.eval_fk(
             self._model, self._state.joint_q, self._state.joint_qd, self._state
         )
@@ -305,8 +323,61 @@ class NewtonBackend(SimBackend):
             self._qvel_cache[:, 3:6] = np_quat_apply_inverse_batched(root_quat, root_omega)
         self._refresh_sensor_cache(sensor_dt=sensor_dt)
 
+    def _resolve_contact_sensor_pairs(self) -> dict[str, tuple[np.ndarray, np.ndarray]]:
+        plans = [plan for plan in self._metadata.sensor_plans if plan.kind == "contact"]
+        if not plans:
+            return {}
+        mapping = getattr(self._solver, "mjc_geom_to_newton_shape", None)
+        if mapping is None:
+            raise RuntimeError(
+                "newton SolverMuJoCo did not publish mjc_geom_to_newton_shape; "
+                "contact sensors cannot be resolved against the compiled model"
+            )
+        mapping_np = np.asarray(mapping.numpy(), dtype=np.int64)
+        if mapping_np.ndim != 2 or mapping_np.shape[0] != self._num_envs:
+            raise RuntimeError(
+                "newton compiled geom mapping does not match the requested worlds: "
+                f"shape {mapping_np.shape}, num_envs {self._num_envs}"
+            )
+        pairs: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        for plan in plans:
+            shape_a = mapping_np[:, plan.geom1_id].copy()
+            shape_b = mapping_np[:, plan.geom2_id].copy()
+            if np.any(shape_a < 0) or np.any(shape_b < 0):
+                raise RuntimeError(
+                    f"newton compiled model dropped geoms {plan.geom1_name!r}/"
+                    f"{plan.geom2_name!r} required by contact sensor {plan.name!r}"
+                )
+            pairs[plan.name] = (shape_a, shape_b)
+        return pairs
+
+    def _refresh_contact_sensors(self, plans: list[NewtonSensorPlan]) -> None:
+        self._solver.update_contacts(self._contacts)
+        self._deps.warp.synchronize_device(self._device)
+        count = int(np.asarray(self._contacts.rigid_contact_count.numpy())[0])
+        shape0 = np.asarray(
+            self._contacts.rigid_contact_shape0.numpy()[:count], dtype=np.int64
+        )
+        shape1 = np.asarray(
+            self._contacts.rigid_contact_shape1.numpy()[:count], dtype=np.int64
+        )
+        for plan in plans:
+            shape_a, shape_b = self._contact_sensor_pairs[plan.name]
+            found = compute_contact_found_flags(
+                self._shape_world, shape0, shape1, shape_a, shape_b
+            )
+            address, dim = self._sensor_slots[plan.name]
+            self._sensor_cache[:, address : address + dim] = found[:, None]
+
     def _refresh_sensor_cache(self, *, sensor_dt: float | None) -> None:
+        contact_plans = [
+            plan for plan in self._metadata.sensor_plans if plan.kind == "contact"
+        ]
+        if contact_plans:
+            self._refresh_contact_sensors(contact_plans)
         for plan in self._metadata.sensor_plans:
+            if plan.kind == "contact":
+                continue
             body_id = plan.body_id - 1
             if body_id < 0:
                 raise RuntimeError(f"sensor {plan.name!r} is attached to the world body")
@@ -535,7 +606,15 @@ class NewtonBackend(SimBackend):
         self._deps.newton.eval_fk(
             self._model, self._state.joint_q, self._state.joint_qd, self._state
         )
-        self._solver.reset(self._state, warp_mask)
+        # flags=0: clear MuJoCo's persistent solver buffers (warmstart, act,
+        # ctrl) without reverting state.joint_q/joint_qd to the model defaults
+        # that a default reset would restore. update_data_interval=0 disables
+        # the per-step state->mjw sync, so push the uploaded joint coordinates
+        # into MuJoCo Warp explicitly on this cold path.
+        self._solver.reset(self._state, warp_mask, flags=0)
+        self._solver._update_mjc_data(
+            self._solver.mjw_data, self._model, self._state, world_mask=warp_mask
+        )
         upload_ms = (time.perf_counter() - t0) * 1000.0
         t0 = time.perf_counter()
         self._refresh_host_cache()
@@ -547,6 +626,132 @@ class NewtonBackend(SimBackend):
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         return DomainRandomizationCapabilities()
+
+    def get_play_capabilities(self) -> BackendPlayCapabilities:
+        return BackendPlayCapabilities(supports_physics_state_playback=True)
+
+    @staticmethod
+    def resolve_play_render_plan(
+        *,
+        play_render_mode: str | None,
+        play_steps: int | None,
+        output_video: str | PathLike[str] | None,
+    ) -> BackendPlayRenderPlan:
+        """Resolve playback modes: ``record`` and ``none`` only, fail closed.
+
+        A staticmethod so the semantics stay testable without a CUDA runtime.
+        """
+        mode = normalize_play_render_mode(play_render_mode)
+        if mode == "none":
+            return BackendPlayRenderPlan(
+                mode="none",
+                headless=True,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        if mode == "auto":
+            raise NotImplementedError(
+                "newton playback does not support auto mode; select record or none explicitly."
+            )
+        if mode == "interactive":
+            raise NotImplementedError(
+                "newton playback does not support interactive or native rendering; "
+                "select record or none."
+            )
+        if isinstance(play_steps, bool) or play_steps is None or int(play_steps) <= 0:
+            raise ValueError(
+                "newton record playback requires a positive finite training.play_steps value."
+            )
+        if output_video is None:
+            raise ValueError("newton record playback requires an output video path.")
+        return BackendPlayRenderPlan(
+            mode="record",
+            headless=True,
+            record_video=True,
+            num_steps=int(play_steps),
+            output_video=output_video,
+        )
+
+    def run_playback(
+        self,
+        *,
+        env: Any,
+        initialize: Any,
+        step: Any,
+        num_steps: int | None,
+        output_video: str | PathLike[str] | None = None,
+        render_spacing: float | None = None,
+        render_offset_mode: str | None = None,
+        headless: bool | None = None,
+        record_video: bool | None = None,
+        frame_state_getter: Any = None,
+        camera_kwargs: dict[str, Any] | None = None,
+        extra_data_getter: Any = None,
+    ) -> str | None:
+        del render_offset_mode
+        should_record = bool(record_video) if record_video is not None else output_video is not None
+        should_run_headless = bool(headless) if headless is not None else should_record
+        return run_offline_snapshot_playback(
+            backend=self,
+            env=env,
+            initialize=initialize,
+            step=step,
+            num_steps=num_steps,
+            output_video=output_video,
+            render_spacing=render_spacing,
+            headless=should_run_headless,
+            record_video=should_record,
+            snapshot_shape=(self._num_envs, 1 + self._metadata.nq + self._metadata.nv),
+            frame_state_getter=frame_state_getter,
+            camera_kwargs=camera_kwargs,
+            backend_label="newton",
+            extra_data_getter=extra_data_getter,
+        )
+
+    def get_physics_state(self) -> np.ndarray:
+        self._require_state("get_physics_state")
+        nq = self._metadata.nq
+        nv = self._metadata.nv
+        state = np.empty((self._num_envs, 1 + nq + nv), dtype=np.float32)
+        state[:, 0] = self._time_cache
+        state[:, 1 : 1 + nq] = self._qpos_cache
+        state[:, 1 + nq :] = self._qvel_cache
+        return state
+
+    def set_physics_state(self, state: np.ndarray) -> None:
+        """Restore a ``get_physics_state`` snapshot through the set_state path."""
+        self._require_state("set_physics_state")
+        nq = self._metadata.nq
+        nv = self._metadata.nv
+        state_array = np.asarray(state, dtype=np.float32)
+        expected = (self._num_envs, 1 + nq + nv)
+        if state_array.shape != expected:
+            raise ValueError(
+                f"newton physics snapshot must use [time, qpos, qvel] layout with shape "
+                f"{expected}, got {state_array.shape}"
+            )
+        self.set_state(
+            np.arange(self._num_envs, dtype=np.intp),
+            state_array[:, 1 : 1 + nq],
+            state_array[:, 1 + nq :],
+        )
+        self._time_cache[...] = state_array[:, 0]
+
+    def get_playback_model(self, env_index: int | None = None) -> str:
+        if env_index is not None:
+            idx = int(env_index)
+            if idx < 0 or idx >= self._num_envs:
+                raise IndexError(f"env_index must be in [0, {self._num_envs - 1}], got {idx}")
+        if not self._playback_model_validated:
+            self._scene_visual_model_file = validate_offline_visual_model(
+                mujoco=self._deps.mujoco,
+                physics_model=self._metadata.playback_model,
+                model_file=self._scene_visual_model_file,
+                backend_label="newton",
+            )
+            self._playback_model_validated = True
+        return self._scene_visual_model_file
 
     def get_base_pos(self) -> np.ndarray:
         self._require_state("get_base_pos")

--- a/src/unisim/backend/newton/capacity.py
+++ b/src/unisim/backend/newton/capacity.py
@@ -25,14 +25,19 @@ class NewtonCapacitySample:
     """Peak solver counts observed during one cold-path calibration window."""
 
     samples: int
+    peak_ncon: int
     peak_nefc: int
-    peak_nj: int
 
     def __post_init__(self) -> None:
-        for name in ("samples", "peak_nefc", "peak_nj"):
+        for name in ("samples", "peak_ncon", "peak_nefc"):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                 raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+
+    @property
+    def peak_nj(self) -> int:
+        """Compatibility spelling for the MuJoCo ``nefc`` constraint count."""
+        return self.peak_nefc
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,25 +59,25 @@ def validate_capacity_limits(
     *,
     nconmax: int,
     njmax: int,
+    peak_ncon: int | None = None,
     peak_nefc: int | None = None,
-    peak_nj: int | None = None,
     context: str = "Newton materialization",
 ) -> None:
     """Validate configured capacities against optional observed solver counts."""
     nconmax = _positive_int("nconmax", nconmax)
     njmax = _positive_int("njmax", njmax)
-    if peak_nefc is not None:
-        peak_nefc = _non_negative_int("peak_nefc", peak_nefc)
-        if peak_nefc > nconmax:
+    if peak_ncon is not None:
+        peak_ncon = _non_negative_int("peak_ncon", peak_ncon)
+        if peak_ncon > nconmax:
             raise NewtonCapacityError(
-                f"{context}: nconmax={nconmax} is below observed nefc={peak_nefc}; "
+                f"{context}: nconmax={nconmax} is below observed ncon={peak_ncon}; "
                 "increase newton_nconmax instead of allowing silent constraint truncation"
             )
-    if peak_nj is not None:
-        peak_nj = _non_negative_int("peak_nj", peak_nj)
-        if peak_nj > njmax:
+    if peak_nefc is not None:
+        peak_nefc = _non_negative_int("peak_nefc", peak_nefc)
+        if peak_nefc > njmax:
             raise NewtonCapacityError(
-                f"{context}: njmax={njmax} is below observed nj={peak_nj}; "
+                f"{context}: njmax={njmax} is below observed nefc={peak_nefc}; "
                 "increase newton_njmax instead of allowing silent solver truncation"
             )
 
@@ -88,24 +93,24 @@ def sample_capacity(
     *,
     sample_steps: int,
 ) -> NewtonCapacitySample:
-    """Sample ``(nefc, nj)`` after each representative cold-path step.
+    """Sample ``(ncon, nefc)`` after each representative cold-path step.
 
     The callback owns engine-specific state access and must return host integer
     counts.  It is deliberately invoked only on the materialization/calibration
     path; hot getters never call it.
     """
     sample_steps = _positive_int("sample_steps", sample_steps)
+    peak_ncon = 0
     peak_nefc = 0
-    peak_nj = 0
     for _ in range(sample_steps):
         counts = advance_and_read_counts()
         if not isinstance(counts, tuple) or len(counts) != 2:
-            raise TypeError("capacity reader must return a (nefc, nj) tuple")
-        nefc = _non_negative_int("nefc", counts[0])
-        nj = _non_negative_int("nj", counts[1])
+            raise TypeError("capacity reader must return a (ncon, nefc) tuple")
+        ncon = _non_negative_int("ncon", counts[0])
+        nefc = _non_negative_int("nefc", counts[1])
+        peak_ncon = max(peak_ncon, ncon)
         peak_nefc = max(peak_nefc, nefc)
-        peak_nj = max(peak_nj, nj)
-    return NewtonCapacitySample(sample_steps, peak_nefc, peak_nj)
+    return NewtonCapacitySample(sample_steps, peak_ncon, peak_nefc)
 
 
 def calibrate_capacity(
@@ -121,8 +126,8 @@ def calibrate_capacity(
     validate_capacity_limits(
         nconmax=nconmax,
         njmax=njmax,
+        peak_ncon=sample.peak_ncon,
         peak_nefc=sample.peak_nefc,
-        peak_nj=sample.peak_nj,
         context=context,
     )
     return NewtonCapacityReport(nconmax=int(nconmax), njmax=int(njmax), sample=sample)

--- a/src/unisim/backend/newton/capacity.py
+++ b/src/unisim/backend/newton/capacity.py
@@ -1,0 +1,138 @@
+"""Fail-closed capacity calibration helpers for the Newton adapter.
+
+Newton delegates its rigid solver to MuJoCo-Warp.  That solver can silently
+truncate contact constraints when ``nconmax`` or ``njmax`` is too small, so
+the adapter must validate the explicit capacities on the cold path and check
+the observed counts at every sampled step.  This module contains only the
+backend-neutral bookkeeping; all Newton/Warp object access stays in the
+adapter-owned reader callback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from unisim.errors import BackendError
+
+
+class NewtonCapacityError(BackendError):
+    """Raised when configured Newton solver capacity is insufficient."""
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonCapacitySample:
+    """Peak solver counts observed during one cold-path calibration window."""
+
+    samples: int
+    peak_nefc: int
+    peak_nj: int
+
+    def __post_init__(self) -> None:
+        for name in ("samples", "peak_nefc", "peak_nj"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonCapacityReport:
+    """Configured limits and the largest counts observed against them."""
+
+    nconmax: int
+    njmax: int
+    sample: NewtonCapacitySample
+
+
+def _positive_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return int(value)
+
+
+def validate_capacity_limits(
+    *,
+    nconmax: int,
+    njmax: int,
+    peak_nefc: int | None = None,
+    peak_nj: int | None = None,
+    context: str = "Newton materialization",
+) -> None:
+    """Validate configured capacities against optional observed solver counts."""
+    nconmax = _positive_int("nconmax", nconmax)
+    njmax = _positive_int("njmax", njmax)
+    if peak_nefc is not None:
+        peak_nefc = _non_negative_int("peak_nefc", peak_nefc)
+        if peak_nefc > nconmax:
+            raise NewtonCapacityError(
+                f"{context}: nconmax={nconmax} is below observed nefc={peak_nefc}; "
+                "increase newton_nconmax instead of allowing silent constraint truncation"
+            )
+    if peak_nj is not None:
+        peak_nj = _non_negative_int("peak_nj", peak_nj)
+        if peak_nj > njmax:
+            raise NewtonCapacityError(
+                f"{context}: njmax={njmax} is below observed nj={peak_nj}; "
+                "increase newton_njmax instead of allowing silent solver truncation"
+            )
+
+
+def _non_negative_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+    return int(value)
+
+
+def sample_capacity(
+    advance_and_read_counts: Callable[[], tuple[int, int]],
+    *,
+    sample_steps: int,
+) -> NewtonCapacitySample:
+    """Sample ``(nefc, nj)`` after each representative cold-path step.
+
+    The callback owns engine-specific state access and must return host integer
+    counts.  It is deliberately invoked only on the materialization/calibration
+    path; hot getters never call it.
+    """
+    sample_steps = _positive_int("sample_steps", sample_steps)
+    peak_nefc = 0
+    peak_nj = 0
+    for _ in range(sample_steps):
+        counts = advance_and_read_counts()
+        if not isinstance(counts, tuple) or len(counts) != 2:
+            raise TypeError("capacity reader must return a (nefc, nj) tuple")
+        nefc = _non_negative_int("nefc", counts[0])
+        nj = _non_negative_int("nj", counts[1])
+        peak_nefc = max(peak_nefc, nefc)
+        peak_nj = max(peak_nj, nj)
+    return NewtonCapacitySample(sample_steps, peak_nefc, peak_nj)
+
+
+def calibrate_capacity(
+    advance_and_read_counts: Callable[[], tuple[int, int]],
+    *,
+    nconmax: int,
+    njmax: int,
+    sample_steps: int,
+    context: str = "Newton materialization",
+) -> NewtonCapacityReport:
+    """Sample and validate one explicit Newton solver capacity configuration."""
+    sample = sample_capacity(advance_and_read_counts, sample_steps=sample_steps)
+    validate_capacity_limits(
+        nconmax=nconmax,
+        njmax=njmax,
+        peak_nefc=sample.peak_nefc,
+        peak_nj=sample.peak_nj,
+        context=context,
+    )
+    return NewtonCapacityReport(nconmax=int(nconmax), njmax=int(njmax), sample=sample)
+
+
+__all__ = [
+    "NewtonCapacityError",
+    "NewtonCapacityReport",
+    "NewtonCapacitySample",
+    "calibrate_capacity",
+    "sample_capacity",
+    "validate_capacity_limits",
+]

--- a/src/unisim/backend/newton/dependencies.py
+++ b/src/unisim/backend/newton/dependencies.py
@@ -1,0 +1,84 @@
+"""Lazy optional-runtime boundary for the Newton backend."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib import metadata
+from importlib.util import find_spec
+from typing import Any
+
+from unisim.optional import OptionalDependencyError
+
+
+class NewtonDependencyError(OptionalDependencyError):
+    """Raised when the pinned Newton runtime cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class NewtonDependencies:
+    """Public modules used by the Newton adapter."""
+
+    newton: Any
+    warp: Any
+    mujoco: Any
+    mujoco_warp: Any
+
+
+PINNED_DISTRIBUTIONS: dict[str, str] = {
+    "newton": "1.5.1",
+    "mujoco-warp": "3.11.0",
+    "mujoco": "3.11.0",
+    "warp-lang": "1.16.0",
+}
+_MODULES = {
+    "newton": "newton",
+    "mujoco-warp": "mujoco_warp",
+    "mujoco": "mujoco",
+    "warp-lang": "warp",
+}
+_INSTALL_HINT = "Install the isolated runtime with `uv sync --extra newton`."
+
+
+def newton_dependencies_available() -> bool:
+    """Probe the Newton stack without importing any engine module."""
+    return all(find_spec(module_name) is not None for module_name in _MODULES.values())
+
+
+def load_newton_dependencies() -> NewtonDependencies:
+    """Validate exact versions, then import the public Newton runtime modules."""
+    for distribution, expected in PINNED_DISTRIBUTIONS.items():
+        try:
+            installed = metadata.version(distribution)
+        except metadata.PackageNotFoundError as exc:
+            raise NewtonDependencyError(
+                f"newton backend requires {distribution}=={expected}. {_INSTALL_HINT}"
+            ) from exc
+        if installed != expected:
+            raise NewtonDependencyError(
+                f"newton backend requires {distribution}=={expected}, found {installed}. "
+                f"{_INSTALL_HINT} Do not combine the newton extra with mujoco or mjwarp."
+            )
+    modules: dict[str, Any] = {}
+    try:
+        for distribution, module_name in _MODULES.items():
+            modules[distribution] = importlib.import_module(module_name)
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise NewtonDependencyError(
+            f"newton backend could not import its optional runtime: {exc}. {_INSTALL_HINT}"
+        ) from exc
+    return NewtonDependencies(
+        newton=modules["newton"],
+        warp=modules["warp-lang"],
+        mujoco=modules["mujoco"],
+        mujoco_warp=modules["mujoco-warp"],
+    )
+
+
+__all__ = [
+    "NewtonDependencies",
+    "NewtonDependencyError",
+    "PINNED_DISTRIBUTIONS",
+    "load_newton_dependencies",
+    "newton_dependencies_available",
+]

--- a/src/unisim/backend/newton/materialization.py
+++ b/src/unisim/backend/newton/materialization.py
@@ -29,7 +29,13 @@ class _TemporarySceneCleanup:
 
 @dataclass(frozen=True, slots=True)
 class NewtonSensorPlan:
-    """One MJCF sensor reconstructed from public Newton state arrays."""
+    """One MJCF sensor reconstructed from public Newton state arrays.
+
+    Site-attached plans populate ``body_id``/``site_pos``/``site_quat``.
+    Contact plans (``kind == "contact"``) instead carry the authored geom
+    pair; their per-world compiled shape indices are resolved once at
+    materialization against ``SolverMuJoCo.mjc_geom_to_newton_shape``.
+    """
 
     name: str
     kind: str
@@ -37,6 +43,10 @@ class NewtonSensorPlan:
     body_id: int
     site_pos: np.ndarray
     site_quat: np.ndarray
+    geom1_name: str = ""
+    geom2_name: str = ""
+    geom1_id: int = -1
+    geom2_id: int = -1
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +56,7 @@ class NewtonModelMetadata:
     source_model_file: str
     diagnostic_model_file: str
     cleanup_handle: Any | None
+    playback_model: Any
     model_name: str
     nq: int
     nv: int
@@ -85,6 +96,114 @@ class NewtonModelAudit:
     qvel_per_world: int
 
 
+# MuJoCo compiles the MJCF contact-sensor ``data`` attribute into a bitmask in
+# ``sensor_intprm[:, 0]``; bit 0 is ``found``.  ``sensor_intprm[:, 1]`` is the
+# ``reduce`` mode and ``sensor_intprm[:, 2]`` is ``num``.
+_CONTACT_DATASPEC_FOUND = 1
+
+
+def compute_contact_found_flags(
+    shape_world: np.ndarray,
+    contact_shape0: np.ndarray,
+    contact_shape1: np.ndarray,
+    shape_a: np.ndarray,
+    shape_b: np.ndarray,
+) -> np.ndarray:
+    """Return 1.0 per env whose world produced a contact between the pair.
+
+    ``shape_a``/``shape_b`` hold the compiled Newton shape indices of the
+    authored geom pair for each env world, and ``shape_world`` maps every
+    Newton shape to its world index (shared/static shapes carry a negative
+    index).  Contact shape pairs are unordered.  A contact is attributed to
+    the world of its non-static shape; contacts without a consistent env world
+    (two shared shapes, or two shapes from different worlds) match nothing.
+    """
+    shape_a = np.asarray(shape_a, dtype=np.int64).reshape(-1)
+    shape_b = np.asarray(shape_b, dtype=np.int64).reshape(-1)
+    found = np.zeros((shape_a.shape[0],), dtype=np.float32)
+    shape0 = np.asarray(contact_shape0, dtype=np.int64).reshape(-1)
+    shape1 = np.asarray(contact_shape1, dtype=np.int64).reshape(-1)
+    if not shape0.size:
+        return found
+    shape_world = np.asarray(shape_world, dtype=np.int64)
+    world0 = shape_world[shape0]
+    world1 = shape_world[shape1]
+    world = np.maximum(world0, world1)
+    same_world = (world0 == world1) | (world0 < 0) | (world1 < 0)
+    valid = same_world & (world >= 0) & (world < found.shape[0])
+    if not np.any(valid):
+        return found
+    world = world[valid]
+    shape0 = shape0[valid]
+    shape1 = shape1[valid]
+    pair_a = shape_a[world]
+    pair_b = shape_b[world]
+    matched = ((shape0 == pair_a) & (shape1 == pair_b)) | (
+        (shape0 == pair_b) & (shape1 == pair_a)
+    )
+    found[world[matched]] = 1.0
+    return found
+
+
+def _scan_contact_sensor(mujoco: Any, model: Any, sensor_id: int, name: str) -> NewtonSensorPlan:
+    """Scan one ``mjSENS_CONTACT`` sensor restricted to ``found`` geom pairs.
+
+    Only the exact authored shape ``data="found" num=1 geom1=... geom2=...``
+    is supported.  Every ``reduce`` mode (none/mindist/netforce) is
+    accepted because it only selects which contact fills the single reported
+    slot; the binary ``found`` flag is identical for all of them.  Any other
+    configuration (other data channels, ``num > 1``, body/subtree/site
+    contacts, unnamed geoms) fails closed.
+    """
+    intprm = np.asarray(model.sensor_intprm[sensor_id], dtype=np.int64)
+    dataspec = int(intprm[0])
+    num = int(intprm[2])
+    if dataspec != _CONTACT_DATASPEC_FOUND:
+        raise NotImplementedError(
+            f"newton backend supports contact sensor {name!r} only with data=\"found\"; "
+            f"compiled dataspec bitmask is {dataspec}"
+        )
+    if num != 1:
+        raise NotImplementedError(
+            f"newton backend supports contact sensor {name!r} only with num=1; "
+            f"compiled num is {num}"
+        )
+    if int(model.sensor_dim[sensor_id]) != 1:
+        raise NotImplementedError(
+            f"newton backend expected contact sensor {name!r} dim 1, "
+            f"compiled dim is {int(model.sensor_dim[sensor_id])}"
+        )
+    geom_obj = int(mujoco.mjtObj.mjOBJ_GEOM)
+    if (
+        int(model.sensor_objtype[sensor_id]) != geom_obj
+        or int(model.sensor_reftype[sensor_id]) != geom_obj
+    ):
+        raise NotImplementedError(
+            f"newton backend supports contact sensor {name!r} only for named geom1/geom2 "
+            "pairs; body, subtree, and site contacts are unsupported"
+        )
+    geom1_id = int(model.sensor_objid[sensor_id])
+    geom2_id = int(model.sensor_refid[sensor_id])
+    geom1_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, geom1_id)
+    geom2_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, geom2_id)
+    if not geom1_name or not geom2_name:
+        raise NotImplementedError(
+            f"newton backend requires named geoms on contact sensor {name!r}"
+        )
+    return NewtonSensorPlan(
+        name=str(name),
+        kind="contact",
+        dim=1,
+        body_id=-1,
+        site_pos=np.zeros(3, dtype=np.float32),
+        site_quat=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        geom1_name=str(geom1_name),
+        geom2_name=str(geom2_name),
+        geom1_id=geom1_id,
+        geom2_id=geom2_id,
+    )
+
+
 def _scan_sensors(mujoco: Any, model: Any) -> tuple[NewtonSensorPlan, ...]:
     supported = {
         mujoco.mjtSensor.mjSENS_GYRO: "gyro",
@@ -102,6 +221,9 @@ def _scan_sensors(mujoco: Any, model: Any) -> tuple[NewtonSensorPlan, ...]:
             raise NotImplementedError(
                 f"newton backend requires named MJCF sensors; sensor id {sensor_id} is unnamed"
             )
+        if sensor_type == mujoco.mjtSensor.mjSENS_CONTACT:
+            plans.append(_scan_contact_sensor(mujoco, model, sensor_id, str(name)))
+            continue
         kind = supported.get(sensor_type)
         if kind is None:
             raise NotImplementedError(
@@ -259,6 +381,7 @@ def scan_newton_model_metadata(mujoco: Any, scene: SceneCfg) -> NewtonModelMetad
         source_model_file=source_model_file,
         diagnostic_model_file=str(scene.model_file),
         cleanup_handle=_TemporarySceneCleanup(*temp_paths) if temp_paths else None,
+        playback_model=model,
         model_name=model_name,
         nq=int(model.nq),
         nv=int(model.nv),
@@ -305,7 +428,12 @@ def audit_newton_model(
     if int(model.body_count) != expected_bodies * num_envs:
         raise RuntimeError("newton compiled body layout differs from the authored MJCF")
 
-    gravity = np.asarray(model.gravity.numpy(), dtype=np.float32).reshape(num_envs, 3)
+    gravity_np = np.asarray(model.gravity.numpy(), dtype=np.float32)
+    if gravity_np.shape[0] == num_envs + 1:
+        # Newton 1.5.1 appends one gravity entry for the global world -1;
+        # only the per-world rows participate in the audit.
+        gravity_np = gravity_np[:num_envs]
+    gravity = gravity_np.reshape(num_envs, 3)
     if not np.allclose(gravity, metadata.gravity, rtol=1e-6, atol=1e-6):
         raise RuntimeError("newton compiled gravity differs from the authored MJCF")
     mass = np.asarray(model.body_mass.numpy(), dtype=np.float32).reshape(num_envs, expected_bodies)
@@ -319,5 +447,6 @@ __all__ = [
     "NewtonModelMetadata",
     "NewtonSensorPlan",
     "audit_newton_model",
+    "compute_contact_found_flags",
     "scan_newton_model_metadata",
 ]

--- a/src/unisim/backend/newton/materialization.py
+++ b/src/unisim/backend/newton/materialization.py
@@ -1,0 +1,323 @@
+"""Cold-path MJCF scan and model audit for the Newton adapter."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from unisim.scene import SceneCfg
+
+
+class _TemporarySceneCleanup:
+    def __init__(self, *paths: str) -> None:
+        self._paths = paths
+        self._cleaned = False
+
+    def cleanup(self) -> None:
+        if self._cleaned:
+            return
+        self._cleaned = True
+        for path in self._paths:
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonSensorPlan:
+    """One MJCF sensor reconstructed from public Newton state arrays."""
+
+    name: str
+    kind: str
+    dim: int
+    body_id: int
+    site_pos: np.ndarray
+    site_quat: np.ndarray
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonModelMetadata:
+    """Immutable authoring metadata scanned once with MuJoCo."""
+
+    source_model_file: str
+    diagnostic_model_file: str
+    cleanup_handle: Any | None
+    model_name: str
+    nq: int
+    nv: int
+    nbody: int
+    root_qpos_dim: int
+    root_qvel_dim: int
+    body_names: tuple[str, ...]
+    body_parent_ids: np.ndarray
+    body_mass: np.ndarray
+    body_ipos: np.ndarray
+    joint_names: tuple[str, ...]
+    joint_qpos_adrs: tuple[int, ...]
+    joint_dof_adrs: tuple[int, ...]
+    actuator_names: tuple[str, ...]
+    actuator_joint_names: tuple[str, ...]
+    actuator_target_kinds: tuple[str, ...]
+    actuator_target_qpos_adrs: tuple[int, ...]
+    actuator_target_qvel_adrs: tuple[int, ...]
+    actuator_ctrl_range: np.ndarray
+    actuator_kp: np.ndarray
+    actuator_kd: np.ndarray
+    keyframes: tuple[tuple[str, np.ndarray], ...]
+    default_qpos: np.ndarray
+    joint_range: np.ndarray | None
+    dof_armature: np.ndarray
+    gravity: np.ndarray
+    sensor_plans: tuple[NewtonSensorPlan, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NewtonModelAudit:
+    """Successful authored-vs-compiled audit summary."""
+
+    worlds: int
+    bodies_per_world: int
+    qpos_per_world: int
+    qvel_per_world: int
+
+
+def _scan_sensors(mujoco: Any, model: Any) -> tuple[NewtonSensorPlan, ...]:
+    supported = {
+        mujoco.mjtSensor.mjSENS_GYRO: "gyro",
+        mujoco.mjtSensor.mjSENS_ACCELEROMETER: "accelerometer",
+        mujoco.mjtSensor.mjSENS_VELOCIMETER: "velocimeter",
+        mujoco.mjtSensor.mjSENS_FRAMEPOS: "framepos",
+        mujoco.mjtSensor.mjSENS_FRAMEQUAT: "framequat",
+        mujoco.mjtSensor.mjSENS_FRAMEZAXIS: "framezaxis",
+    }
+    plans: list[NewtonSensorPlan] = []
+    for sensor_id in range(int(model.nsensor)):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_SENSOR, sensor_id)
+        sensor_type = mujoco.mjtSensor(int(model.sensor_type[sensor_id]))
+        if not name:
+            raise NotImplementedError(
+                f"newton backend requires named MJCF sensors; sensor id {sensor_id} is unnamed"
+            )
+        kind = supported.get(sensor_type)
+        if kind is None:
+            raise NotImplementedError(
+                f"newton backend cannot reconstruct MJCF sensor {name!r} of type "
+                f"{sensor_type.name} from public Newton State arrays"
+            )
+        if int(model.sensor_objtype[sensor_id]) != int(mujoco.mjtObj.mjOBJ_SITE):
+            raise NotImplementedError(
+                f"newton backend reconstructs {kind} sensor {name!r} from sites only"
+            )
+        site_id = int(model.sensor_objid[sensor_id])
+        body_id = int(model.site_bodyid[site_id])
+        plans.append(
+            NewtonSensorPlan(
+                name=str(name),
+                kind=kind,
+                dim=int(model.sensor_dim[sensor_id]),
+                body_id=body_id,
+                site_pos=np.asarray(model.site_pos[site_id], dtype=np.float32).copy(),
+                site_quat=np.asarray(model.site_quat[site_id], dtype=np.float32).copy(),
+            )
+        )
+    return tuple(plans)
+
+
+def _reject_silent_geometry_gaps(mujoco: Any, model: Any) -> None:
+    geom_types = np.asarray(model.geom_type, dtype=np.int32)
+    cone_value = getattr(mujoco.mjtGeom, "mjGEOM_CONE", None)
+    if cone_value is not None and np.any(geom_types == int(cone_value)):
+        raise NotImplementedError(
+            "newton SolverMuJoCo does not map GeoType.CONE; replace cone geometry "
+            "before selecting the newton backend"
+        )
+    mesh = int(mujoco.mjtGeom.mjGEOM_MESH)
+    masks = np.asarray(model.geom_contype, dtype=np.int64) | np.asarray(
+        model.geom_conaffinity, dtype=np.int64
+    )
+    colliding_mesh_ids = np.flatnonzero((geom_types == mesh) & (masks != 0))
+    if colliding_mesh_ids.size:
+        names = [
+            str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, int(geom_id)) or geom_id)
+            for geom_id in colliding_mesh_ids
+        ]
+        raise NotImplementedError(
+            "newton SolverMuJoCo convexifies triangle-mesh collision geometry; "
+            f"colliding mesh geoms are rejected: {', '.join(names)}"
+        )
+
+
+def scan_newton_model_metadata(mujoco: Any, scene: SceneCfg) -> NewtonModelMetadata:
+    """Compose fragments, reject known silent gaps, and cache MJCF metadata."""
+    if scene is None or not scene.model_file:
+        raise ValueError("NewtonBackend requires SceneCfg.model_file")
+    if scene.terrain is not None:
+        raise NotImplementedError(
+            "newton backend does not yet support generated terrain or height-field scanners"
+        )
+    temp_paths: list[str] = []
+    source_model_file = str(scene.model_file)
+    if scene.fragment_files:
+        from unisim.backend.mujoco.xml import materialize_scene_fragments
+
+        source_model_file = materialize_scene_fragments(
+            source_model_file, fragment_files=scene.fragment_files
+        )
+        temp_paths.append(source_model_file)
+    model = mujoco.MjModel.from_xml_path(source_model_file)
+    _reject_silent_geometry_gaps(mujoco, model)
+
+    free = int(mujoco.mjtJoint.mjJNT_FREE)
+    single_dof = {int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE)}
+    supported_joints = single_dof | {free}
+    unsupported_joints = [
+        joint_id
+        for joint_id in range(int(model.njnt))
+        if int(model.jnt_type[joint_id]) not in supported_joints
+    ]
+    if unsupported_joints:
+        raise NotImplementedError(
+            "newton backend supports only free, hinge, and slide joints; unsupported "
+            f"MJCF joint ids: {unsupported_joints}"
+        )
+    root_qpos_dim, root_qvel_dim = (
+        (7, 6) if int(model.njnt) and int(model.jnt_type[0]) == free else (0, 0)
+    )
+    joint_names: list[str] = []
+    joint_qpos_adrs: list[int] = []
+    joint_dof_adrs: list[int] = []
+    for joint_id in range(int(model.njnt)):
+        if int(model.jnt_type[joint_id]) not in single_dof:
+            continue
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        if not name:
+            raise NotImplementedError(
+                f"newton backend requires named single-DoF joints; joint id {joint_id} is unnamed"
+            )
+        joint_names.append(str(name))
+        joint_qpos_adrs.append(int(model.jnt_qposadr[joint_id]))
+        joint_dof_adrs.append(int(model.jnt_dofadr[joint_id]))
+
+    actuator_names: list[str] = []
+    actuator_joint_names: list[str] = []
+    actuator_target_kinds: list[str] = []
+    actuator_target_qpos_adrs: list[int] = []
+    actuator_target_qvel_adrs: list[int] = []
+    for actuator_id in range(int(model.nu)):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, actuator_id)
+        joint_id = int(model.actuator_trnid[actuator_id, 0])
+        if (
+            not name
+            or int(model.actuator_trntype[actuator_id])
+            not in {int(mujoco.mjtTrn.mjTRN_JOINT), int(mujoco.mjtTrn.mjTRN_JOINTINPARENT)}
+            or joint_id < 0
+            or int(model.jnt_type[joint_id]) not in single_dof
+        ):
+            raise NotImplementedError(
+                "newton backend requires named actuators targeting single-DoF joints; "
+                f"actuator id {actuator_id} is unsupported"
+            )
+        joint_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, joint_id)
+        bias = np.asarray(model.actuator_biasprm[actuator_id], dtype=np.float32)
+        if abs(float(bias[1])) > 1e-8:
+            target_kind = "position"
+        elif abs(float(bias[2])) > 1e-8:
+            target_kind = "velocity"
+        else:
+            target_kind = "direct"
+        actuator_names.append(str(name))
+        actuator_joint_names.append(str(joint_name))
+        actuator_target_kinds.append(target_kind)
+        actuator_target_qpos_adrs.append(int(model.jnt_qposadr[joint_id]))
+        actuator_target_qvel_adrs.append(int(model.jnt_dofadr[joint_id]))
+
+    keyframes = tuple(
+        (
+            str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, key_id)),
+            np.asarray(model.key_qpos[key_id], dtype=np.float32).copy(),
+        )
+        for key_id in range(int(model.nkey))
+        if mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_KEY, key_id)
+    )
+    non_free = np.asarray(model.jnt_type, dtype=np.int32) != free
+    joint_range = np.asarray(model.jnt_range, dtype=np.float32)[non_free]
+    body_names = tuple(
+        str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_id) or "")
+        for body_id in range(int(model.nbody))
+    )
+    raw_model_names = getattr(model, "names", b"")
+    model_name = (
+        raw_model_names.split(b"\0", 1)[0].decode("utf-8", errors="replace")
+        if isinstance(raw_model_names, bytes)
+        else str(raw_model_names)
+    )
+    return NewtonModelMetadata(
+        source_model_file=source_model_file,
+        diagnostic_model_file=str(scene.model_file),
+        cleanup_handle=_TemporarySceneCleanup(*temp_paths) if temp_paths else None,
+        model_name=model_name,
+        nq=int(model.nq),
+        nv=int(model.nv),
+        nbody=int(model.nbody),
+        root_qpos_dim=root_qpos_dim,
+        root_qvel_dim=root_qvel_dim,
+        body_names=body_names,
+        body_parent_ids=np.asarray(model.body_parentid, dtype=np.int32).copy(),
+        body_mass=np.asarray(model.body_mass, dtype=np.float32).copy(),
+        body_ipos=np.asarray(model.body_ipos, dtype=np.float32).copy(),
+        joint_names=tuple(joint_names),
+        joint_qpos_adrs=tuple(joint_qpos_adrs),
+        joint_dof_adrs=tuple(joint_dof_adrs),
+        actuator_names=tuple(actuator_names),
+        actuator_joint_names=tuple(actuator_joint_names),
+        actuator_target_kinds=tuple(actuator_target_kinds),
+        actuator_target_qpos_adrs=tuple(actuator_target_qpos_adrs),
+        actuator_target_qvel_adrs=tuple(actuator_target_qvel_adrs),
+        actuator_ctrl_range=np.asarray(model.actuator_ctrlrange, dtype=np.float32).copy(),
+        actuator_kp=np.asarray(model.actuator_gainprm[:, 0], dtype=np.float32).copy(),
+        actuator_kd=np.asarray(-model.actuator_biasprm[:, 2], dtype=np.float32).copy(),
+        keyframes=keyframes,
+        default_qpos=np.asarray(model.qpos0, dtype=np.float32).copy(),
+        joint_range=None if not joint_range.size else joint_range.copy(),
+        dof_armature=np.asarray(model.dof_armature, dtype=np.float32).copy(),
+        gravity=np.asarray(model.opt.gravity, dtype=np.float32).copy(),
+        sensor_plans=_scan_sensors(mujoco, model),
+    )
+
+
+def audit_newton_model(
+    model: Any, metadata: NewtonModelMetadata, num_envs: int
+) -> NewtonModelAudit:
+    """Compare authored gravity/mass/layout against the finalized Newton model."""
+    expected_bodies = metadata.nbody - 1
+    if int(model.world_count) != num_envs:
+        raise RuntimeError(
+            f"newton compiled world count {model.world_count} != authored request {num_envs}"
+        )
+    if int(model.joint_coord_count) != metadata.nq * num_envs:
+        raise RuntimeError("newton compiled qpos layout differs from the authored MJCF")
+    if int(model.joint_dof_count) != metadata.nv * num_envs:
+        raise RuntimeError("newton compiled qvel layout differs from the authored MJCF")
+    if int(model.body_count) != expected_bodies * num_envs:
+        raise RuntimeError("newton compiled body layout differs from the authored MJCF")
+
+    gravity = np.asarray(model.gravity.numpy(), dtype=np.float32).reshape(num_envs, 3)
+    if not np.allclose(gravity, metadata.gravity, rtol=1e-6, atol=1e-6):
+        raise RuntimeError("newton compiled gravity differs from the authored MJCF")
+    mass = np.asarray(model.body_mass.numpy(), dtype=np.float32).reshape(num_envs, expected_bodies)
+    if not np.allclose(mass, metadata.body_mass[1:], rtol=1e-5, atol=1e-6):
+        raise RuntimeError("newton compiled body masses differ from the authored MJCF")
+    return NewtonModelAudit(num_envs, expected_bodies, metadata.nq, metadata.nv)
+
+
+__all__ = [
+    "NewtonModelAudit",
+    "NewtonModelMetadata",
+    "NewtonSensorPlan",
+    "audit_newton_model",
+    "scan_newton_model_metadata",
+]

--- a/src/unisim/backend/newton/runtime.py
+++ b/src/unisim/backend/newton/runtime.py
@@ -1,0 +1,30 @@
+"""Process-global device binding owned by the Newton adapter."""
+
+from __future__ import annotations
+
+from .dependencies import load_newton_dependencies
+
+_BOUND_DEVICE: str | None = None
+
+
+def bind_newton_process_device(device: str) -> str:
+    """Select Newton's Warp device explicitly for the current process."""
+    global _BOUND_DEVICE
+    dependencies = load_newton_dependencies()
+    dependencies.warp.set_device(device)
+    selected = dependencies.warp.get_device()
+    if not bool(selected.is_cuda):
+        raise RuntimeError(
+            "newton backend requires an active CUDA Warp device; "
+            f"resolved {selected!s} from {device!r}"
+        )
+    _BOUND_DEVICE = str(selected)
+    return _BOUND_DEVICE
+
+
+def get_bound_newton_process_device() -> str | None:
+    """Return the explicitly selected device without probing Warp defaults."""
+    return _BOUND_DEVICE
+
+
+__all__ = ["bind_newton_process_device", "get_bound_newton_process_device"]

--- a/src/unisim/backend/playback_common.py
+++ b/src/unisim/backend/playback_common.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
+from os import PathLike
+from pathlib import Path
+from typing import Any, TypeVar
 
 import numpy as np
+
+ObsT = TypeVar("ObsT")
 
 
 class _ImageIOProxy:
@@ -29,3 +34,141 @@ def env_cfg_value(env: Any, name: str, default: Any) -> Any:
 def write_playback_video(path: str, frames: list[np.ndarray], *, fps: int) -> None:
     """Write playback frames with the repository-managed imageio stack."""
     imageio.mimsave(path, frames, fps=fps)
+
+
+def validate_offline_visual_model(
+    *,
+    mujoco: Any,
+    physics_model: Any,
+    model_file: str | PathLike[str],
+    backend_label: str,
+) -> str:
+    """Validate the detached MuJoCo visual twin used for offline playback."""
+    path = Path(model_file)
+    if not path.is_file():
+        raise ValueError(
+            f"{backend_label} offline playback visual model does not exist or is not a file: "
+            f"{path}"
+        )
+    try:
+        visual_model = mujoco.MjModel.from_xml_path(str(path))
+    except Exception as exc:
+        raise ValueError(
+            f"{backend_label} offline playback could not load visual model {path}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    physics_dims = (int(physics_model.nq), int(physics_model.nv))
+    visual_dims = (int(visual_model.nq), int(visual_model.nv))
+    if visual_dims != physics_dims:
+        raise ValueError(
+            f"{backend_label} offline playback visual model state dimensions are incompatible: "
+            f"physics nq/nv={physics_dims}, visual nq/nv={visual_dims}."
+        )
+
+    joint_object = mujoco.mjtObj.mjOBJ_JOINT
+
+    def _joint_layout(model: Any) -> tuple[tuple[str | None, int, int, int], ...]:
+        return tuple(
+            (
+                mujoco.mj_id2name(model, joint_object, joint_id),
+                int(model.jnt_type[joint_id]),
+                int(model.jnt_qposadr[joint_id]),
+                int(model.jnt_dofadr[joint_id]),
+            )
+            for joint_id in range(int(model.njnt))
+        )
+
+    physics_layout = _joint_layout(physics_model)
+    visual_layout = _joint_layout(visual_model)
+    if visual_layout != physics_layout:
+        raise ValueError(
+            f"{backend_label} offline playback visual model joint layout is incompatible; "
+            "joint names, types, qpos addresses, and dof addresses must match physics."
+        )
+    return str(path)
+
+
+def run_offline_snapshot_playback(
+    *,
+    backend: Any,
+    env: Any,
+    initialize: Callable[[], ObsT],
+    step: Callable[[ObsT], ObsT],
+    num_steps: int | None,
+    output_video: str | PathLike[str] | None,
+    render_spacing: float | None,
+    headless: bool,
+    record_video: bool,
+    snapshot_shape: tuple[int, int],
+    frame_state_getter: Callable[[], np.ndarray] | None,
+    camera_kwargs: dict[str, Any] | None,
+    backend_label: str,
+    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+) -> str:
+    """Render detached host snapshots with the offline MuJoCo pipeline."""
+    if not headless:
+        raise NotImplementedError(
+            f"{backend_label} offline playback does not support interactive rendering; "
+            "use training.play_render_mode=record."
+        )
+    if not record_video:
+        raise ValueError(f"{backend_label} offline playback requires record_video=true.")
+    if isinstance(num_steps, bool) or num_steps is None or int(num_steps) <= 0:
+        raise ValueError(
+            f"{backend_label} record playback requires a positive finite num_steps value."
+        )
+    if output_video is None:
+        raise ValueError(f"{backend_label} record playback requires an output_video path.")
+
+    # Both checks are playback-only cold-path work. Physics construction and
+    # step/reset never import the renderer or parse the visual model.
+    backend.get_playback_model()
+    try:
+        from unisim.visualization import render_many
+
+        renderer_usable = bool(render_many.render_backend_usable())
+    except Exception as exc:
+        raise RuntimeError(
+            f"{backend_label} offline playback could not initialize the MuJoCo renderer: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    if not renderer_usable:
+        raise RuntimeError(
+            f"{backend_label} offline playback requires a usable MuJoCo off-screen renderer; "
+            "configure EGL, OSMesa, or GLFW before recording."
+        )
+
+    getter = frame_state_getter or env.get_physics_state_snapshot
+    expected_shape = snapshot_shape
+
+    def _validated_state_getter() -> np.ndarray:
+        state = np.asarray(getter(), dtype=np.float32)
+        if state.shape != expected_shape:
+            raise ValueError(
+                f"{backend_label} offline playback snapshot must use [time, qpos, qvel] layout "
+                f"with shape {expected_shape}, got {state.shape}."
+            )
+        return state
+
+    from unisim.backend.mujoco.playback import run_mujoco_playback
+
+    result = run_mujoco_playback(
+        env=env,
+        initialize=initialize,
+        step=step,
+        num_steps=int(num_steps),
+        output_video=output_video,
+        render_spacing=render_spacing,
+        headless=True,
+        record_video=True,
+        frame_state_getter=_validated_state_getter,
+        camera_kwargs=camera_kwargs,
+        extra_data_getter=extra_data_getter,
+    )
+    if result is None:
+        raise RuntimeError(
+            f"{backend_label} offline playback produced no frames; the MuJoCo renderer or worker "
+            "failed after preflight."
+        )
+    return result

--- a/src/unisim/backend/process_device.py
+++ b/src/unisim/backend/process_device.py
@@ -19,15 +19,16 @@ def resolve_backend_process_device(
     device, so its collector must receive the exact CUDA device already
     assigned to the rank's learner.
     """
-    if backend_type != "mjwarp":
+    if backend_type not in {"mjwarp", "newton"}:
         return None
     if learner_device is None:
-        raise ValueError("mjwarp requires an explicit CUDA process device")
+        raise ValueError(f"{backend_type} requires an explicit CUDA process device")
 
     resolved = str(learner_device).strip()
     if resolved.split(":", 1)[0].lower() != "cuda":
         raise ValueError(
-            f"mjwarp requires a CUDA process device shared with its learner; got {resolved!r}"
+            f"{backend_type} requires a CUDA process device shared with its learner; "
+            f"got {resolved!r}"
         )
     return resolved
 
@@ -41,6 +42,10 @@ def configure_backend_process_device(
     if resolved is None:
         return None
 
+    if backend_type == "newton":
+        from .newton.runtime import bind_newton_process_device
+
+        return bind_newton_process_device(resolved)
     from .mjwarp.runtime import bind_mjwarp_process_device
 
     return bind_mjwarp_process_device(resolved)

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -43,6 +43,10 @@ def create_backend(
     bench_nsteps = kwargs.pop("bench_nsteps", 1)
     mjwarp_nconmax = kwargs.pop("mjwarp_nconmax", None)
     mjwarp_njmax = kwargs.pop("mjwarp_njmax", None)
+    newton_device = kwargs.pop("newton_device", None)
+    newton_nconmax = kwargs.pop("newton_nconmax", None)
+    newton_njmax = kwargs.pop("newton_njmax", None)
+    newton_capacity_check_steps = kwargs.pop("newton_capacity_check_steps", 1)
     drake_backend_mode = kwargs.pop("drake_backend_mode", "batch")
     drake_nthread = kwargs.pop("drake_nthread", None)
     isaacgym_device_id = kwargs.pop("isaacgym_device_id", None)
@@ -114,6 +118,31 @@ def create_backend(
         kwargs["nconmax"] = mjwarp_nconmax
         kwargs["njmax"] = mjwarp_njmax
         return MjwarpBackend(scene, num_envs, sim_dt, **kwargs)
+    if backend_type == "newton":
+        from .backend.newton.backend import NewtonBackend
+
+        if body_state_required:
+            raise NotImplementedError(
+                "newton does not support body-state sensor injection; define MJCF sensors"
+            )
+        if position_actuator_gains is not None:
+            raise ValueError(
+                "newton uses direct MJCF actuators; position_actuator_gains has no equivalent"
+            )
+        _warn_ignored_mujoco_options(
+            "newton",
+            post_step_forward_sensor=post_step_forward_sensor,
+            iterations=iterations,
+            chunk_size=chunk_size,
+            adaptive_chunk_size=adaptive_chunk_size,
+            cpu_ids=cpu_ids,
+            bench_nsteps=bench_nsteps,
+        )
+        kwargs["device"] = newton_device
+        kwargs["nconmax"] = newton_nconmax
+        kwargs["njmax"] = newton_njmax
+        kwargs["capacity_check_steps"] = newton_capacity_check_steps
+        return NewtonBackend(scene, num_envs, sim_dt, **kwargs)
     if backend_type == "genesis":
         from .backend.genesis.backend import GenesisBackend
 

--- a/tests/test_all_adapters.py
+++ b/tests/test_all_adapters.py
@@ -6,7 +6,16 @@ from unisim.optional import OptionalDependencyError
 
 def test_manifest_covers_all_current_backends():
     names = {spec.name for spec in unisim.ADAPTER_SPECS}
-    assert names == {"mujoco", "motrix", "drake", "mjwarp", "genesis", "isaacgym", "isaacsim"}
+    assert names == {
+        "mujoco",
+        "motrix",
+        "drake",
+        "mjwarp",
+        "newton",
+        "genesis",
+        "isaacgym",
+        "isaacsim",
+    }
     assert all(spec.status == "available" for spec in unisim.ADAPTER_SPECS)
 
 
@@ -17,6 +26,7 @@ def test_manifest_covers_all_current_backends():
         ("motrix", "MotrixBackend"),
         ("drake", "DrakeBackend"),
         ("mjwarp", "MjwarpBackend"),
+        ("newton", "NewtonBackend"),
         ("genesis", "GenesisBackend"),
         ("isaacgym", "IsaacGymBackend"),
         ("isaacsim", "IsaacSimBackend"),
@@ -31,7 +41,9 @@ def test_every_manifest_adapter_has_a_lazy_public_class(backend_type: str, expor
     assert adapter.__module__.startswith("unisim.backend.")
 
 
-@pytest.mark.parametrize("backend_type", ["mujoco", "motrix", "drake", "mjwarp", "genesis"])
+@pytest.mark.parametrize(
+    "backend_type", ["mujoco", "motrix", "drake", "mjwarp", "newton", "genesis"]
+)
 def test_in_process_adapters_require_scene(backend_type):
     with pytest.raises(ValueError, match="requires a SceneCfg"):
         unisim.create_backend(backend_type)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -35,6 +35,7 @@ def test_adapter_manifest_covers_roadmap_backends() -> None:
         "motrix",
         "drake",
         "mjwarp",
+        "newton",
         "genesis",
         "isaacgym",
         "isaacsim",

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -8,7 +8,8 @@ def test_import_does_not_pull_unilab_or_engine_modules():
     code = (
         "import sys, unisim; "
         "blocked = [name for name in sys.modules if name == 'unilab' or "
-        "name.startswith(('hydra', 'torch', 'gymnasium', 'mujoco', 'motrixsim'))]; "
+        "name.startswith(('hydra', 'torch', 'gymnasium', 'mujoco', 'motrixsim', "
+        "'newton', 'warp'))]; "
         "assert not blocked, blocked"
     )
     result = subprocess.run(

--- a/tests/test_newton_capacity.py
+++ b/tests/test_newton_capacity.py
@@ -14,15 +14,15 @@ def test_capacity_sample_tracks_peak_counts() -> None:
     values = iter(((3, 7), (12, 9), (8, 11)))
     sample = sample_capacity(lambda: next(values), sample_steps=3)
     assert sample.samples == 3
-    assert sample.peak_nefc == 12
-    assert sample.peak_nj == 11
+    assert sample.peak_ncon == 12
+    assert sample.peak_nefc == 11
 
 
 def test_capacity_overflow_fails_closed() -> None:
-    with pytest.raises(NewtonCapacityError, match="nconmax=8.*nefc=9"):
+    with pytest.raises(NewtonCapacityError, match="nconmax=8.*ncon=9"):
         calibrate_capacity(lambda: (9, 2), nconmax=8, njmax=4, sample_steps=1)
 
-    with pytest.raises(NewtonCapacityError, match="njmax=4.*nj=5"):
+    with pytest.raises(NewtonCapacityError, match="njmax=4.*nefc=5"):
         calibrate_capacity(lambda: (2, 5), nconmax=8, njmax=4, sample_steps=1)
 
 
@@ -38,8 +38,8 @@ def test_capacity_limits_require_positive_integers(name: str, value: object) -> 
 
 
 def test_capacity_reader_shape_is_validated() -> None:
-    with pytest.raises(TypeError, match=r"\(nefc, nj\)"):
+    with pytest.raises(TypeError, match=r"\(ncon, nefc\)"):
         sample_capacity(lambda: (1, 2, 3), sample_steps=1)  # type: ignore[return-value]
 
-    with pytest.raises(ValueError, match="nefc"):
+    with pytest.raises(ValueError, match="ncon"):
         sample_capacity(lambda: (-1, 0), sample_steps=1)

--- a/tests/test_newton_capacity.py
+++ b/tests/test_newton_capacity.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from unisim.backend.newton.capacity import (
+    NewtonCapacityError,
+    calibrate_capacity,
+    sample_capacity,
+    validate_capacity_limits,
+)
+
+
+def test_capacity_sample_tracks_peak_counts() -> None:
+    values = iter(((3, 7), (12, 9), (8, 11)))
+    sample = sample_capacity(lambda: next(values), sample_steps=3)
+    assert sample.samples == 3
+    assert sample.peak_nefc == 12
+    assert sample.peak_nj == 11
+
+
+def test_capacity_overflow_fails_closed() -> None:
+    with pytest.raises(NewtonCapacityError, match="nconmax=8.*nefc=9"):
+        calibrate_capacity(lambda: (9, 2), nconmax=8, njmax=4, sample_steps=1)
+
+    with pytest.raises(NewtonCapacityError, match="njmax=4.*nj=5"):
+        calibrate_capacity(lambda: (2, 5), nconmax=8, njmax=4, sample_steps=1)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [("nconmax", 0), ("njmax", -1), ("nconmax", True)],
+)
+def test_capacity_limits_require_positive_integers(name: str, value: object) -> None:
+    kwargs = {"nconmax": 1, "njmax": 1}
+    kwargs[name] = value
+    with pytest.raises(ValueError, match=name):
+        validate_capacity_limits(**kwargs)
+
+
+def test_capacity_reader_shape_is_validated() -> None:
+    with pytest.raises(TypeError, match=r"\(nefc, nj\)"):
+        sample_capacity(lambda: (1, 2, 3), sample_steps=1)  # type: ignore[return-value]
+
+    with pytest.raises(ValueError, match="nefc"):
+        sample_capacity(lambda: (-1, 0), sample_steps=1)

--- a/tests/test_newton_contract.py
+++ b/tests/test_newton_contract.py
@@ -9,6 +9,7 @@ import sys
 import textwrap
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import unisim
@@ -18,6 +19,7 @@ from unisim.backend.newton.dependencies import (
     load_newton_dependencies,
     newton_dependencies_available,
 )
+from unisim.backend.newton.materialization import compute_contact_found_flags
 from unisim.conformance import assert_backend_conformance
 from unisim.scene import SceneCfg
 
@@ -38,6 +40,152 @@ _MODEL = """
   <actuator><motor name="hinge_motor" joint="hinge" ctrlrange="-1 1"/></actuator>
 </mujoco>
 """
+
+
+def test_contact_found_flags_match_unordered_pairs_per_world() -> None:
+    # Two env worlds; per-world pairs are (0, 1) and (2, 3).
+    shape_world = np.array([0, 0, 1, 1], dtype=np.int64)
+    shape_a = np.array([0, 2], dtype=np.int64)
+    shape_b = np.array([1, 3], dtype=np.int64)
+    # One contact in world 0 with the pair reversed, one in world 1 in order.
+    shape0 = np.array([1, 2], dtype=np.int64)
+    shape1 = np.array([0, 3], dtype=np.int64)
+    flags = compute_contact_found_flags(shape_world, shape0, shape1, shape_a, shape_b)
+    assert flags.dtype == np.float32
+    assert flags.tolist() == [1.0, 1.0]
+
+
+def test_contact_found_flags_attribute_only_the_contacting_world() -> None:
+    shape_world = np.array([0, 0, 1, 1], dtype=np.int64)
+    shape_a = np.array([0, 2], dtype=np.int64)
+    shape_b = np.array([1, 3], dtype=np.int64)
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([3], dtype=np.int64),
+        np.array([2], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [0.0, 1.0]
+
+
+def test_contact_found_flags_follow_non_static_shape_for_shared_worlds() -> None:
+    # Shape 0 is a shared/static shape (world -1); each env owns one box shape.
+    shape_world = np.array([-1, 0, 1], dtype=np.int64)
+    shape_a = np.array([0, 0], dtype=np.int64)
+    shape_b = np.array([1, 2], dtype=np.int64)
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([0, 2], dtype=np.int64),
+        np.array([1, 0], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [1.0, 1.0]
+
+
+def test_contact_found_flags_reject_contacts_without_an_env_world() -> None:
+    shape_world = np.array([-1, 0, 1], dtype=np.int64)
+    shape_a = np.array([0, 0], dtype=np.int64)
+    shape_b = np.array([1, 2], dtype=np.int64)
+    # A contact between two shared shapes matches no env even when the shared
+    # shape index collides with a resolved pair entry.
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([0, 0], dtype=np.int64),
+        np.array([0, 0], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [0.0, 0.0]
+
+
+def test_contact_found_flags_reject_cross_world_pairs() -> None:
+    shape_world = np.array([0, 0, 1, 1], dtype=np.int64)
+    shape_a = np.array([0, 2], dtype=np.int64)
+    shape_b = np.array([1, 3], dtype=np.int64)
+    # Shapes 1 (world 0) and 2 (world 1) can never legitimately touch; even
+    # such a malformed contact must not raise a flag.
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([1], dtype=np.int64),
+        np.array([2], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [0.0, 0.0]
+
+
+def test_contact_found_flags_empty_contacts_are_zero() -> None:
+    shape_world = np.array([0, 0], dtype=np.int64)
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.zeros(0, dtype=np.int64),
+        np.zeros(0, dtype=np.int64),
+        np.array([0], dtype=np.int64),
+        np.array([1], dtype=np.int64),
+    )
+    assert flags.tolist() == [0.0]
+
+
+def test_newton_play_render_plan_record() -> None:
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="record", play_steps=24, output_video="play.mp4"
+    )
+    assert plan.mode == "record"
+    assert plan.headless
+    assert plan.record_video
+    assert plan.num_steps == 24
+    assert plan.output_video == "play.mp4"
+
+
+def test_newton_play_render_plan_none_is_inert() -> None:
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="none", play_steps=None, output_video=None
+    )
+    assert plan.mode == "none"
+    assert plan.headless
+    assert not plan.record_video
+    assert plan.num_steps is None
+    assert plan.output_video is None
+
+
+@pytest.mark.parametrize("mode", ["auto", "interactive"])
+def test_newton_play_render_plan_rejects_auto_and_interactive(mode: str) -> None:
+    with pytest.raises(NotImplementedError, match="newton playback"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode=mode, play_steps=10, output_video="play.mp4"
+        )
+
+
+@pytest.mark.parametrize("play_steps", [None, 0, -3])
+def test_newton_play_render_plan_requires_positive_steps(play_steps: int | None) -> None:
+    with pytest.raises(ValueError, match="play_steps"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=play_steps, output_video="play.mp4"
+        )
+
+
+def test_newton_play_render_plan_requires_output_video() -> None:
+    with pytest.raises(ValueError, match="output video"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=10, output_video=None
+        )
+
+
+def test_newton_play_capabilities_declare_physics_state_playback() -> None:
+    backend = NewtonBackend.__new__(NewtonBackend)
+    capabilities = backend.get_play_capabilities()
+    assert capabilities.supports_physics_state_playback
+    assert not capabilities.supports_native_interactive_renderer
+    assert not capabilities.supports_native_video_capture
+
+
+def test_base_set_physics_state_fails_closed_by_default() -> None:
+    from unisim.fake import FakeBackend
+
+    with pytest.raises(NotImplementedError, match="physics-state restore"):
+        FakeBackend().set_physics_state(np.zeros((2, 3), dtype=np.float32))
 
 
 def test_newton_getters_do_not_materialize_warp_arrays() -> None:
@@ -101,4 +249,41 @@ def test_newton_conformance_when_cuda_runtime_is_available(tmp_path: Path) -> No
         capacity_check_steps=1,
     )
     assert_backend_conformance(backend)
+    backend.close()
+
+
+def test_newton_physics_state_roundtrip_when_cuda_runtime_is_available(
+    tmp_path: Path,
+) -> None:
+    try:
+        deps = load_newton_dependencies()
+    except NewtonDependencyError as exc:
+        pytest.skip(str(exc))
+    deps.warp.init()
+    device = deps.warp.get_device()
+    if not bool(device.is_cuda):
+        pytest.skip("Newton physics-state roundtrip requires a CUDA Warp device")
+    model_file = tmp_path / "newton.xml"
+    model_file.write_text(_MODEL, encoding="utf-8")
+    backend = NewtonBackend(
+        SceneCfg(model_file=str(model_file)),
+        num_envs=2,
+        sim_dt=0.005,
+        device=str(device),
+        capacity_check_steps=1,
+    )
+    ctrl = np.zeros((2, backend.num_actuators), dtype=np.float32)
+    backend.step(ctrl, nsteps=3)
+    snapshot = backend.get_physics_state()
+    assert snapshot.dtype == np.float32
+    assert snapshot.shape == (2, 1 + 8 + 7)
+    assert np.isfinite(snapshot).all()
+
+    backend.step(ctrl, nsteps=3)
+    backend.set_physics_state(snapshot)
+    restored = backend.get_physics_state()
+    np.testing.assert_allclose(restored, snapshot, rtol=1e-5, atol=1e-5)
+
+    with pytest.raises(ValueError, match="physics snapshot"):
+        backend.set_physics_state(snapshot[:, :-1])
     backend.close()

--- a/tests/test_newton_contract.py
+++ b/tests/test_newton_contract.py
@@ -1,0 +1,104 @@
+"""Static and optional-runtime boundary tests for the Newton adapter."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import unisim
+from unisim.backend.newton.backend import NewtonBackend
+from unisim.backend.newton.dependencies import (
+    NewtonDependencyError,
+    load_newton_dependencies,
+    newton_dependencies_available,
+)
+from unisim.conformance import assert_backend_conformance
+from unisim.scene import SceneCfg
+
+_MODEL = """
+<mujoco model="unisim-newton-test">
+  <option timestep="0.005" gravity="0 0 -9.81"/>
+  <worldbody>
+    <geom name="ground" type="plane" size="2 2 0.1"/>
+    <body name="base" pos="0 0 0.5">
+      <joint name="root" type="free"/>
+      <geom name="base_geom" type="sphere" size="0.08" mass="1"/>
+      <body name="arm" pos="0 0 0.12">
+        <joint name="hinge" type="hinge" axis="0 1 0"/>
+        <geom name="arm_geom" type="capsule" fromto="0 0 0 0 0 0.2" size="0.03" mass="0.2"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><motor name="hinge_motor" joint="hinge" ctrlrange="-1 1"/></actuator>
+</mujoco>
+"""
+
+
+def test_newton_getters_do_not_materialize_warp_arrays() -> None:
+    tree = ast.parse(textwrap.dedent(inspect.getsource(NewtonBackend)))
+    backend = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    getter_nodes = [
+        node
+        for node in backend.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("get_")
+    ]
+    offenders = [
+        getter.name
+        for getter in getter_nodes
+        for node in ast.walk(getter)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "numpy"
+    ]
+    assert offenders == []
+
+
+def test_newton_import_boundary_does_not_load_optional_modules() -> None:
+    code = (
+        "import sys, unisim; "
+        "assert not [name for name in sys.modules if name == 'newton' or "
+        "name == 'warp' or name.startswith('mujoco_warp')]"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_newton_manifest_and_lazy_exports() -> None:
+    assert unisim.adapter_spec("newton").extra == "newton"
+    assert unisim.NewtonBackend is NewtonBackend
+    assert unisim.NewtonDependencyError is NewtonDependencyError
+
+
+def test_newton_dependency_probe_is_fail_closed_when_extra_is_absent() -> None:
+    if newton_dependencies_available():
+        pytest.skip("Newton optional runtime is installed in this environment")
+    with pytest.raises(NewtonDependencyError, match="newton backend requires"):
+        unisim.create_backend("newton", scene=object())
+
+
+def test_newton_conformance_when_cuda_runtime_is_available(tmp_path: Path) -> None:
+    try:
+        deps = load_newton_dependencies()
+    except NewtonDependencyError as exc:
+        pytest.skip(str(exc))
+    deps.warp.init()
+    device = deps.warp.get_device()
+    if not bool(device.is_cuda):
+        pytest.skip("Newton conformance requires a CUDA Warp device")
+    model_file = tmp_path / "newton.xml"
+    model_file.write_text(_MODEL, encoding="utf-8")
+    backend = NewtonBackend(
+        SceneCfg(model_file=str(model_file)),
+        num_envs=2,
+        sim_dt=0.005,
+        device=str(device),
+        capacity_check_steps=1,
+    )
+    assert_backend_conformance(backend)
+    backend.close()

--- a/tests/test_newton_materialization.py
+++ b/tests/test_newton_materialization.py
@@ -59,6 +59,73 @@ def test_metadata_rejects_cone_geometry(tmp_path: Path) -> None:
         scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
 
 
+_CONTACT_SCENE = """
+<mujoco model="contact-scan-test">
+  <worldbody>
+    <geom name="floor" type="plane" size="1 1 0.1"/>
+    <body name="box" pos="0 0 1">
+      <joint name="hinge" type="hinge"/>
+      <geom name="box_geom" type="box" size="0.1 0.1 0.1" mass="1"/>
+      <site name="box_site" pos="0 0 0"/>
+    </body>
+  </worldbody>
+  <sensor>{sensor}</sensor>
+</mujoco>
+"""
+
+
+def _scan_contact_sensor(tmp_path: Path, sensor: str):
+    path = tmp_path / "scene.xml"
+    path.write_text(_CONTACT_SCENE.format(sensor=sensor), encoding="utf-8")
+    return scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
+
+
+@pytest.mark.parametrize("reduce_mode", ["none", "mindist", "netforce"])
+def test_metadata_scans_contact_found_sensor(tmp_path: Path, reduce_mode: str) -> None:
+    metadata = _scan_contact_sensor(
+        tmp_path,
+        f'<contact name="foot" geom1="floor" geom2="box_geom" data="found" num="1" '
+        f'reduce="{reduce_mode}"/>',
+    )
+    assert len(metadata.sensor_plans) == 1
+    plan = metadata.sensor_plans[0]
+    assert plan.name == "foot"
+    assert plan.kind == "contact"
+    assert plan.dim == 1
+    assert plan.geom1_name == "floor"
+    assert plan.geom2_name == "box_geom"
+    assert plan.geom1_id == 0
+    assert plan.geom2_id == 1
+
+
+def test_metadata_rejects_contact_sensor_data_channels(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="found"):
+        _scan_contact_sensor(
+            tmp_path,
+            '<contact name="c" geom1="floor" geom2="box_geom" data="force" num="1"/>',
+        )
+
+
+def test_metadata_rejects_contact_sensor_num_above_one(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="num=1"):
+        _scan_contact_sensor(
+            tmp_path,
+            '<contact name="c" geom1="floor" geom2="box_geom" data="found" num="2"/>',
+        )
+
+
+@pytest.mark.parametrize(
+    "sensor",
+    [
+        '<contact name="c" body1="box" data="found" num="1"/>',
+        '<contact name="c" site="box_site" data="found" num="1"/>',
+    ],
+)
+def test_metadata_rejects_contact_sensor_non_geom_pairs(tmp_path: Path, sensor: str) -> None:
+    with pytest.raises(NotImplementedError, match="geom1/geom2"):
+        _scan_contact_sensor(tmp_path, sensor)
+
+
 def test_newton_warp_path_has_no_mj_data_access() -> None:
     for path in Path(__file__).parents[1].joinpath("src/unisim/backend/newton").glob("*.py"):
         assert "mj_data" not in path.read_text(encoding="utf-8")

--- a/tests/test_newton_materialization.py
+++ b/tests/test_newton_materialization.py
@@ -1,0 +1,64 @@
+"""Cold-path MJCF compensation and fail-closed asset checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim.backend.newton.materialization import scan_newton_model_metadata
+from unisim.scene import SceneCfg
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def _write_model(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "scene.xml"
+    path.write_text(
+        f"<mujoco model='metadata-test'><worldbody>{body}</worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_metadata_scans_keyframes_and_supported_sensors(tmp_path: Path) -> None:
+    path = tmp_path / "scene.xml"
+    path.write_text(
+        """
+        <mujoco model="metadata-test">
+          <worldbody>
+            <body name="base"><joint name="hinge" type="hinge"/>
+              <site name="imu" pos="0 0 0"/>
+              <geom type="sphere" size="0.1"/>
+            </body>
+          </worldbody>
+          <sensor><gyro name="gyro" site="imu"/></sensor>
+          <keyframe><key name="home" qpos="0.25"/></keyframe>
+        </mujoco>
+        """,
+        encoding="utf-8",
+    )
+    metadata = scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
+    assert metadata.joint_names == ("hinge",)
+    assert metadata.keyframes[0][0] == "home"
+    np.testing.assert_allclose(metadata.keyframes[0][1], [0.25])
+    assert metadata.sensor_plans[0].name == "gyro"
+    assert metadata.sensor_plans[0].dim == 3
+
+
+def test_metadata_rejects_cone_geometry(tmp_path: Path) -> None:
+    if not hasattr(mujoco.mjtGeom, "mjGEOM_CONE"):
+        pytest.skip("installed MuJoCo does not expose a cone geom type")
+    path = _write_model(
+        tmp_path,
+        "<body name='base'><joint name='hinge' type='hinge'/><geom type='cone' "
+        "size='0.1 0.2'/></body>",
+    )
+    with pytest.raises(NotImplementedError, match="CONE"):
+        scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
+
+
+def test_newton_warp_path_has_no_mj_data_access() -> None:
+    for path in Path(__file__).parents[1].joinpath("src/unisim/backend/newton").glob("*.py"):
+        assert "mj_data" not in path.read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
+conflicts = [[
+    { package = "unisim-core", extra = "mjwarp" },
+    { package = "unisim-core", extra = "newton" },
+], [
+    { package = "unisim-core", extra = "mujoco" },
+    { package = "unisim-core", extra = "newton" },
+]]
 
 [[package]]
 name = "absl-py"
@@ -125,7 +132,7 @@ name = "cffi"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
 wheels = [
@@ -187,9 +194,9 @@ name = "coacd"
 version = "1.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/94/622a380a5c4cac78c1f19379b1d3fa193903f848311c200924309797abf8/coacd-1.0.14-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4cd9e1f327af766f6364e79e384ebfe152780a3d8dbbd09ce0756ec14f9e1256", size = 3426003, upload-time = "2026-08-28T21:53:32.005Z" },
@@ -215,7 +222,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -286,8 +293,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -430,9 +437,9 @@ name = "drake-uni"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/3a/248c89902111de84dd8bbaa947da87f80a4ec6e251197f4b82f6636eb0fc/drake_uni-0.1.0.tar.gz", hash = "sha256:46875ba06685ab73ab9b77a955f04c441c2aef21f8e15a9199a2d2c0ebb328f3", size = 36819, upload-time = "2026-09-02T07:22:39.204Z" }
 wheels = [
@@ -453,10 +460,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec" },
-    { name = "importlib-resources" },
-    { name = "typing-extensions" },
-    { name = "zipp" },
+    { name = "fsspec", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "importlib-resources", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "zipp", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 
 [[package]]
@@ -474,9 +481,9 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec" },
-    { name = "typing-extensions" },
-    { name = "zipp" },
+    { name = "fsspec", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "zipp", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 
 [[package]]
@@ -484,7 +491,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -496,9 +503,9 @@ name = "fast-simplification"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/0a/b943887803aefecd01d30cd150bd2a6f03d90b96886e3befdcc5d4276c98/fast_simplification-0.2.0.tar.gz", hash = "sha256:ed02ea6f4968ec98f963f2d3665dbafd0297ec12aea9e4d0a87c4b3c14d608a8", size = 31865, upload-time = "2026-08-12T19:53:50.49Z" }
 wheels = [
@@ -622,21 +629,22 @@ name = "genesis-world"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "coacd" },
     { name = "dracopy" },
     { name = "fast-simplification" },
     { name = "freetype-py" },
     { name = "frozendict" },
-    { name = "gs-madrona", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "gs-madrona", marker = "(platform_machine != 'AMD64' and platform_machine != 'x86_64' and extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (platform_machine != 'AMD64' and platform_machine != 'x86_64' and extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (sys_platform != 'linux' and extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "libigl" },
     { name = "moviepy" },
-    { name = "mujoco" },
+    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
+    { name = "mujoco", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-unisim-core-newton'" },
     { name = "numba" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "opencv-python" },
     { name = "openexr" },
     { name = "pillow" },
@@ -644,8 +652,8 @@ dependencies = [
     { name = "py-cpuinfo" },
     { name = "pycollada" },
     { name = "pydantic" },
-    { name = "pygel3d", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pygel3d", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pygel3d", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pygel3d", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "pyglet" },
     { name = "pygltflib" },
     { name = "pymeshlab" },
@@ -653,8 +661,8 @@ dependencies = [
     { name = "pysplashsurf" },
     { name = "quadrants" },
     { name = "rtree" },
-    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "tetgen" },
     { name = "trimesh" },
     { name = "vtk" },
@@ -700,9 +708,9 @@ name = "imageio"
 version = "2.37.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "pillow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/62/aa770a9307508d2a2a2c62d536a49347bffe9e55322db27838d3c93d0b07/imageio-2.37.4.tar.gz", hash = "sha256:e45cbc5e83502047fb138f7f585f7f105a136a57eea5f4b3cfc6ce1b52720bd3", size = 390173, upload-time = "2026-07-20T05:26:11.369Z" }
@@ -841,12 +849,12 @@ name = "libigl"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/41/8b04eb112af0579790af6a04f7d0ffc9be6827ce44e99495d30c6820e1fc/libigl-2.6.3.tar.gz", hash = "sha256:e2a3ff17b88cae728cb60ea63850131315bb661045a8642db73aea98c91486ab", size = 41273089, upload-time = "2026-09-01T02:47:31.393Z" }
 wheels = [
@@ -991,15 +999,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "cycler", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "fonttools", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pillow", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pyparsing", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1054,16 +1062,16 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "cycler", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "fonttools", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pillow", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -1115,9 +1123,9 @@ version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/2a/8bc5f7dc9ead9577ac9938487b105c10b5c4cbb702f16b3ab61995c21bb1/motrixsim_core-0.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:571292c53d7580c7a83c64071ccd5e5235c9f71acd0a61d35a96a39bf2b24dd9", size = 47126258, upload-time = "2026-06-08T14:29:38.062Z" },
@@ -1146,9 +1154,9 @@ dependencies = [
     { name = "decorator" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "pillow" },
     { name = "proglog" },
     { name = "python-dotenv" },
@@ -1162,15 +1170,20 @@ wheels = [
 name = "mujoco"
 version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "absl-py" },
-    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
-    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.11'" },
-    { name = "glfw" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pyopengl" },
+    { name = "absl-py", marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version < '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version < '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version >= '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version >= '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "glfw", marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version < '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version < '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version == '3.11.*' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version >= '3.12' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pyopengl", marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/3b/c76837b7fdb007f7605ff783689a0bd23a5a49b065928bec2f1fa7ea3d67/mujoco-3.10.0.tar.gz", hash = "sha256:c9e8d5d87d82204ed5bccc87d843c0a53e75aaf381de2938ec46d04f1ac6e24e", size = 1094987, upload-time = "2026-06-22T17:40:59.904Z" }
 wheels = [
@@ -1197,14 +1210,53 @@ wheels = [
 ]
 
 [[package]]
+name = "mujoco"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "absl-py", marker = "extra == 'extra-11-unisim-core-newton'" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "glfw", marker = "extra == 'extra-11-unisim-core-newton'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pyopengl", marker = "extra == 'extra-11-unisim-core-newton'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/2d/290f3f4062eec1c0d5246de0a75f1b18b59a1961081f49ddc97333fc8263/mujoco-3.11.0.tar.gz", hash = "sha256:390856102af9547dfd87cb2791eb105a3d2e00a37323fe9a12ed17e512aff1a6", size = 1139880, upload-time = "2026-07-28T01:23:32.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/4f/cac3ffdff6fbd63860d1be28a7f45fa1206ed638d4c774fe4505b9563c7c/mujoco-3.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6d830dab9f43781980d1e673f06938d80261f9960d8086d8a221ba0118b68c79", size = 17455595, upload-time = "2026-07-28T01:22:20.595Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f5/f8dfdbc9964b24bb1c2fb60467474d7a85f160c609ce29099d6eda9806ec/mujoco-3.11.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aac0102660762fad316cea63b81765593c97bdda0e22251eb64ff561f78e6853", size = 17632593, upload-time = "2026-07-28T01:22:23.616Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f5/9bb09c44bbc7b3d844aed8517f130cbc99e565b5f5e8a55c8f06f40b8129/mujoco-3.11.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39b813755f4b09b75a0ccaec0e1e37d313bc7c9ca1be94203a9aae3b7829cae0", size = 18727136, upload-time = "2026-07-28T01:22:26.625Z" },
+    { url = "https://files.pythonhosted.org/packages/43/40/e5123f0502dbb61158fa8f73b6d5576d3a818e3b3b07794732760759acf8/mujoco-3.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:c82557572b279dd61540f2da6d61afed64ef765c210e24abeee4f2b2a57660bb", size = 15651634, upload-time = "2026-07-28T01:22:29.765Z" },
+    { url = "https://files.pythonhosted.org/packages/82/cb/eaa909bfdb093d82b80518182db89936fd0cc5486aeac31e71d9940e4800/mujoco-3.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:87a70b79d461b3afe03d1cd3dfb44b9ba1955a80b011a87c9536a6ef9c7936c8", size = 17474359, upload-time = "2026-07-28T01:22:32.578Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d6/74fcb2a95b21de5217f19d9eb87db923d337e204da4dedaffeacababd28a/mujoco-3.11.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d09bcec0d9338fd79095314c4bd3a3072d7063e94a27d47f78e6159ca9a2baa9", size = 17655486, upload-time = "2026-07-28T01:22:35.33Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3d/3c933a7a8e7f00e12260ad175195b8bbc36fd3aa62068f00db36351a2147/mujoco-3.11.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:16f94f05745225aaafb68016cbd2a1617f4af6b4bfca6c97d22c7b14e598d1f1", size = 18751041, upload-time = "2026-07-28T01:22:38.149Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/e09d6ac38f3e7af2fec0b3501515973f8a400d9c3d1e22e727a21762f598/mujoco-3.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:5a286601c6a73a21f576ac6405e842a3221eb7db53013084a5c2e341a35112ee", size = 15687351, upload-time = "2026-07-28T01:22:40.864Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b3/b2b449b5978bcb13277c9e50d764e6d8cd9534f58f071fb1647724123e2c/mujoco-3.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3609c198de090c8218b9cc62ca6133f0feede8edd103b743b8002f3f735fcd9b", size = 17511145, upload-time = "2026-07-28T01:22:43.668Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/65/d8130bb8a673f9cdc8a8fb2ef02f9b6931708567de57f17395106e83b4e3/mujoco-3.11.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:517bff03623c3329a563f575afd7d731b0be5c4f92a54dcec934b99120b4a9ec", size = 17704436, upload-time = "2026-07-28T01:22:47.05Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/7b79f5d8fbd019658a3b5feb6ffd09c1e727eaf93f518685d3cc105a28f5/mujoco-3.11.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f40214fefc8c2fe0002a3c8abadf30de7a3330634f3c45cc29b407b40a0173fc", size = 18868030, upload-time = "2026-07-28T01:22:50.494Z" },
+    { url = "https://files.pythonhosted.org/packages/19/46/f994cd7d973c4db4f6b5af19ba6eb62703b9aafc8f894c5bc5ceadd31b0d/mujoco-3.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:98c08a5eec9411ecd6f763f1e635fbc8f31e3ea3701584d6b7edcc24d8d6c575", size = 15791637, upload-time = "2026-07-28T01:22:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/16/4b822d608cb4bc5aafe910b6f6947c73ecd467470935408e4ad0d207023e/mujoco-3.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd282aae46dc7350472bd4a81dd789ea011ff961c00fd60c9434e67bfd0519a3", size = 17511474, upload-time = "2026-07-28T01:22:57.111Z" },
+    { url = "https://files.pythonhosted.org/packages/47/73/4cbe741986ed86f13e86ad92a11de870bdec4979eaafcbc7ef3164680260/mujoco-3.11.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1ea2ed1d20b7cca55fc1e0257f2d4f6ab6e83855f669530fb3f55c85da80aac", size = 17704381, upload-time = "2026-07-28T01:23:00.158Z" },
+    { url = "https://files.pythonhosted.org/packages/90/2e/843071e21831fa5ef4029de6874789f9fd32f340d42fced383757c484bdd/mujoco-3.11.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3379c36b508474127b08e51e77942c493c2f1d7215b425e3b95de08dcba662e0", size = 18868301, upload-time = "2026-07-28T01:23:03.054Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/25/2a518a33b359b0798a9e8b55f30a4c9ab0cadd0cab8d85872ff9da6ca309/mujoco-3.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:d48b4a18d409ce4c746f32b3b402a8419b7450d9a89de68b81d73a3ef333d0e4", size = 15792231, upload-time = "2026-07-28T01:23:05.798Z" },
+]
+
+[[package]]
 name = "mujoco-uni-runtime"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mujoco" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version < '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version < '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version == '3.11.*' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version >= '3.12' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/75/c4ca9dac2e86858eac44daa5d2b2a4593ffbfcf21d09f4799ddae3071893/mujoco_uni_runtime-0.4.0.tar.gz", hash = "sha256:2d5cc07866eb02cf643dbcbdae837a4f82cd47a60c4f2697650e9e9c1c8fb679", size = 54082, upload-time = "2026-08-24T02:42:37.271Z" }
 
@@ -1212,19 +1264,48 @@ sdist = { url = "https://files.pythonhosted.org/packages/d1/75/c4ca9dac2e86858ea
 name = "mujoco-warp"
 version = "3.10.0.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
-    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.11'" },
-    { name = "mujoco" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "warp-lang" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "warp-lang", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/02/1687ee928ea468345546af79dcfd65da9cd5840e16d1e71a244223494e54/mujoco_warp-3.10.0.3.tar.gz", hash = "sha256:f22196465cb1350677f66d8b65aa23bf37d95e150ce3ba3c68ea934ba35e3070", size = 2074757, upload-time = "2026-07-22T15:28:01.367Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/a1/a8e616daafb219fccc2d23367894d305e442e2e18bc5e0dd855d9986d979/mujoco_warp-3.10.0.3-py3-none-any.whl", hash = "sha256:9435e5d6a7061af32aecc8da38124bfccceea27fc85176b33b66b7c4b76b4c1a", size = 2152650, upload-time = "2026-07-22T15:27:59.463Z" },
+]
+
+[[package]]
+name = "mujoco-warp"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "absl-py" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "mujoco", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/02/da883029b3661619651d0e2469ec17df92dd64ca5de25119886d516ee1de/mujoco_warp-3.11.0.tar.gz", hash = "sha256:e9e521a3809b95baa98c44bd4fcaccb035b5c700e2616efc52ebc33d29ae2eef", size = 2075418, upload-time = "2026-07-28T01:21:41.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/03/9bf86946c755a9a020c1bea587841472b0206351f73f67e41050fcb2a20c/mujoco_warp-3.11.0-py3-none-any.whl", hash = "sha256:97e77e877c1c2ea064ae68eaace2333dec94f2d8984091ba7b383bc8c34958f6", size = 2153348, upload-time = "2026-07-28T01:21:40.18Z" },
 ]
 
 [[package]]
@@ -1233,10 +1314,10 @@ version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ast-serialize" },
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/6a/878cc1097d4035f82bd516658d0c528d2a9955bc7b363afcbd0b07fea11b/mypy-2.3.1.tar.gz", hash = "sha256:47c1b1207258513a9d93495f69c8be9de73916186f0e52703e8c461b7a623419", size = 3992554, upload-time = "2026-08-15T03:03:38.549Z" }
@@ -1303,14 +1384,25 @@ wheels = [
 ]
 
 [[package]]
+name = "newton"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d6a3e799c25cf04b5ab35b9903cafd09731df123a0c91f4d27caed28d431/newton-1.5.1-py3-none-any.whl", hash = "sha256:a757269fe03ca2e50edb9636b3c7eb91c2d1e359b6e9c992b33dc6d9058b5285", size = 5564220, upload-time = "2026-08-27T20:33:23.381Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.67.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/90/2544f4e3a61e501d6c9a5418fd4b905323222693d54a02cab0106a0af865/numba-0.67.0.tar.gz", hash = "sha256:cd75aa535b33fa05d9d930b1ae8af9f97a2881e96d72dfb38ec9b78284d9f851", size = 2836515, upload-time = "2026-08-11T23:04:00.174Z" }
 wheels = [
@@ -1497,6 +1589,8 @@ version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
 ]
 
 [[package]]
@@ -1505,6 +1599,8 @@ version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
 ]
 
 [[package]]
@@ -1512,9 +1608,9 @@ name = "opencv-python"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
 wheels = [
@@ -1533,9 +1629,9 @@ name = "openexr"
 version = "3.4.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/a3/8b57f9bef539c195363cf966bbdc02951d3ce5d0a9f612d262f7fe66caad/openexr-3.4.15.tar.gz", hash = "sha256:6c9a28a4f4089379c9c4fd301edaa4dba0ed315862c029f453690a8191370a47", size = 25673422, upload-time = "2026-08-21T23:13:29.49Z" }
 wheels = [
@@ -1741,9 +1837,9 @@ name = "pycollada"
 version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/8d/52a5364a17eb96129962cae8d3ee7658775e085ad0ba38388684ad5944e9/pycollada-0.9.3.tar.gz", hash = "sha256:c34d6dcf0fe2eba5896f71c96d37a1c0fe1a61f08440fa0cfcec3dc2895d3302", size = 110826, upload-time = "2026-01-24T15:45:23.625Z" }
@@ -1869,9 +1965,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "plotly" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "plotly", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fb/eee3d9698b38c7005a500205f2559bf1f2983ecc232cb7ad2f7cc518ed4e/PyGEL3D-0.6.1-py3-none-any.whl", hash = "sha256:6403447c1a2d3c592871ad7ec7c30854e299149cd1532b46c78c5f43009d06f2", size = 4095361, upload-time = "2025-02-24T12:16:07.392Z" },
@@ -1886,11 +1982,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "plotly" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "plotly", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/4f/8e58c1f7cef75c2a4572c8db9b7cf29df8a1a4a23bd90c738935e183003a/pygel3d-0.8.0.tar.gz", hash = "sha256:cdd5407c71259226a618ced64b21fa415ef9eea35d07866dd8454cb4089311c0", size = 859598, upload-time = "2026-08-27T14:59:52.87Z" }
 wheels = [
@@ -1933,9 +2029,9 @@ name = "pymeshlab"
 version = "2025.7.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/7e/d44a74e360163ffc37f380c1be421c1594bd67e4ef9a4805691fdb662449/pymeshlab-2025.7.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5692a0a50cca49178ad9a3ceb02f60f200c7572b72f89964c7dbf915ef9e65a", size = 64994803, upload-time = "2026-01-30T08:40:19.586Z" },
@@ -1983,9 +2079,9 @@ name = "pysplashsurf"
 version = "0.14.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/c0/59a4a1a6a99c691f4fc6e254a73b4fa64986fb1ce66d2329fb4263f7c238/pysplashsurf-0.14.1.0.tar.gz", hash = "sha256:8304e3c923a8b5c6b59e9d9091fb868012053d48ae9bddf907354bd70ce063ac", size = 484484, upload-time = "2026-03-21T20:19:02.348Z" }
 wheels = [
@@ -2008,13 +2104,13 @@ name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
@@ -2096,9 +2192,9 @@ dependencies = [
     { name = "cffi" },
     { name = "colorama" },
     { name = "dill" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "setuptools" },
@@ -2184,14 +2280,14 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" } },
+    { name = "imageio", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "lazy-loader", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pillow", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
 wheels = [
@@ -2227,17 +2323,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "tifffile", version = "2026.8.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imageio", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "lazy-loader", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pillow", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "tifffile", version = "2026.8.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
 wheels = [
@@ -2283,7 +2379,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2342,7 +2438,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2396,7 +2492,7 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
 wheels = [
@@ -2454,9 +2550,9 @@ name = "tetgen"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/15/a52fd7c1049ba8e39f7ee7ada132221ac535c6c18e6c07c27be1ef4fdf6b/tetgen-0.8.2.tar.gz", hash = "sha256:06ca8d8b9e21cdbb75334e20ee77e788e88f4b2cdb85c51b008592cb3f9af964", size = 824449, upload-time = "2026-01-27T20:48:55.271Z" }
 wheels = [
@@ -2485,7 +2581,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -2500,7 +2596,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -2515,7 +2611,7 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/07/90078f49e60718d414d5440dc498301f11ff049458e65cf8d27c62a5c9d1/tifffile-2026.8.23.tar.gz", hash = "sha256:bd3c816f166f85c93329a54a0c9a1eccc9968a6a78f91d63b65d7b17675915f2", size = 446179, upload-time = "2026-08-23T18:45:05.976Z" }
 wheels = [
@@ -2563,7 +2659,7 @@ name = "tqdm"
 version = "4.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
@@ -2575,9 +2671,9 @@ name = "trimesh"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/3f/a13d797349fdd00a8586b60d6b71df849e1766e2002729697a265b27a773/trimesh-5.1.0.tar.gz", hash = "sha256:927aa8748af8b84cb969c8f53270d929e546f2beada77a2bc234b605fddf1454", size = 870501, upload-time = "2026-08-31T18:28:55.464Z" }
 wheels = [
@@ -2623,9 +2719,9 @@ name = "unisim-core"
 version = "1.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 
 [package.optional-dependencies]
@@ -2636,15 +2732,21 @@ genesis = [
     { name = "genesis-world" },
 ]
 mjwarp = [
-    { name = "mujoco-warp" },
-    { name = "warp-lang" },
+    { name = "mujoco-warp", version = "3.10.0.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "warp-lang", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
 ]
 motrix = [
     { name = "motrixsim-core" },
 ]
 mujoco = [
-    { name = "mujoco" },
+    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" } },
     { name = "mujoco-uni-runtime" },
+]
+newton = [
+    { name = "mujoco", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mujoco-warp", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "newton" },
+    { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [package.dev-dependencies]
@@ -2660,12 +2762,16 @@ requires-dist = [
     { name = "genesis-world", marker = "extra == 'genesis'", specifier = "==1.3.3" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5" },
+    { name = "mujoco", marker = "extra == 'newton'", specifier = "==3.11.0" },
     { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.4.0" },
     { name = "mujoco-warp", marker = "extra == 'mjwarp'", specifier = "==3.10.0.3" },
+    { name = "mujoco-warp", marker = "extra == 'newton'", specifier = "==3.11.0" },
+    { name = "newton", marker = "extra == 'newton'", specifier = "==1.5.1" },
     { name = "numpy" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
+    { name = "warp-lang", marker = "extra == 'newton'", specifier = "==1.16.0" },
 ]
-provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "isaacgym", "isaacsim"]
+provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "newton", "isaacgym", "isaacsim"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2679,8 +2785,8 @@ name = "vtk"
 version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/51/fa0acc077a712e3ce1a683868c78fbba29d00a3a590808575160ac627bcc/vtk-9.7.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:43d327f6691e74a97b2a2e44bfd9fed7ea4e5c04f88f7398810a5c199c111f2a", size = 110868260, upload-time = "2026-08-15T21:36:12.314Z" },
@@ -2707,12 +2813,38 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/8a/8be711f3b5431a6e0bdb97117d681b03cf2bb95d6fcf8869861900898d88/warp_lang-1.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:19a7590c4484e8250ab19165311d2a1774138663b361c41e8be2865c7515c4ae", size = 25221601, upload-time = "2026-08-03T02:26:38.389Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3d/47feef2eee4739437e19d6949ea231ca4181c9eacbaa39144761e6130d94/warp_lang-1.16.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:96449fc1e3b354185e2f09434fb794b5953ab2e8673b104d7e7f48d5d418bb35", size = 163074225, upload-time = "2026-08-03T02:27:03.632Z" },
+    { url = "https://files.pythonhosted.org/packages/db/96/0c2b070b3101c669955cafd36262548b2e8b00dfdeda3aeb7afbc0f9d65c/warp_lang-1.16.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d4715171bd6821436b82293d774c9a082ace08215c189572b4348d1e48fb8ee8", size = 167563789, upload-time = "2026-08-03T02:27:37.512Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/17/c98fab81156f0d25f17200f52f69210b94a9abba101066736df8cc493522/warp_lang-1.16.0-py3-none-win_amd64.whl", hash = "sha256:8690c9096e0a271985339d4aa4b37675e7d62852620ca861ac032dc85b124542", size = 146387135, upload-time = "2026-08-03T02:28:17.956Z" },
+]
+
+[[package]]
+name = "warp-lang"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/b0/9b1de407fa10b380f5ca4ed1c3e5b129be55ea26a927c7a49e45cdde14b0/warp_lang-1.17.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fec43afb81caa2190c0b7fa3aaf4d869f3599839f0c40b9ead84331f91e993", size = 27544218, upload-time = "2026-08-31T05:52:29.177Z" },


### PR DESCRIPTION
## Summary

- integrate Newton runtime dependency isolation (Child #23 / PR #26)
- integrate explicit capacity overflow protection (Child #24 / PR #27)
- integrate the NewtonBackend adapter, conformance coverage, lazy exports, factory wiring, and authored-vs-compiled safeguards (Child #25 / PR #28)

Parent roadmap: #22

## Validation

- `make check` — 62 passed, 3 skipped
- `make package` — source distribution and wheel built successfully
- `uv lock --check` — passed

Newton/CUDA-specific tests remain fail-closed/skipped when the optional runtime is unavailable; the base import boundary remains lazy.
