### PR TITLE
feat(issue-31): Newton contact sensor, record playback, and reset/audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Add snapshot playback support to the Newton adapter: `get_physics_state` /
+  `set_physics_state` ([time, qpos, qvel] host-cache layout), record/none
+  `resolve_play_render_plan` semantics, and `run_playback` through the shared
+  offline MuJoCo snapshot renderer now in `unisim.backend.playback_common`
+  (mjwarp behavior and messages unchanged). Add a fail-closed
+  `SimBackend.set_physics_state` default.
+- Add MJCF contact-sensor (`mjSENS_CONTACT`) support to the Newton adapter for
+  the exact `data="found" num=1` named-geom-pair shape: per-env binary flags
+  are resolved once against `SolverMuJoCo.mjc_geom_to_newton_shape` at
+  materialization and refreshed through `SolverMuJoCo.update_contacts`; all
+  other contact-sensor configurations remain fail-closed.
 - Rework the README around the project overview, UniLab relationship,
   installation, and quick start, and add the Chinese `README_zh.md`.
 - Add the isolated Newton 1.5.1 runtime extra and a metadata/import probe;

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -750,6 +750,16 @@ class SimBackend(abc.ABC):
             f"{self.__class__.__name__} does not support physics-state playback"
         )
 
+    def set_physics_state(self, state: np.ndarray) -> None:
+        """Restore a snapshot produced by ``get_physics_state``.
+
+        Backends implementing this must refresh their host caches so state and
+        sensor getters stay consistent with the restored physics state.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support physics-state restore"
+        )
+
     def get_playback_model(self, env_index: int | None = None) -> Any:
         """Return the playback model for a specific env when variants exist.
 

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -1,15 +1,22 @@
-"""Cold-path MuJoCo offline playback bridge for ``mjwarp``."""
+"""Cold-path MuJoCo offline playback bridge for ``mjwarp``.
+
+The implementation lives in :mod:`unisim.backend.playback_common` so other
+snapshot-based adapters (Newton) share one offline MuJoCo pipeline; the
+wrappers below keep the historical mjwarp names, signatures, and messages.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from os import PathLike
-from pathlib import Path
 from typing import Any, TypeVar
 
 import numpy as np
 
-from unisim.backend.mujoco.playback import run_mujoco_playback
+from unisim.backend.playback_common import (
+    run_offline_snapshot_playback,
+    validate_offline_visual_model,
+)
 
 ObsT = TypeVar("ObsT")
 
@@ -21,48 +28,12 @@ def validate_mjwarp_visual_model(
     model_file: str | PathLike[str],
 ) -> str:
     """Validate the detached MuJoCo visual twin used for offline playback."""
-    path = Path(model_file)
-    if not path.is_file():
-        raise ValueError(
-            f"mjwarp offline playback visual model does not exist or is not a file: {path}"
-        )
-    try:
-        visual_model = mujoco.MjModel.from_xml_path(str(path))
-    except Exception as exc:
-        raise ValueError(
-            f"mjwarp offline playback could not load visual model {path}: "
-            f"{type(exc).__name__}: {exc}"
-        ) from exc
-
-    physics_dims = (int(physics_model.nq), int(physics_model.nv))
-    visual_dims = (int(visual_model.nq), int(visual_model.nv))
-    if visual_dims != physics_dims:
-        raise ValueError(
-            "mjwarp offline playback visual model state dimensions are incompatible: "
-            f"physics nq/nv={physics_dims}, visual nq/nv={visual_dims}."
-        )
-
-    joint_object = mujoco.mjtObj.mjOBJ_JOINT
-
-    def _joint_layout(model: Any) -> tuple[tuple[str | None, int, int, int], ...]:
-        return tuple(
-            (
-                mujoco.mj_id2name(model, joint_object, joint_id),
-                int(model.jnt_type[joint_id]),
-                int(model.jnt_qposadr[joint_id]),
-                int(model.jnt_dofadr[joint_id]),
-            )
-            for joint_id in range(int(model.njnt))
-        )
-
-    physics_layout = _joint_layout(physics_model)
-    visual_layout = _joint_layout(visual_model)
-    if visual_layout != physics_layout:
-        raise ValueError(
-            "mjwarp offline playback visual model joint layout is incompatible; "
-            "joint names, types, qpos addresses, and dof addresses must match physics."
-        )
-    return str(path)
+    return validate_offline_visual_model(
+        mujoco=mujoco,
+        physics_model=physics_model,
+        model_file=model_file,
+        backend_label="mjwarp",
+    )
 
 
 def run_mjwarp_playback(
@@ -82,64 +53,19 @@ def run_mjwarp_playback(
     extra_data_getter: Callable[[], np.ndarray | None] | None = None,
 ) -> str:
     """Render detached mjwarp host snapshots with the existing MuJoCo pipeline."""
-    if not headless:
-        raise NotImplementedError(
-            "mjwarp offline playback does not support interactive rendering; "
-            "use training.play_render_mode=record."
-        )
-    if not record_video:
-        raise ValueError("mjwarp offline playback requires record_video=true.")
-    if isinstance(num_steps, bool) or num_steps is None or int(num_steps) <= 0:
-        raise ValueError("mjwarp record playback requires a positive finite num_steps value.")
-    if output_video is None:
-        raise ValueError("mjwarp record playback requires an output_video path.")
-
-    # Both checks are playback-only cold-path work. Physics construction and
-    # step/reset never import the renderer or parse the visual model.
-    backend.get_playback_model()
-    try:
-        from unisim.visualization import render_many
-
-        renderer_usable = bool(render_many.render_backend_usable())
-    except Exception as exc:
-        raise RuntimeError(
-            "mjwarp offline playback could not initialize the MuJoCo renderer: "
-            f"{type(exc).__name__}: {exc}"
-        ) from exc
-    if not renderer_usable:
-        raise RuntimeError(
-            "mjwarp offline playback requires a usable MuJoCo off-screen renderer; "
-            "configure EGL, OSMesa, or GLFW before recording."
-        )
-
-    getter = frame_state_getter or env.get_physics_state_snapshot
-    expected_shape = snapshot_shape
-
-    def _validated_state_getter() -> np.ndarray:
-        state = np.asarray(getter(), dtype=np.float32)
-        if state.shape != expected_shape:
-            raise ValueError(
-                "mjwarp offline playback snapshot must use [time, qpos, qvel] layout "
-                f"with shape {expected_shape}, got {state.shape}."
-            )
-        return state
-
-    result = run_mujoco_playback(
+    return run_offline_snapshot_playback(
+        backend=backend,
         env=env,
         initialize=initialize,
         step=step,
-        num_steps=int(num_steps),
+        num_steps=num_steps,
         output_video=output_video,
         render_spacing=render_spacing,
-        headless=True,
-        record_video=True,
-        frame_state_getter=_validated_state_getter,
+        headless=headless,
+        record_video=record_video,
+        snapshot_shape=snapshot_shape,
+        frame_state_getter=frame_state_getter,
         camera_kwargs=camera_kwargs,
+        backend_label="mjwarp",
         extra_data_getter=extra_data_getter,
     )
-    if result is None:
-        raise RuntimeError(
-            "mjwarp offline playback produced no frames; the MuJoCo renderer or worker "
-            "failed after preflight."
-        )
-    return result

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -10,11 +10,22 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from os import PathLike
 from typing import Any
 
 import numpy as np
 
-from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.backend.base import (
+    BackendPlayCapabilities,
+    BackendPlayRenderPlan,
+    BackendRootStateLayout,
+    SimBackend,
+    normalize_play_render_mode,
+)
+from unisim.backend.playback_common import (
+    run_offline_snapshot_playback,
+    validate_offline_visual_model,
+)
 from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
 from unisim.scene import SceneCfg
 from unisim.utils.rotation import (
@@ -28,7 +39,9 @@ from .capacity import NewtonCapacityReport, calibrate_capacity, validate_capacit
 from .dependencies import load_newton_dependencies
 from .materialization import (
     NewtonModelAudit,
+    NewtonSensorPlan,
     audit_newton_model,
+    compute_contact_found_flags,
     scan_newton_model_metadata,
 )
 from .runtime import get_bound_newton_process_device
@@ -118,8 +131,11 @@ class NewtonBackend(SimBackend):
         self._control: Any | None = None
         self._contacts: Any | None = None
         self._view: Any | None = None
+        self._shape_world: np.ndarray | None = None
+        self._contact_sensor_pairs: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         self._audit: NewtonModelAudit | None = None
         self._capacity_report: NewtonCapacityReport | None = None
+        self._playback_model_validated = False
         self._closed = False
 
         nbody = len(self._body_names)
@@ -200,6 +216,8 @@ class NewtonBackend(SimBackend):
         self._contacts = newton.Contacts(
             self._solver.get_max_contact_count(), 0, device=self._device
         )
+        self._shape_world = np.asarray(self._model.shape_world.numpy(), dtype=np.int64)
+        self._contact_sensor_pairs = self._resolve_contact_sensor_pairs()
         newton.eval_fk(
             self._model, self._state.joint_q, self._state.joint_qd, self._state
         )
@@ -305,8 +323,61 @@ class NewtonBackend(SimBackend):
             self._qvel_cache[:, 3:6] = np_quat_apply_inverse_batched(root_quat, root_omega)
         self._refresh_sensor_cache(sensor_dt=sensor_dt)
 
+    def _resolve_contact_sensor_pairs(self) -> dict[str, tuple[np.ndarray, np.ndarray]]:
+        plans = [plan for plan in self._metadata.sensor_plans if plan.kind == "contact"]
+        if not plans:
+            return {}
+        mapping = getattr(self._solver, "mjc_geom_to_newton_shape", None)
+        if mapping is None:
+            raise RuntimeError(
+                "newton SolverMuJoCo did not publish mjc_geom_to_newton_shape; "
+                "contact sensors cannot be resolved against the compiled model"
+            )
+        mapping_np = np.asarray(mapping.numpy(), dtype=np.int64)
+        if mapping_np.ndim != 2 or mapping_np.shape[0] != self._num_envs:
+            raise RuntimeError(
+                "newton compiled geom mapping does not match the requested worlds: "
+                f"shape {mapping_np.shape}, num_envs {self._num_envs}"
+            )
+        pairs: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        for plan in plans:
+            shape_a = mapping_np[:, plan.geom1_id].copy()
+            shape_b = mapping_np[:, plan.geom2_id].copy()
+            if np.any(shape_a < 0) or np.any(shape_b < 0):
+                raise RuntimeError(
+                    f"newton compiled model dropped geoms {plan.geom1_name!r}/"
+                    f"{plan.geom2_name!r} required by contact sensor {plan.name!r}"
+                )
+            pairs[plan.name] = (shape_a, shape_b)
+        return pairs
+
+    def _refresh_contact_sensors(self, plans: list[NewtonSensorPlan]) -> None:
+        self._solver.update_contacts(self._contacts)
+        self._deps.warp.synchronize_device(self._device)
+        count = int(np.asarray(self._contacts.rigid_contact_count.numpy())[0])
+        shape0 = np.asarray(
+            self._contacts.rigid_contact_shape0.numpy()[:count], dtype=np.int64
+        )
+        shape1 = np.asarray(
+            self._contacts.rigid_contact_shape1.numpy()[:count], dtype=np.int64
+        )
+        for plan in plans:
+            shape_a, shape_b = self._contact_sensor_pairs[plan.name]
+            found = compute_contact_found_flags(
+                self._shape_world, shape0, shape1, shape_a, shape_b
+            )
+            address, dim = self._sensor_slots[plan.name]
+            self._sensor_cache[:, address : address + dim] = found[:, None]
+
     def _refresh_sensor_cache(self, *, sensor_dt: float | None) -> None:
+        contact_plans = [
+            plan for plan in self._metadata.sensor_plans if plan.kind == "contact"
+        ]
+        if contact_plans:
+            self._refresh_contact_sensors(contact_plans)
         for plan in self._metadata.sensor_plans:
+            if plan.kind == "contact":
+                continue
             body_id = plan.body_id - 1
             if body_id < 0:
                 raise RuntimeError(f"sensor {plan.name!r} is attached to the world body")
@@ -535,7 +606,15 @@ class NewtonBackend(SimBackend):
         self._deps.newton.eval_fk(
             self._model, self._state.joint_q, self._state.joint_qd, self._state
         )
-        self._solver.reset(self._state, warp_mask)
+        # flags=0: clear MuJoCo's persistent solver buffers (warmstart, act,
+        # ctrl) without reverting state.joint_q/joint_qd to the model defaults
+        # that a default reset would restore. update_data_interval=0 disables
+        # the per-step state->mjw sync, so push the uploaded joint coordinates
+        # into MuJoCo Warp explicitly on this cold path.
+        self._solver.reset(self._state, warp_mask, flags=0)
+        self._solver._update_mjc_data(
+            self._solver.mjw_data, self._model, self._state, world_mask=warp_mask
+        )
         upload_ms = (time.perf_counter() - t0) * 1000.0
         t0 = time.perf_counter()
         self._refresh_host_cache()
@@ -547,6 +626,132 @@ class NewtonBackend(SimBackend):
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         return DomainRandomizationCapabilities()
+
+    def get_play_capabilities(self) -> BackendPlayCapabilities:
+        return BackendPlayCapabilities(supports_physics_state_playback=True)
+
+    @staticmethod
+    def resolve_play_render_plan(
+        *,
+        play_render_mode: str | None,
+        play_steps: int | None,
+        output_video: str | PathLike[str] | None,
+    ) -> BackendPlayRenderPlan:
+        """Resolve playback modes: ``record`` and ``none`` only, fail closed.
+
+        A staticmethod so the semantics stay testable without a CUDA runtime.
+        """
+        mode = normalize_play_render_mode(play_render_mode)
+        if mode == "none":
+            return BackendPlayRenderPlan(
+                mode="none",
+                headless=True,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+            )
+        if mode == "auto":
+            raise NotImplementedError(
+                "newton playback does not support auto mode; select record or none explicitly."
+            )
+        if mode == "interactive":
+            raise NotImplementedError(
+                "newton playback does not support interactive or native rendering; "
+                "select record or none."
+            )
+        if isinstance(play_steps, bool) or play_steps is None or int(play_steps) <= 0:
+            raise ValueError(
+                "newton record playback requires a positive finite training.play_steps value."
+            )
+        if output_video is None:
+            raise ValueError("newton record playback requires an output video path.")
+        return BackendPlayRenderPlan(
+            mode="record",
+            headless=True,
+            record_video=True,
+            num_steps=int(play_steps),
+            output_video=output_video,
+        )
+
+    def run_playback(
+        self,
+        *,
+        env: Any,
+        initialize: Any,
+        step: Any,
+        num_steps: int | None,
+        output_video: str | PathLike[str] | None = None,
+        render_spacing: float | None = None,
+        render_offset_mode: str | None = None,
+        headless: bool | None = None,
+        record_video: bool | None = None,
+        frame_state_getter: Any = None,
+        camera_kwargs: dict[str, Any] | None = None,
+        extra_data_getter: Any = None,
+    ) -> str | None:
+        del render_offset_mode
+        should_record = bool(record_video) if record_video is not None else output_video is not None
+        should_run_headless = bool(headless) if headless is not None else should_record
+        return run_offline_snapshot_playback(
+            backend=self,
+            env=env,
+            initialize=initialize,
+            step=step,
+            num_steps=num_steps,
+            output_video=output_video,
+            render_spacing=render_spacing,
+            headless=should_run_headless,
+            record_video=should_record,
+            snapshot_shape=(self._num_envs, 1 + self._metadata.nq + self._metadata.nv),
+            frame_state_getter=frame_state_getter,
+            camera_kwargs=camera_kwargs,
+            backend_label="newton",
+            extra_data_getter=extra_data_getter,
+        )
+
+    def get_physics_state(self) -> np.ndarray:
+        self._require_state("get_physics_state")
+        nq = self._metadata.nq
+        nv = self._metadata.nv
+        state = np.empty((self._num_envs, 1 + nq + nv), dtype=np.float32)
+        state[:, 0] = self._time_cache
+        state[:, 1 : 1 + nq] = self._qpos_cache
+        state[:, 1 + nq :] = self._qvel_cache
+        return state
+
+    def set_physics_state(self, state: np.ndarray) -> None:
+        """Restore a ``get_physics_state`` snapshot through the set_state path."""
+        self._require_state("set_physics_state")
+        nq = self._metadata.nq
+        nv = self._metadata.nv
+        state_array = np.asarray(state, dtype=np.float32)
+        expected = (self._num_envs, 1 + nq + nv)
+        if state_array.shape != expected:
+            raise ValueError(
+                f"newton physics snapshot must use [time, qpos, qvel] layout with shape "
+                f"{expected}, got {state_array.shape}"
+            )
+        self.set_state(
+            np.arange(self._num_envs, dtype=np.intp),
+            state_array[:, 1 : 1 + nq],
+            state_array[:, 1 + nq :],
+        )
+        self._time_cache[...] = state_array[:, 0]
+
+    def get_playback_model(self, env_index: int | None = None) -> str:
+        if env_index is not None:
+            idx = int(env_index)
+            if idx < 0 or idx >= self._num_envs:
+                raise IndexError(f"env_index must be in [0, {self._num_envs - 1}], got {idx}")
+        if not self._playback_model_validated:
+            self._scene_visual_model_file = validate_offline_visual_model(
+                mujoco=self._deps.mujoco,
+                physics_model=self._metadata.playback_model,
+                model_file=self._scene_visual_model_file,
+                backend_label="newton",
+            )
+            self._playback_model_validated = True
+        return self._scene_visual_model_file
 
     def get_base_pos(self) -> np.ndarray:
         self._require_state("get_base_pos")

--- a/src/unisim/backend/newton/materialization.py
+++ b/src/unisim/backend/newton/materialization.py
@@ -29,7 +29,13 @@ class _TemporarySceneCleanup:
 
 @dataclass(frozen=True, slots=True)
 class NewtonSensorPlan:
-    """One MJCF sensor reconstructed from public Newton state arrays."""
+    """One MJCF sensor reconstructed from public Newton state arrays.
+
+    Site-attached plans populate ``body_id``/``site_pos``/``site_quat``.
+    Contact plans (``kind == "contact"``) instead carry the authored geom
+    pair; their per-world compiled shape indices are resolved once at
+    materialization against ``SolverMuJoCo.mjc_geom_to_newton_shape``.
+    """
 
     name: str
     kind: str
@@ -37,6 +43,10 @@ class NewtonSensorPlan:
     body_id: int
     site_pos: np.ndarray
     site_quat: np.ndarray
+    geom1_name: str = ""
+    geom2_name: str = ""
+    geom1_id: int = -1
+    geom2_id: int = -1
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +56,7 @@ class NewtonModelMetadata:
     source_model_file: str
     diagnostic_model_file: str
     cleanup_handle: Any | None
+    playback_model: Any
     model_name: str
     nq: int
     nv: int
@@ -85,6 +96,114 @@ class NewtonModelAudit:
     qvel_per_world: int
 
 
+# MuJoCo compiles the MJCF contact-sensor ``data`` attribute into a bitmask in
+# ``sensor_intprm[:, 0]``; bit 0 is ``found``.  ``sensor_intprm[:, 1]`` is the
+# ``reduce`` mode and ``sensor_intprm[:, 2]`` is ``num``.
+_CONTACT_DATASPEC_FOUND = 1
+
+
+def compute_contact_found_flags(
+    shape_world: np.ndarray,
+    contact_shape0: np.ndarray,
+    contact_shape1: np.ndarray,
+    shape_a: np.ndarray,
+    shape_b: np.ndarray,
+) -> np.ndarray:
+    """Return 1.0 per env whose world produced a contact between the pair.
+
+    ``shape_a``/``shape_b`` hold the compiled Newton shape indices of the
+    authored geom pair for each env world, and ``shape_world`` maps every
+    Newton shape to its world index (shared/static shapes carry a negative
+    index).  Contact shape pairs are unordered.  A contact is attributed to
+    the world of its non-static shape; contacts without a consistent env world
+    (two shared shapes, or two shapes from different worlds) match nothing.
+    """
+    shape_a = np.asarray(shape_a, dtype=np.int64).reshape(-1)
+    shape_b = np.asarray(shape_b, dtype=np.int64).reshape(-1)
+    found = np.zeros((shape_a.shape[0],), dtype=np.float32)
+    shape0 = np.asarray(contact_shape0, dtype=np.int64).reshape(-1)
+    shape1 = np.asarray(contact_shape1, dtype=np.int64).reshape(-1)
+    if not shape0.size:
+        return found
+    shape_world = np.asarray(shape_world, dtype=np.int64)
+    world0 = shape_world[shape0]
+    world1 = shape_world[shape1]
+    world = np.maximum(world0, world1)
+    same_world = (world0 == world1) | (world0 < 0) | (world1 < 0)
+    valid = same_world & (world >= 0) & (world < found.shape[0])
+    if not np.any(valid):
+        return found
+    world = world[valid]
+    shape0 = shape0[valid]
+    shape1 = shape1[valid]
+    pair_a = shape_a[world]
+    pair_b = shape_b[world]
+    matched = ((shape0 == pair_a) & (shape1 == pair_b)) | (
+        (shape0 == pair_b) & (shape1 == pair_a)
+    )
+    found[world[matched]] = 1.0
+    return found
+
+
+def _scan_contact_sensor(mujoco: Any, model: Any, sensor_id: int, name: str) -> NewtonSensorPlan:
+    """Scan one ``mjSENS_CONTACT`` sensor restricted to ``found`` geom pairs.
+
+    Only the exact authored shape ``data="found" num=1 geom1=... geom2=...``
+    is supported.  Every ``reduce`` mode (none/mindist/netforce) is
+    accepted because it only selects which contact fills the single reported
+    slot; the binary ``found`` flag is identical for all of them.  Any other
+    configuration (other data channels, ``num > 1``, body/subtree/site
+    contacts, unnamed geoms) fails closed.
+    """
+    intprm = np.asarray(model.sensor_intprm[sensor_id], dtype=np.int64)
+    dataspec = int(intprm[0])
+    num = int(intprm[2])
+    if dataspec != _CONTACT_DATASPEC_FOUND:
+        raise NotImplementedError(
+            f"newton backend supports contact sensor {name!r} only with data=\"found\"; "
+            f"compiled dataspec bitmask is {dataspec}"
+        )
+    if num != 1:
+        raise NotImplementedError(
+            f"newton backend supports contact sensor {name!r} only with num=1; "
+            f"compiled num is {num}"
+        )
+    if int(model.sensor_dim[sensor_id]) != 1:
+        raise NotImplementedError(
+            f"newton backend expected contact sensor {name!r} dim 1, "
+            f"compiled dim is {int(model.sensor_dim[sensor_id])}"
+        )
+    geom_obj = int(mujoco.mjtObj.mjOBJ_GEOM)
+    if (
+        int(model.sensor_objtype[sensor_id]) != geom_obj
+        or int(model.sensor_reftype[sensor_id]) != geom_obj
+    ):
+        raise NotImplementedError(
+            f"newton backend supports contact sensor {name!r} only for named geom1/geom2 "
+            "pairs; body, subtree, and site contacts are unsupported"
+        )
+    geom1_id = int(model.sensor_objid[sensor_id])
+    geom2_id = int(model.sensor_refid[sensor_id])
+    geom1_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, geom1_id)
+    geom2_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, geom2_id)
+    if not geom1_name or not geom2_name:
+        raise NotImplementedError(
+            f"newton backend requires named geoms on contact sensor {name!r}"
+        )
+    return NewtonSensorPlan(
+        name=str(name),
+        kind="contact",
+        dim=1,
+        body_id=-1,
+        site_pos=np.zeros(3, dtype=np.float32),
+        site_quat=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        geom1_name=str(geom1_name),
+        geom2_name=str(geom2_name),
+        geom1_id=geom1_id,
+        geom2_id=geom2_id,
+    )
+
+
 def _scan_sensors(mujoco: Any, model: Any) -> tuple[NewtonSensorPlan, ...]:
     supported = {
         mujoco.mjtSensor.mjSENS_GYRO: "gyro",
@@ -102,6 +221,9 @@ def _scan_sensors(mujoco: Any, model: Any) -> tuple[NewtonSensorPlan, ...]:
             raise NotImplementedError(
                 f"newton backend requires named MJCF sensors; sensor id {sensor_id} is unnamed"
             )
+        if sensor_type == mujoco.mjtSensor.mjSENS_CONTACT:
+            plans.append(_scan_contact_sensor(mujoco, model, sensor_id, str(name)))
+            continue
         kind = supported.get(sensor_type)
         if kind is None:
             raise NotImplementedError(
@@ -259,6 +381,7 @@ def scan_newton_model_metadata(mujoco: Any, scene: SceneCfg) -> NewtonModelMetad
         source_model_file=source_model_file,
         diagnostic_model_file=str(scene.model_file),
         cleanup_handle=_TemporarySceneCleanup(*temp_paths) if temp_paths else None,
+        playback_model=model,
         model_name=model_name,
         nq=int(model.nq),
         nv=int(model.nv),
@@ -305,7 +428,12 @@ def audit_newton_model(
     if int(model.body_count) != expected_bodies * num_envs:
         raise RuntimeError("newton compiled body layout differs from the authored MJCF")
 
-    gravity = np.asarray(model.gravity.numpy(), dtype=np.float32).reshape(num_envs, 3)
+    gravity_np = np.asarray(model.gravity.numpy(), dtype=np.float32)
+    if gravity_np.shape[0] == num_envs + 1:
+        # Newton 1.5.1 appends one gravity entry for the global world -1;
+        # only the per-world rows participate in the audit.
+        gravity_np = gravity_np[:num_envs]
+    gravity = gravity_np.reshape(num_envs, 3)
     if not np.allclose(gravity, metadata.gravity, rtol=1e-6, atol=1e-6):
         raise RuntimeError("newton compiled gravity differs from the authored MJCF")
     mass = np.asarray(model.body_mass.numpy(), dtype=np.float32).reshape(num_envs, expected_bodies)
@@ -319,5 +447,6 @@ __all__ = [
     "NewtonModelMetadata",
     "NewtonSensorPlan",
     "audit_newton_model",
+    "compute_contact_found_flags",
     "scan_newton_model_metadata",
 ]

--- a/src/unisim/backend/playback_common.py
+++ b/src/unisim/backend/playback_common.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
+from os import PathLike
+from pathlib import Path
+from typing import Any, TypeVar
 
 import numpy as np
+
+ObsT = TypeVar("ObsT")
 
 
 class _ImageIOProxy:
@@ -29,3 +34,141 @@ def env_cfg_value(env: Any, name: str, default: Any) -> Any:
 def write_playback_video(path: str, frames: list[np.ndarray], *, fps: int) -> None:
     """Write playback frames with the repository-managed imageio stack."""
     imageio.mimsave(path, frames, fps=fps)
+
+
+def validate_offline_visual_model(
+    *,
+    mujoco: Any,
+    physics_model: Any,
+    model_file: str | PathLike[str],
+    backend_label: str,
+) -> str:
+    """Validate the detached MuJoCo visual twin used for offline playback."""
+    path = Path(model_file)
+    if not path.is_file():
+        raise ValueError(
+            f"{backend_label} offline playback visual model does not exist or is not a file: "
+            f"{path}"
+        )
+    try:
+        visual_model = mujoco.MjModel.from_xml_path(str(path))
+    except Exception as exc:
+        raise ValueError(
+            f"{backend_label} offline playback could not load visual model {path}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+    physics_dims = (int(physics_model.nq), int(physics_model.nv))
+    visual_dims = (int(visual_model.nq), int(visual_model.nv))
+    if visual_dims != physics_dims:
+        raise ValueError(
+            f"{backend_label} offline playback visual model state dimensions are incompatible: "
+            f"physics nq/nv={physics_dims}, visual nq/nv={visual_dims}."
+        )
+
+    joint_object = mujoco.mjtObj.mjOBJ_JOINT
+
+    def _joint_layout(model: Any) -> tuple[tuple[str | None, int, int, int], ...]:
+        return tuple(
+            (
+                mujoco.mj_id2name(model, joint_object, joint_id),
+                int(model.jnt_type[joint_id]),
+                int(model.jnt_qposadr[joint_id]),
+                int(model.jnt_dofadr[joint_id]),
+            )
+            for joint_id in range(int(model.njnt))
+        )
+
+    physics_layout = _joint_layout(physics_model)
+    visual_layout = _joint_layout(visual_model)
+    if visual_layout != physics_layout:
+        raise ValueError(
+            f"{backend_label} offline playback visual model joint layout is incompatible; "
+            "joint names, types, qpos addresses, and dof addresses must match physics."
+        )
+    return str(path)
+
+
+def run_offline_snapshot_playback(
+    *,
+    backend: Any,
+    env: Any,
+    initialize: Callable[[], ObsT],
+    step: Callable[[ObsT], ObsT],
+    num_steps: int | None,
+    output_video: str | PathLike[str] | None,
+    render_spacing: float | None,
+    headless: bool,
+    record_video: bool,
+    snapshot_shape: tuple[int, int],
+    frame_state_getter: Callable[[], np.ndarray] | None,
+    camera_kwargs: dict[str, Any] | None,
+    backend_label: str,
+    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+) -> str:
+    """Render detached host snapshots with the offline MuJoCo pipeline."""
+    if not headless:
+        raise NotImplementedError(
+            f"{backend_label} offline playback does not support interactive rendering; "
+            "use training.play_render_mode=record."
+        )
+    if not record_video:
+        raise ValueError(f"{backend_label} offline playback requires record_video=true.")
+    if isinstance(num_steps, bool) or num_steps is None or int(num_steps) <= 0:
+        raise ValueError(
+            f"{backend_label} record playback requires a positive finite num_steps value."
+        )
+    if output_video is None:
+        raise ValueError(f"{backend_label} record playback requires an output_video path.")
+
+    # Both checks are playback-only cold-path work. Physics construction and
+    # step/reset never import the renderer or parse the visual model.
+    backend.get_playback_model()
+    try:
+        from unisim.visualization import render_many
+
+        renderer_usable = bool(render_many.render_backend_usable())
+    except Exception as exc:
+        raise RuntimeError(
+            f"{backend_label} offline playback could not initialize the MuJoCo renderer: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    if not renderer_usable:
+        raise RuntimeError(
+            f"{backend_label} offline playback requires a usable MuJoCo off-screen renderer; "
+            "configure EGL, OSMesa, or GLFW before recording."
+        )
+
+    getter = frame_state_getter or env.get_physics_state_snapshot
+    expected_shape = snapshot_shape
+
+    def _validated_state_getter() -> np.ndarray:
+        state = np.asarray(getter(), dtype=np.float32)
+        if state.shape != expected_shape:
+            raise ValueError(
+                f"{backend_label} offline playback snapshot must use [time, qpos, qvel] layout "
+                f"with shape {expected_shape}, got {state.shape}."
+            )
+        return state
+
+    from unisim.backend.mujoco.playback import run_mujoco_playback
+
+    result = run_mujoco_playback(
+        env=env,
+        initialize=initialize,
+        step=step,
+        num_steps=int(num_steps),
+        output_video=output_video,
+        render_spacing=render_spacing,
+        headless=True,
+        record_video=True,
+        frame_state_getter=_validated_state_getter,
+        camera_kwargs=camera_kwargs,
+        extra_data_getter=extra_data_getter,
+    )
+    if result is None:
+        raise RuntimeError(
+            f"{backend_label} offline playback produced no frames; the MuJoCo renderer or worker "
+            "failed after preflight."
+        )
+    return result

--- a/tests/test_newton_contract.py
+++ b/tests/test_newton_contract.py
@@ -9,6 +9,7 @@ import sys
 import textwrap
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import unisim
@@ -18,6 +19,7 @@ from unisim.backend.newton.dependencies import (
     load_newton_dependencies,
     newton_dependencies_available,
 )
+from unisim.backend.newton.materialization import compute_contact_found_flags
 from unisim.conformance import assert_backend_conformance
 from unisim.scene import SceneCfg
 
@@ -38,6 +40,152 @@ _MODEL = """
   <actuator><motor name="hinge_motor" joint="hinge" ctrlrange="-1 1"/></actuator>
 </mujoco>
 """
+
+
+def test_contact_found_flags_match_unordered_pairs_per_world() -> None:
+    # Two env worlds; per-world pairs are (0, 1) and (2, 3).
+    shape_world = np.array([0, 0, 1, 1], dtype=np.int64)
+    shape_a = np.array([0, 2], dtype=np.int64)
+    shape_b = np.array([1, 3], dtype=np.int64)
+    # One contact in world 0 with the pair reversed, one in world 1 in order.
+    shape0 = np.array([1, 2], dtype=np.int64)
+    shape1 = np.array([0, 3], dtype=np.int64)
+    flags = compute_contact_found_flags(shape_world, shape0, shape1, shape_a, shape_b)
+    assert flags.dtype == np.float32
+    assert flags.tolist() == [1.0, 1.0]
+
+
+def test_contact_found_flags_attribute_only_the_contacting_world() -> None:
+    shape_world = np.array([0, 0, 1, 1], dtype=np.int64)
+    shape_a = np.array([0, 2], dtype=np.int64)
+    shape_b = np.array([1, 3], dtype=np.int64)
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([3], dtype=np.int64),
+        np.array([2], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [0.0, 1.0]
+
+
+def test_contact_found_flags_follow_non_static_shape_for_shared_worlds() -> None:
+    # Shape 0 is a shared/static shape (world -1); each env owns one box shape.
+    shape_world = np.array([-1, 0, 1], dtype=np.int64)
+    shape_a = np.array([0, 0], dtype=np.int64)
+    shape_b = np.array([1, 2], dtype=np.int64)
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([0, 2], dtype=np.int64),
+        np.array([1, 0], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [1.0, 1.0]
+
+
+def test_contact_found_flags_reject_contacts_without_an_env_world() -> None:
+    shape_world = np.array([-1, 0, 1], dtype=np.int64)
+    shape_a = np.array([0, 0], dtype=np.int64)
+    shape_b = np.array([1, 2], dtype=np.int64)
+    # A contact between two shared shapes matches no env even when the shared
+    # shape index collides with a resolved pair entry.
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([0, 0], dtype=np.int64),
+        np.array([0, 0], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [0.0, 0.0]
+
+
+def test_contact_found_flags_reject_cross_world_pairs() -> None:
+    shape_world = np.array([0, 0, 1, 1], dtype=np.int64)
+    shape_a = np.array([0, 2], dtype=np.int64)
+    shape_b = np.array([1, 3], dtype=np.int64)
+    # Shapes 1 (world 0) and 2 (world 1) can never legitimately touch; even
+    # such a malformed contact must not raise a flag.
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.array([1], dtype=np.int64),
+        np.array([2], dtype=np.int64),
+        shape_a,
+        shape_b,
+    )
+    assert flags.tolist() == [0.0, 0.0]
+
+
+def test_contact_found_flags_empty_contacts_are_zero() -> None:
+    shape_world = np.array([0, 0], dtype=np.int64)
+    flags = compute_contact_found_flags(
+        shape_world,
+        np.zeros(0, dtype=np.int64),
+        np.zeros(0, dtype=np.int64),
+        np.array([0], dtype=np.int64),
+        np.array([1], dtype=np.int64),
+    )
+    assert flags.tolist() == [0.0]
+
+
+def test_newton_play_render_plan_record() -> None:
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="record", play_steps=24, output_video="play.mp4"
+    )
+    assert plan.mode == "record"
+    assert plan.headless
+    assert plan.record_video
+    assert plan.num_steps == 24
+    assert plan.output_video == "play.mp4"
+
+
+def test_newton_play_render_plan_none_is_inert() -> None:
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="none", play_steps=None, output_video=None
+    )
+    assert plan.mode == "none"
+    assert plan.headless
+    assert not plan.record_video
+    assert plan.num_steps is None
+    assert plan.output_video is None
+
+
+@pytest.mark.parametrize("mode", ["auto", "interactive"])
+def test_newton_play_render_plan_rejects_auto_and_interactive(mode: str) -> None:
+    with pytest.raises(NotImplementedError, match="newton playback"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode=mode, play_steps=10, output_video="play.mp4"
+        )
+
+
+@pytest.mark.parametrize("play_steps", [None, 0, -3])
+def test_newton_play_render_plan_requires_positive_steps(play_steps: int | None) -> None:
+    with pytest.raises(ValueError, match="play_steps"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=play_steps, output_video="play.mp4"
+        )
+
+
+def test_newton_play_render_plan_requires_output_video() -> None:
+    with pytest.raises(ValueError, match="output video"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode="record", play_steps=10, output_video=None
+        )
+
+
+def test_newton_play_capabilities_declare_physics_state_playback() -> None:
+    backend = NewtonBackend.__new__(NewtonBackend)
+    capabilities = backend.get_play_capabilities()
+    assert capabilities.supports_physics_state_playback
+    assert not capabilities.supports_native_interactive_renderer
+    assert not capabilities.supports_native_video_capture
+
+
+def test_base_set_physics_state_fails_closed_by_default() -> None:
+    from unisim.fake import FakeBackend
+
+    with pytest.raises(NotImplementedError, match="physics-state restore"):
+        FakeBackend().set_physics_state(np.zeros((2, 3), dtype=np.float32))
 
 
 def test_newton_getters_do_not_materialize_warp_arrays() -> None:
@@ -101,4 +249,41 @@ def test_newton_conformance_when_cuda_runtime_is_available(tmp_path: Path) -> No
         capacity_check_steps=1,
     )
     assert_backend_conformance(backend)
+    backend.close()
+
+
+def test_newton_physics_state_roundtrip_when_cuda_runtime_is_available(
+    tmp_path: Path,
+) -> None:
+    try:
+        deps = load_newton_dependencies()
+    except NewtonDependencyError as exc:
+        pytest.skip(str(exc))
+    deps.warp.init()
+    device = deps.warp.get_device()
+    if not bool(device.is_cuda):
+        pytest.skip("Newton physics-state roundtrip requires a CUDA Warp device")
+    model_file = tmp_path / "newton.xml"
+    model_file.write_text(_MODEL, encoding="utf-8")
+    backend = NewtonBackend(
+        SceneCfg(model_file=str(model_file)),
+        num_envs=2,
+        sim_dt=0.005,
+        device=str(device),
+        capacity_check_steps=1,
+    )
+    ctrl = np.zeros((2, backend.num_actuators), dtype=np.float32)
+    backend.step(ctrl, nsteps=3)
+    snapshot = backend.get_physics_state()
+    assert snapshot.dtype == np.float32
+    assert snapshot.shape == (2, 1 + 8 + 7)
+    assert np.isfinite(snapshot).all()
+
+    backend.step(ctrl, nsteps=3)
+    backend.set_physics_state(snapshot)
+    restored = backend.get_physics_state()
+    np.testing.assert_allclose(restored, snapshot, rtol=1e-5, atol=1e-5)
+
+    with pytest.raises(ValueError, match="physics snapshot"):
+        backend.set_physics_state(snapshot[:, :-1])
     backend.close()

--- a/tests/test_newton_materialization.py
+++ b/tests/test_newton_materialization.py
@@ -59,6 +59,73 @@ def test_metadata_rejects_cone_geometry(tmp_path: Path) -> None:
         scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
 
 
+_CONTACT_SCENE = """
+<mujoco model="contact-scan-test">
+  <worldbody>
+    <geom name="floor" type="plane" size="1 1 0.1"/>
+    <body name="box" pos="0 0 1">
+      <joint name="hinge" type="hinge"/>
+      <geom name="box_geom" type="box" size="0.1 0.1 0.1" mass="1"/>
+      <site name="box_site" pos="0 0 0"/>
+    </body>
+  </worldbody>
+  <sensor>{sensor}</sensor>
+</mujoco>
+"""
+
+
+def _scan_contact_sensor(tmp_path: Path, sensor: str):
+    path = tmp_path / "scene.xml"
+    path.write_text(_CONTACT_SCENE.format(sensor=sensor), encoding="utf-8")
+    return scan_newton_model_metadata(mujoco, SceneCfg(model_file=str(path)))
+
+
+@pytest.mark.parametrize("reduce_mode", ["none", "mindist", "netforce"])
+def test_metadata_scans_contact_found_sensor(tmp_path: Path, reduce_mode: str) -> None:
+    metadata = _scan_contact_sensor(
+        tmp_path,
+        f'<contact name="foot" geom1="floor" geom2="box_geom" data="found" num="1" '
+        f'reduce="{reduce_mode}"/>',
+    )
+    assert len(metadata.sensor_plans) == 1
+    plan = metadata.sensor_plans[0]
+    assert plan.name == "foot"
+    assert plan.kind == "contact"
+    assert plan.dim == 1
+    assert plan.geom1_name == "floor"
+    assert plan.geom2_name == "box_geom"
+    assert plan.geom1_id == 0
+    assert plan.geom2_id == 1
+
+
+def test_metadata_rejects_contact_sensor_data_channels(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="found"):
+        _scan_contact_sensor(
+            tmp_path,
+            '<contact name="c" geom1="floor" geom2="box_geom" data="force" num="1"/>',
+        )
+
+
+def test_metadata_rejects_contact_sensor_num_above_one(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="num=1"):
+        _scan_contact_sensor(
+            tmp_path,
+            '<contact name="c" geom1="floor" geom2="box_geom" data="found" num="2"/>',
+        )
+
+
+@pytest.mark.parametrize(
+    "sensor",
+    [
+        '<contact name="c" body1="box" data="found" num="1"/>',
+        '<contact name="c" site="box_site" data="found" num="1"/>',
+    ],
+)
+def test_metadata_rejects_contact_sensor_non_geom_pairs(tmp_path: Path, sensor: str) -> None:
+    with pytest.raises(NotImplementedError, match="geom1/geom2"):
+        _scan_contact_sensor(tmp_path, sensor)
+
+
 def test_newton_warp_path_has_no_mj_data_access() -> None:
     for path in Path(__file__).parents[1].joinpath("src/unisim/backend/newton").glob("*.py"):
         assert "mj_data" not in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

承接 child issue #31（roadmap #22），为 NewtonBackend 补齐 UniLab 训练与回放所需能力：

- **contact sensor**：支持 `mjSENS_CONTACT`（`data="found"`、num=1、geom pair），经公开 `SolverMuJoCo.update_contacts` 重建接触对（`_scan_contact_sensor` + `compute_contact_found_flags`）。注意 Newton MJCF importer 默认 `shape_gap=0.1`，contact found 会在几何接触前略早报 1——这是对后端 contact list 的忠实镜像。
- **record playback**：`resolve_play_render_plan`（record/none）、`run_playback`（经新的共享模块 `src/unisim/backend/playback_common.py`，mjwarp 同步复用）、`get_physics_state`/`set_physics_state` 快照，回放经 MuJoCo 离线渲染。
- **pre-existing bug 修复**：`set_state` 的 solver.reset `flags=StateFlags.ALL` 会吞掉上传的 reset（改 `flags=0` + `_update_mjc_data`）；`audit_newton_model` 的 gravity 多算一行 global world -1。

## Validation

- `make check`（最终 head f796869）：85 passed / 4 skipped。
- CUDA 冒烟通过。
- 真机端到端（UniLab PR [#1511](https://github.com/unilabsim/UniLab/pull/1511)）：`uv run train --algo sac --task g1_walk_flat --sim newton` 完整 5000/5000 iterations（reward/mean 6.68 → 242.3，episode length → 983，~43k steps/s，4m25s wall，RTX 4090 / torch 2.8.0+cu128 / newton 1.5.1 / mujoco-warp 3.11，run `2026-09-06_01-21-36_newton`），并对 `model_5000.pt` 完成 record 回放验证（800 帧 MuJoCo 快照渲染，步态正常）。

Closes #31