### PR TITLE
feat(issue-33): native ViewerGL rendering for Newton playback (record + interactive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Add native ViewerGL playback to the Newton adapter behind the new
+  `newton-render` extra (`pyglet>=2.1.6,<3`, `imgui-bundle>=1.92.0`):
+  `record` renders offscreen through `ViewerGL(headless=True)` when the viewer
+  dependencies are importable and falls back to the offline MuJoCo snapshot
+  pipeline otherwise, `interactive` opens the windowed viewer (fail-closed
+  without the dependencies or a reachable display), and `auto` picks
+  `interactive` with a display and `record` without one. `run_playback`
+  drives the native loops; `init_renderer`/`render`/`capture_video_frame`
+  implement the base renderer hooks. `BackendPlayRenderPlan` gains a
+  diagnostic `renderer` field surfaced by `log_playback_plan`.
 - Add snapshot playback support to the Newton adapter: `get_physics_state` /
   `set_physics_state` ([time, qpos, qvel] host-cache layout), record/none
   `resolve_play_render_plan` semantics, and `run_playback` through the shared

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -25,3 +25,12 @@ probe; add `--import` when the native runtime should be imported explicitly.
 The adapter's cold-path calibration samples solver counts and raises an explicit
 capacity error when `nconmax` or `njmax` is too small; it never accepts silent
 constraint truncation.
+
+Newton playback renders natively through `ViewerGL` when the separate
+`newton-render` extra (`pyglet>=2.1.6,<3`, `imgui-bundle>=1.92.0`, installed
+as `uv sync --extra newton --extra newton-render`) is available: `record`
+renders offscreen, `interactive` opens the windowed viewer, and `auto` picks
+by display availability. Without the extra, `record` falls back to the offline
+MuJoCo snapshot pipeline and `interactive` fails closed with an actionable
+error. Headless offscreen GL needs EGL (`PYOPENGL_PLATFORM=egl`) or GLX under
+Wayland.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,15 @@ newton = [
     "mujoco==3.11.0",
     "warp-lang==1.16.0",
 ]
+# GUI dependencies for Newton's native ViewerGL playback (record and
+# interactive).  Kept out of the ``newton`` extra so pure training
+# environments stay headless-clean; install as
+# `uv sync --extra newton --extra newton-render`.  Mirrors the floors Newton
+# itself pins under its ``examples`` extra.
+newton-render = [
+    "pyglet>=2.1.6,<3",
+    "imgui-bundle>=1.92.0",
+]
 # Isaac SDKs are vendor-managed and cannot be represented as redistributable
 # PyPI dependencies.  These empty extras provide a stable installation and
 # support-matrix spelling while runtime discovery uses dedicated workers.

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -196,13 +196,19 @@ PLAY_RENDER_MODES = frozenset({"auto", "interactive", "record", "none"})
 
 @dataclass(frozen=True)
 class BackendPlayRenderPlan:
-    """Backend-resolved playback rendering behavior."""
+    """Backend-resolved playback rendering behavior.
+
+    ``renderer`` names the concrete renderer the backend selected for the
+    plan (for example a native viewer versus an offline snapshot pipeline)
+    and is purely diagnostic: consumers must not branch on it.
+    """
 
     mode: str
     headless: bool
     record_video: bool
     num_steps: int | None
     output_video: str | PathLike[str] | None
+    renderer: str | None = None
 
 
 def normalize_play_render_mode(play_render_mode: str | None) -> str:
@@ -218,10 +224,11 @@ def log_playback_plan(plan: BackendPlayRenderPlan, *, prefix: str = "") -> None:
     if plan.mode == "none":
         print(f"{prefix}Skipping playback because training.play_render_mode=none.")
         return
+    via = f" via {plan.renderer}" if plan.renderer else ""
     if plan.record_video:
-        print(f"{prefix}Rendering video to {plan.output_video}...")
+        print(f"{prefix}Rendering video to {plan.output_video}{via}...")
     elif plan.mode == "interactive":
-        print(f"{prefix}Starting interactive visualization...")
+        print(f"{prefix}Starting interactive visualization{via}...")
         print(f"{prefix}Use the renderer window or browser URL reported by the backend.")
     else:
         print(f"{prefix}Running playback without video recording...")

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -8,6 +8,7 @@ and tests must use numerical tolerances.
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Sequence
 from os import PathLike
@@ -19,6 +20,7 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    RenderClosedError,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -36,7 +38,11 @@ from unisim.utils.rotation import (
 )
 
 from .capacity import NewtonCapacityReport, calibrate_capacity, validate_capacity_limits
-from .dependencies import load_newton_dependencies
+from .dependencies import (
+    load_newton_dependencies,
+    newton_render_dependencies_available,
+    require_newton_render_dependencies,
+)
 from .materialization import (
     NewtonModelAudit,
     NewtonSensorPlan,
@@ -44,9 +50,18 @@ from .materialization import (
     compute_contact_found_flags,
     scan_newton_model_metadata,
 )
+from .playback import (
+    MAX_RENDER_WORLDS,
+    MUJOCO_SNAPSHOT_RENDERER,
+    NEWTON_NATIVE_RENDERER,
+    display_available,
+    run_newton_native_playback,
+)
 from .runtime import get_bound_newton_process_device
 
 _WORLD_Z = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+
+logger = logging.getLogger(__name__)
 
 
 class NewtonBackend(SimBackend):
@@ -136,6 +151,8 @@ class NewtonBackend(SimBackend):
         self._audit: NewtonModelAudit | None = None
         self._capacity_report: NewtonCapacityReport | None = None
         self._playback_model_validated = False
+        self._viewer: Any | None = None
+        self._render_config: tuple[bool, bool] | None = None
         self._closed = False
 
         nbody = len(self._body_names)
@@ -628,7 +645,12 @@ class NewtonBackend(SimBackend):
         return DomainRandomizationCapabilities()
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
-        return BackendPlayCapabilities(supports_physics_state_playback=True)
+        native = newton_render_dependencies_available()
+        return BackendPlayCapabilities(
+            supports_native_interactive_renderer=native,
+            supports_physics_state_playback=True,
+            supports_native_video_capture=native,
+        )
 
     @staticmethod
     def resolve_play_render_plan(
@@ -637,9 +659,15 @@ class NewtonBackend(SimBackend):
         play_steps: int | None,
         output_video: str | PathLike[str] | None,
     ) -> BackendPlayRenderPlan:
-        """Resolve playback modes: ``record`` and ``none`` only, fail closed.
+        """Resolve playback modes, selecting the concrete renderer.
 
-        A staticmethod so the semantics stay testable without a CUDA runtime.
+        ``record`` uses the native ViewerGL offscreen renderer when the viewer
+        dependencies are importable and falls back to the offline MuJoCo
+        snapshot pipeline otherwise.  ``interactive`` requires both the viewer
+        dependencies and a reachable display and fails closed otherwise.
+        ``auto`` resolves to ``interactive`` with a display and ``record``
+        without one.  A staticmethod so the semantics stay testable without a
+        CUDA runtime.
         """
         mode = normalize_play_render_mode(play_render_mode)
         if mode == "none":
@@ -651,13 +679,29 @@ class NewtonBackend(SimBackend):
                 output_video=None,
             )
         if mode == "auto":
-            raise NotImplementedError(
-                "newton playback does not support auto mode; select record or none explicitly."
-            )
+            mode = "interactive" if display_available() else "record"
         if mode == "interactive":
-            raise NotImplementedError(
-                "newton playback does not support interactive or native rendering; "
-                "select record or none."
+            if not newton_render_dependencies_available():
+                raise NotImplementedError(
+                    "newton interactive playback requires the native viewer dependencies "
+                    "(pyglet>=2.1.6,<3, imgui-bundle>=1.92.0); install them with "
+                    "`uv sync --extra newton --extra newton-render`, or select "
+                    "training.play_render_mode=record or none."
+                )
+            if not display_available():
+                raise NotImplementedError(
+                    "newton interactive playback requires a reachable display "
+                    "(DISPLAY or WAYLAND_DISPLAY); on headless hosts select "
+                    "training.play_render_mode=record (offscreen GL needs EGL via "
+                    "PYOPENGL_PLATFORM=egl, or GLX under Wayland)."
+                )
+            return BackendPlayRenderPlan(
+                mode="interactive",
+                headless=False,
+                record_video=False,
+                num_steps=None,
+                output_video=None,
+                renderer=NEWTON_NATIVE_RENDERER,
             )
         if isinstance(play_steps, bool) or play_steps is None or int(play_steps) <= 0:
             raise ValueError(
@@ -665,12 +709,18 @@ class NewtonBackend(SimBackend):
             )
         if output_video is None:
             raise ValueError("newton record playback requires an output video path.")
+        renderer = (
+            NEWTON_NATIVE_RENDERER
+            if newton_render_dependencies_available()
+            else MUJOCO_SNAPSHOT_RENDERER
+        )
         return BackendPlayRenderPlan(
             mode="record",
             headless=True,
             record_video=True,
             num_steps=int(play_steps),
             output_video=output_video,
+            renderer=renderer,
         )
 
     def run_playback(
@@ -692,6 +742,36 @@ class NewtonBackend(SimBackend):
         del render_offset_mode
         should_record = bool(record_video) if record_video is not None else output_video is not None
         should_run_headless = bool(headless) if headless is not None else should_record
+        if not should_run_headless and not should_record:
+            try:
+                return run_newton_native_playback(
+                    backend=self,
+                    env=env,
+                    initialize=initialize,
+                    step=step,
+                    num_steps=num_steps,
+                    output_video=None,
+                    render_spacing=render_spacing,
+                    headless=False,
+                    record_video=False,
+                    camera_kwargs=camera_kwargs,
+                )
+            except RenderClosedError:
+                logger.info("Render window closed.")
+                return None
+        if newton_render_dependencies_available():
+            return run_newton_native_playback(
+                backend=self,
+                env=env,
+                initialize=initialize,
+                step=step,
+                num_steps=num_steps,
+                output_video=output_video,
+                render_spacing=render_spacing,
+                headless=should_run_headless,
+                record_video=should_record,
+                camera_kwargs=camera_kwargs,
+            )
         return run_offline_snapshot_playback(
             backend=self,
             env=env,
@@ -708,6 +788,81 @@ class NewtonBackend(SimBackend):
             backend_label="newton",
             extra_data_getter=extra_data_getter,
         )
+
+    def init_renderer(
+        self,
+        spacing: float = 1.0,
+        *,
+        offset_mode: str = "grid",
+        headless: bool = False,
+        capture: bool = False,
+        width: int = 1280,
+        height: int = 720,
+        camera_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Attach a native ViewerGL renderer on the cold playback path.
+
+        ``offset_mode`` is accepted for contract parity and ignored: envs are
+        laid out with ViewerGL's grid world offsets.  ``camera_kwargs`` is
+        likewise accepted for parity; the native viewer keeps its default
+        camera (the offline MuJoCo snapshot path honors camera kwargs).  The
+        first (headless, capture) pair is pinned.
+        """
+        del offset_mode, camera_kwargs
+        config = (bool(headless), bool(capture))
+        if self._viewer is not None:
+            if self._render_config != config:
+                raise RuntimeError(
+                    "newton renderer is already initialized with "
+                    f"(headless, capture)={self._render_config}, requested {config}"
+                )
+            return
+        require_newton_render_dependencies()
+        self._require_state("init_renderer")
+        try:
+            from newton.viewer import ViewerGL
+        except ImportError as exc:
+            raise RuntimeError(
+                "newton native renderer could not import newton.viewer.ViewerGL: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        try:
+            viewer = ViewerGL(width=int(width), height=int(height), headless=bool(headless))
+        except Exception as exc:
+            raise RuntimeError(
+                "newton native viewer could not create an OpenGL context "
+                f"({type(exc).__name__}: {exc}); interactive mode needs a reachable "
+                "display (DISPLAY or WAYLAND_DISPLAY), headless offscreen mode needs "
+                "EGL (PYOPENGL_PLATFORM=egl) or GLX under Wayland."
+            ) from exc
+        viewer.set_model(self._model)
+        if self._num_envs > MAX_RENDER_WORLDS:
+            viewer.set_visible_worlds(list(range(MAX_RENDER_WORLDS)))
+        viewer.set_world_offsets((float(spacing), float(spacing), 0.0))
+        self._viewer = viewer
+        self._render_config = config
+
+    def _require_viewer(self, operation: str) -> Any:
+        if self._viewer is None:
+            raise RuntimeError(f"newton {operation} requires init_renderer first")
+        return self._viewer
+
+    def _render_viewer_frame(self, viewer: Any) -> None:
+        self._require_state("render")
+        viewer.begin_frame(float(self._time_cache[0]))
+        viewer.log_state(self._state)
+        viewer.end_frame()
+
+    def render(self) -> None:
+        viewer = self._require_viewer("render")
+        self._render_viewer_frame(viewer)
+        if not viewer.is_running():
+            raise RenderClosedError("newton render window was closed")
+
+    def capture_video_frame(self) -> np.ndarray:
+        viewer = self._require_viewer("capture_video_frame")
+        self._render_viewer_frame(viewer)
+        return np.asarray(viewer.get_frame().numpy(), dtype=np.uint8)
 
     def get_physics_state(self) -> np.ndarray:
         self._require_state("get_physics_state")
@@ -842,6 +997,13 @@ class NewtonBackend(SimBackend):
         )
 
     def close(self) -> None:
+        if self._viewer is not None:
+            viewer = self._viewer
+            self._viewer = None
+            try:
+                viewer.close()
+            except Exception:  # teardown must not mask the primary lifecycle
+                logger.debug("newton viewer close failed", exc_info=True)
         self._closed = True
         self.cleanup_scene_assets()
 

--- a/src/unisim/backend/newton/dependencies.py
+++ b/src/unisim/backend/newton/dependencies.py
@@ -39,6 +39,67 @@ _MODULES = {
 }
 _INSTALL_HINT = "Install the isolated runtime with `uv sync --extra newton`."
 
+# Native ViewerGL rendering needs GUI libraries that must stay out of the
+# pure-training environment; they ship in the separate ``newton-render``
+# extra (Newton pins the same floors under its own ``examples`` extra).
+_RENDER_REQUIREMENTS: dict[str, tuple[tuple[int, ...], tuple[int, ...] | None]] = {
+    "pyglet": ((2, 1, 6), (3, 0, 0)),
+    "imgui-bundle": ((1, 92, 0), None),
+}
+_RENDER_MODULES = {"pyglet": "pyglet", "imgui-bundle": "imgui_bundle"}
+_RENDER_INSTALL_HINT = (
+    "Install them with `uv sync --extra newton --extra newton-render`."
+)
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for token in version.replace("-", ".").split("."):
+        if not token.isdigit():
+            break
+        parts.append(int(token))
+    return tuple(parts)
+
+
+def _render_dependency_problem(distribution: str) -> str | None:
+    module_name = _RENDER_MODULES[distribution]
+    if find_spec(module_name) is None:
+        return f"{distribution} is not installed"
+    minimum, maximum = _RENDER_REQUIREMENTS[distribution]
+    try:
+        installed = _version_tuple(metadata.version(distribution))
+    except metadata.PackageNotFoundError:
+        return f"{distribution} is not installed"
+    if installed < minimum:
+        return f"{distribution}>={'.'.join(str(p) for p in minimum)} is required, found {installed}"
+    if maximum is not None and installed >= maximum:
+        return f"{distribution}<{'.'.join(str(p) for p in maximum)} is required, found {installed}"
+    return None
+
+
+def newton_render_dependencies_available() -> bool:
+    """Probe the native viewer stack without importing any GUI module."""
+    return all(
+        _render_dependency_problem(distribution) is None
+        for distribution in _RENDER_REQUIREMENTS
+    )
+
+
+def require_newton_render_dependencies() -> None:
+    """Fail closed unless Newton's native viewer stack is importable."""
+    problems = [
+        problem
+        for distribution in _RENDER_REQUIREMENTS
+        if (problem := _render_dependency_problem(distribution)) is not None
+    ]
+    if problems:
+        raise NewtonDependencyError(
+            "newton native rendering requires the viewer dependencies "
+            "(pyglet>=2.1.6,<3, imgui-bundle>=1.92.0): "
+            + "; ".join(problems)
+            + f". {_RENDER_INSTALL_HINT}"
+        )
+
 
 def newton_dependencies_available() -> bool:
     """Probe the Newton stack without importing any engine module."""
@@ -81,4 +142,6 @@ __all__ = [
     "PINNED_DISTRIBUTIONS",
     "load_newton_dependencies",
     "newton_dependencies_available",
+    "newton_render_dependencies_available",
+    "require_newton_render_dependencies",
 ]

--- a/src/unisim/backend/newton/playback.py
+++ b/src/unisim/backend/newton/playback.py
@@ -1,0 +1,113 @@
+"""Cold-path native ViewerGL playback bridge for the Newton adapter.
+
+Rendering happens only on the play/eval path; the training hot path never
+touches this module.  Headless offscreen rendering still needs a GL context:
+on Linux hosts without a display server use EGL (``PYOPENGL_PLATFORM=egl``);
+under Wayland Newton forces GLX for its pyglet window.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+from os import PathLike
+from typing import Any, TypeVar
+
+import numpy as np
+
+from unisim.backend.playback_common import env_cfg_value, write_playback_video
+
+ObsT = TypeVar("ObsT")
+
+NEWTON_NATIVE_RENDERER = "newton-viewer-gl"
+MUJOCO_SNAPSHOT_RENDERER = "mujoco-snapshot"
+
+# Native playback renders a bounded number of env worlds; the offline MuJoCo
+# snapshot path stays the way to visualize larger batches.
+MAX_RENDER_WORLDS = 16
+
+
+def display_available() -> bool:
+    """Return whether a display is reachable for the interactive viewer."""
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def run_newton_native_playback(
+    *,
+    backend: Any,
+    env: Any,
+    initialize: Callable[[], ObsT],
+    step: Callable[[ObsT], ObsT],
+    num_steps: int | None,
+    output_video: str | PathLike[str] | None,
+    render_spacing: float | None,
+    headless: bool,
+    record_video: bool,
+    camera_kwargs: dict[str, Any] | None,
+) -> str | None:
+    """Drive native ViewerGL playback for an env wrapper (genesis semantics)."""
+    if record_video and not headless:
+        raise ValueError("newton native video recording requires headless=true.")
+
+    if headless or record_video:
+        if num_steps is None:
+            raise ValueError("newton captured playback requires a finite num_steps value.")
+        if record_video and output_video is None:
+            raise ValueError("newton native video recording requires an output_video path.")
+
+        backend.init_renderer(
+            spacing=float(render_spacing) if render_spacing is not None else 1.0,
+            headless=headless,
+            capture=True,
+            width=1280,
+            height=720,
+            camera_kwargs=dict(camera_kwargs or {}),
+        )
+
+        obs = initialize()
+        frames: list[np.ndarray] | None = [] if record_video else None
+        for _ in range(num_steps):
+            obs = step(obs)
+            frame = np.asarray(backend.capture_video_frame(), dtype=np.uint8)
+            if frames is not None:
+                frames.append(frame.copy())
+
+        if not record_video:
+            return None
+
+        assert output_video is not None
+        assert frames is not None
+        ctrl_dt = float(env_cfg_value(env, "ctrl_dt", 1.0 / 60.0))
+        write_playback_video(str(output_video), frames, fps=int(1.0 / ctrl_dt))
+        return str(output_video)
+
+    backend.init_renderer(
+        spacing=float(render_spacing) if render_spacing is not None else 1.0,
+        headless=False,
+        camera_kwargs=dict(camera_kwargs or {}),
+    )
+    obs = initialize()
+    last_render_time = time.perf_counter()
+    render_dt = 1.0 / 60.0
+    steps_run = 0
+
+    while num_steps is None or steps_run < num_steps:
+        obs = step(obs)
+        current_time = time.perf_counter()
+        elapsed = current_time - last_render_time
+        if elapsed < render_dt:
+            time.sleep(render_dt - elapsed)
+        last_render_time = time.perf_counter()
+        backend.render()
+        steps_run += 1
+    return None
+
+
+__all__ = [
+    "MUJOCO_SNAPSHOT_RENDERER",
+    "MAX_RENDER_WORLDS",
+    "NEWTON_NATIVE_RENDERER",
+    "display_available",
+    "run_newton_native_playback",
+]

--- a/tests/test_newton_contract.py
+++ b/tests/test_newton_contract.py
@@ -128,7 +128,19 @@ def test_contact_found_flags_empty_contacts_are_zero() -> None:
     assert flags.tolist() == [0.0]
 
 
-def test_newton_play_render_plan_record() -> None:
+def _patch_render_probes(monkeypatch: pytest.MonkeyPatch, *, native: bool, display: bool) -> None:
+    monkeypatch.setattr(
+        "unisim.backend.newton.backend.newton_render_dependencies_available",
+        lambda: native,
+    )
+    monkeypatch.setattr(
+        "unisim.backend.newton.backend.display_available",
+        lambda: display,
+    )
+
+
+def test_newton_play_render_plan_record_native_renderer(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_render_probes(monkeypatch, native=True, display=False)
     plan = NewtonBackend.resolve_play_render_plan(
         play_render_mode="record", play_steps=24, output_video="play.mp4"
     )
@@ -137,6 +149,20 @@ def test_newton_play_render_plan_record() -> None:
     assert plan.record_video
     assert plan.num_steps == 24
     assert plan.output_video == "play.mp4"
+    assert plan.renderer == "newton-viewer-gl"
+
+
+def test_newton_play_render_plan_record_snapshot_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_render_probes(monkeypatch, native=False, display=False)
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="record", play_steps=24, output_video="play.mp4"
+    )
+    assert plan.mode == "record"
+    assert plan.headless
+    assert plan.record_video
+    assert plan.renderer == "mujoco-snapshot"
 
 
 def test_newton_play_render_plan_none_is_inert() -> None:
@@ -148,37 +174,192 @@ def test_newton_play_render_plan_none_is_inert() -> None:
     assert not plan.record_video
     assert plan.num_steps is None
     assert plan.output_video is None
+    assert plan.renderer is None
 
 
-@pytest.mark.parametrize("mode", ["auto", "interactive"])
-def test_newton_play_render_plan_rejects_auto_and_interactive(mode: str) -> None:
-    with pytest.raises(NotImplementedError, match="newton playback"):
+def test_newton_play_render_plan_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_render_probes(monkeypatch, native=True, display=True)
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="interactive", play_steps=None, output_video=None
+    )
+    assert plan.mode == "interactive"
+    assert not plan.headless
+    assert not plan.record_video
+    assert plan.num_steps is None
+    assert plan.output_video is None
+    assert plan.renderer == "newton-viewer-gl"
+
+
+def test_newton_play_render_plan_interactive_requires_render_deps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_render_probes(monkeypatch, native=False, display=True)
+    with pytest.raises(NotImplementedError, match="newton-render"):
         NewtonBackend.resolve_play_render_plan(
-            play_render_mode=mode, play_steps=10, output_video="play.mp4"
+            play_render_mode="interactive", play_steps=None, output_video=None
         )
 
 
+def test_newton_play_render_plan_interactive_requires_display(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_render_probes(monkeypatch, native=True, display=False)
+    with pytest.raises(NotImplementedError, match="DISPLAY"):
+        NewtonBackend.resolve_play_render_plan(
+            play_render_mode="interactive", play_steps=None, output_video=None
+        )
+
+
+def test_newton_play_render_plan_auto_with_display(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_render_probes(monkeypatch, native=True, display=True)
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="auto", play_steps=None, output_video=None
+    )
+    assert plan.mode == "interactive"
+    assert plan.renderer == "newton-viewer-gl"
+
+
+def test_newton_play_render_plan_auto_without_display_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_render_probes(monkeypatch, native=False, display=False)
+    plan = NewtonBackend.resolve_play_render_plan(
+        play_render_mode="auto", play_steps=12, output_video="play.mp4"
+    )
+    assert plan.mode == "record"
+    assert plan.headless
+    assert plan.record_video
+    assert plan.renderer == "mujoco-snapshot"
+
+
 @pytest.mark.parametrize("play_steps", [None, 0, -3])
-def test_newton_play_render_plan_requires_positive_steps(play_steps: int | None) -> None:
+def test_newton_play_render_plan_requires_positive_steps(
+    monkeypatch: pytest.MonkeyPatch, play_steps: int | None
+) -> None:
+    _patch_render_probes(monkeypatch, native=False, display=False)
     with pytest.raises(ValueError, match="play_steps"):
         NewtonBackend.resolve_play_render_plan(
             play_render_mode="record", play_steps=play_steps, output_video="play.mp4"
         )
 
 
-def test_newton_play_render_plan_requires_output_video() -> None:
+def test_newton_play_render_plan_requires_output_video(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_render_probes(monkeypatch, native=False, display=False)
     with pytest.raises(ValueError, match="output video"):
         NewtonBackend.resolve_play_render_plan(
             play_render_mode="record", play_steps=10, output_video=None
         )
 
 
-def test_newton_play_capabilities_declare_physics_state_playback() -> None:
+def test_newton_play_capabilities_follow_render_deps(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = NewtonBackend.__new__(NewtonBackend)
+    monkeypatch.setattr(
+        "unisim.backend.newton.backend.newton_render_dependencies_available",
+        lambda: True,
+    )
+    capabilities = backend.get_play_capabilities()
+    assert capabilities.supports_physics_state_playback
+    assert capabilities.supports_native_interactive_renderer
+    assert capabilities.supports_native_video_capture
+    monkeypatch.setattr(
+        "unisim.backend.newton.backend.newton_render_dependencies_available",
+        lambda: False,
+    )
     capabilities = backend.get_play_capabilities()
     assert capabilities.supports_physics_state_playback
     assert not capabilities.supports_native_interactive_renderer
     assert not capabilities.supports_native_video_capture
+
+
+def test_newton_log_playback_plan_reports_renderer(capsys: pytest.CaptureFixture) -> None:
+    from unisim.backend.base import BackendPlayRenderPlan, log_playback_plan
+
+    plan = BackendPlayRenderPlan(
+        mode="record",
+        headless=True,
+        record_video=True,
+        num_steps=5,
+        output_video="play.mp4",
+        renderer="newton-viewer-gl",
+    )
+    log_playback_plan(plan)
+    out = capsys.readouterr().out
+    assert "newton-viewer-gl" in out
+
+
+def test_newton_render_dependency_probe_is_fail_closed_when_extra_absent() -> None:
+    from unisim.backend.newton.dependencies import (
+        newton_render_dependencies_available,
+        require_newton_render_dependencies,
+    )
+
+    if newton_render_dependencies_available():
+        pytest.skip("newton render extra is installed in this environment")
+    with pytest.raises(NewtonDependencyError, match="newton-render"):
+        require_newton_render_dependencies()
+
+
+def test_newton_init_renderer_fails_closed_without_render_deps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise() -> None:
+        raise NewtonDependencyError("missing viewer deps")
+
+    monkeypatch.setattr(
+        "unisim.backend.newton.backend.require_newton_render_dependencies", _raise
+    )
+    backend = NewtonBackend.__new__(NewtonBackend)
+    backend._viewer = None
+    backend._render_config = None
+    with pytest.raises(NewtonDependencyError, match="missing viewer deps"):
+        backend.init_renderer(headless=True, capture=True)
+
+
+def test_newton_native_playback_validates_before_renderer_init() -> None:
+    from unisim.backend.newton.playback import run_newton_native_playback
+
+    backend = object()  # validation must run before any backend method is touched
+    with pytest.raises(ValueError, match="headless=true"):
+        run_newton_native_playback(
+            backend=backend,
+            env=None,
+            initialize=lambda: None,
+            step=lambda obs: obs,
+            num_steps=5,
+            output_video="play.mp4",
+            render_spacing=None,
+            headless=False,
+            record_video=True,
+            camera_kwargs=None,
+        )
+    with pytest.raises(ValueError, match="num_steps"):
+        run_newton_native_playback(
+            backend=backend,
+            env=None,
+            initialize=lambda: None,
+            step=lambda obs: obs,
+            num_steps=None,
+            output_video="play.mp4",
+            render_spacing=None,
+            headless=True,
+            record_video=True,
+            camera_kwargs=None,
+        )
+    with pytest.raises(ValueError, match="output_video"):
+        run_newton_native_playback(
+            backend=backend,
+            env=None,
+            initialize=lambda: None,
+            step=lambda obs: obs,
+            num_steps=5,
+            output_video=None,
+            render_spacing=None,
+            headless=True,
+            record_video=True,
+            camera_kwargs=None,
+        )
 
 
 def test_base_set_physics_state_fails_closed_by_default() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -733,6 +733,35 @@ wheels = [
 ]
 
 [[package]]
+name = "imgui-bundle"
+version = "1.92.900"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/47/ff477f7258baddf0c02bbcf6406099c7ed78ebd63f3b9cebce899e6cf79a/imgui_bundle-1.92.900.tar.gz", hash = "sha256:1476409b76c7f600d0da472aed87e96382444df50695280b3ed9acd5065cb6c2", size = 48942607, upload-time = "2026-08-14T15:03:28.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/29/adcc7c20b3b221d8ccb9cdef57c64b8bf65edfa47ca68d0b97d1df073c37/imgui_bundle-1.92.900-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a48a77015376b92da6f1a8571d0cbedda2c08c04ba6cfb9c1041e63087e1bc0a", size = 10470836, upload-time = "2026-08-14T15:02:20.605Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/63/754f39d5883f9672e979d63f38bbd605ffbad6cf54204241112c9de0c24d/imgui_bundle-1.92.900-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:465a27bd3e47652d6775d7b2b82c44f5b5e335c1ebe9748d0f41508334f5bec5", size = 12436149, upload-time = "2026-08-14T15:02:22.988Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2c/08614c47b9c3fcb3a43370eff61e1ee948359bd9ede9a4c52783f6201986/imgui_bundle-1.92.900-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a0a9cc025bf8eef19d8a44dbc9c588fb46a55d5ee83c039c4e09f928f609a710", size = 13566113, upload-time = "2026-08-14T15:02:29.185Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/da/2b5f2010262934994d9e856ff47e5d0068a817fa603658b6fc158bbae070/imgui_bundle-1.92.900-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:888648b11a74cdbd933d7937d546c2f69af2515cba1c4d542bcb3c7b435e5e41", size = 13491234, upload-time = "2026-08-14T15:02:31.309Z" },
+    { url = "https://files.pythonhosted.org/packages/00/57/f93e27495ac8eb42a537b1f4ae7a1f2febeb0650f9358ee37271e533ddca/imgui_bundle-1.92.900-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:355df4c828705e64fbc6918bc9fae6fe0a2bd5915076187c70f6a98ba090e244", size = 14424930, upload-time = "2026-08-14T15:02:33.38Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c9/6542979fa31be264acfc29c1b327410ab1ad0731be411c002a2e0a865706/imgui_bundle-1.92.900-cp311-cp311-win_amd64.whl", hash = "sha256:d4ce5f75018359c296cda0fca0b7cba81dbec455a7af0efc5052d7a63a2ccaaf", size = 11414926, upload-time = "2026-08-14T15:02:35.834Z" },
+    { url = "https://files.pythonhosted.org/packages/93/2c/aaa6fc7f5103d00b4912f8c7cabf9a2a115b2c9b26288a11a886f16e21e0/imgui_bundle-1.92.900-cp311-cp311-win_arm64.whl", hash = "sha256:992a566b9323e5ea56028eefca4573f4341922a436555950d0caa6256da6dd48", size = 11005607, upload-time = "2026-08-14T15:02:37.767Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f5/65afb7315809d547579a0f887564948bffaa1e6dfc76d52225a8a91fa47f/imgui_bundle-1.92.900-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a9ebef3f6a310e0c30b94bb7893c97727e85c12d829ea23fd39b3e5750fb22be", size = 10466178, upload-time = "2026-08-14T15:02:40.333Z" },
+    { url = "https://files.pythonhosted.org/packages/59/87/c4411c33af69a76ea6652fac544974bf70d0f0af1564bdaa999832e27dbe/imgui_bundle-1.92.900-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:41432897d2ed5b7f5641434b644bef1cf81d163453d2ee2716715ca2e7e4f422", size = 12400792, upload-time = "2026-08-14T15:02:42.75Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e9/b688ff0c634302519345ee7b71d621bfb9f1ffd77339a40888d064f0456c/imgui_bundle-1.92.900-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6a0134ee4e4e0f6884d91534cb394c822998ca9d8e79c42afc3b3163a55e2ee4", size = 13551616, upload-time = "2026-08-14T15:02:45.132Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fd/b6413aa238d384f9d5545cf52cd8b604b4ecaa4197ef62a8d640cfe27655/imgui_bundle-1.92.900-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a84d8c0efb49cde2e41c77be003b825e9f8145b38dfbbbc3123fe1687de4c780", size = 13454620, upload-time = "2026-08-14T15:02:47.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/da/64b451dec41d01b9b916e6ef6ccab960c989bef9639f37b12d9406d5d526/imgui_bundle-1.92.900-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:90d07764c532a124379bba32517f0afb18160015065a76ede48825098c5e13f3", size = 14408387, upload-time = "2026-08-14T15:02:49.907Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d6/be48072268fa3037ebe950525a637ad86b9b21c5317865933964f9d10c2b/imgui_bundle-1.92.900-cp312-cp312-win_amd64.whl", hash = "sha256:38d7a46fcda76bd221aafae58c1b80b53143304a6bda1d1782f917be3a851b0b", size = 11379834, upload-time = "2026-08-14T15:02:51.988Z" },
+    { url = "https://files.pythonhosted.org/packages/35/21/b0f8c8b60fbd6d89f589a486dba70aac66506917b33e8950921ff466c64f/imgui_bundle-1.92.900-cp312-cp312-win_arm64.whl", hash = "sha256:5dd8bf63a2ffd32998021d68cd4249e5da5060d9f3b7e69dbd2ace5398606b59", size = 10986018, upload-time = "2026-08-14T15:02:54.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b1/997a598fc0b9e4d7a786493e41d133e1be6bafa6246e344dcc2c5206b2ee/imgui_bundle-1.92.900-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:878ab97e631b06421538940b973ae45157e146787627c27a31c827c52e9dfc45", size = 10465494, upload-time = "2026-08-14T15:02:56.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1d/60c31f347a6970399ec8c0ff636cac93778108ae1e800f8fae75465619bb/imgui_bundle-1.92.900-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:85cc0cd481455233670c0a7ab42dc1210a4c48d3c36bb83d4decf38730b964d9", size = 12400575, upload-time = "2026-08-14T15:02:58.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/65/0b3455db652cc8b85064292d4cd6d2ec828415d18bd709511672655aa978/imgui_bundle-1.92.900-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:04bbf81ff81d9b0fce55cc78522cea16b611642779861e3f42e8daae44d4037f", size = 13551340, upload-time = "2026-08-14T15:03:00.689Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7f/33806aa5280ef05a4a34afc0db9765e88224ca7c0cf41f1dd2facc4e9169/imgui_bundle-1.92.900-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:37a45e09cd105c242497da7d1a37591c1993ab3614ffb9a0b3c74a7d1d5201fe", size = 13454360, upload-time = "2026-08-14T15:03:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ad/2557bde98d7172c99688626ec266912b2bebaa6e81eac79f874fe9a75ef6/imgui_bundle-1.92.900-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f6ebd02420860e0040bbd1f3f9b04c69b5ec1fc2b51704b97e52e4400644b303", size = 14408281, upload-time = "2026-08-14T15:03:04.928Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b6/7c274964ed0bb151c6397a82d302e0e5ee44db3501e07f6633d647116e43/imgui_bundle-1.92.900-cp313-cp313-win_amd64.whl", hash = "sha256:914c348555cb3b2f1bf11c1d4d6b94d88a3b7136dc31271edf284e06430ddb3e", size = 11379369, upload-time = "2026-08-14T15:03:07.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/13/f5004791bebb1b71e13a0b533a12bda4ddca32d3f2397ec4a607e4a0461f/imgui_bundle-1.92.900-cp313-cp313-win_arm64.whl", hash = "sha256:8a83c2d90ea3751f514f5f1a1e7a95c18f0cdbaa453dcb04dfcb63ce15456e77", size = 10985728, upload-time = "2026-08-14T15:03:09.433Z" },
+]
+
+[[package]]
 name = "importlib-resources"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2748,6 +2777,10 @@ newton = [
     { name = "newton" },
     { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
 ]
+newton-render = [
+    { name = "imgui-bundle" },
+    { name = "pyglet" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2760,6 +2793,7 @@ dev = [
 requires-dist = [
     { name = "drake-uni", marker = "extra == 'drake'", specifier = "==0.1.0" },
     { name = "genesis-world", marker = "extra == 'genesis'", specifier = "==1.3.3" },
+    { name = "imgui-bundle", marker = "extra == 'newton-render'", specifier = ">=1.92.0" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5" },
     { name = "mujoco", marker = "extra == 'newton'", specifier = "==3.11.0" },
@@ -2768,10 +2802,11 @@ requires-dist = [
     { name = "mujoco-warp", marker = "extra == 'newton'", specifier = "==3.11.0" },
     { name = "newton", marker = "extra == 'newton'", specifier = "==1.5.1" },
     { name = "numpy" },
+    { name = "pyglet", marker = "extra == 'newton-render'", specifier = ">=2.1.6,<3" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
     { name = "warp-lang", marker = "extra == 'newton'", specifier = "==1.16.0" },
 ]
-provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "newton", "isaacgym", "isaacsim"]
+provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "newton", "newton-render", "isaacgym", "isaacsim"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

承接 child issue #33（UniLab roadmap [Motphys/UniLab#1513](https://github.com/Motphys/UniLab/issues/1513)），为 `NewtonBackend` 接入 Newton 自带渲染器 `newton.viewer.ViewerGL`：

- **离线 record（native）**：`ViewerGL(headless=True)` + `get_frame()` 帧读取写 mp4（renderer 诊断名 `newton-viewer-gl`）；未安装渲染依赖时回退既有 MuJoCo 快照路径（`mujoco-snapshot`）。
- **交互式 interactive**：`ViewerGL()` 窗口模式，60Hz 节流循环，关窗经 `RenderClosedError` 正常退出（genesis 惯例）。
- **`resolve_play_render_plan` 新语义**：`auto` 有显示→interactive / 无显示→record；`interactive` 缺依赖或无显示时 fail-closed（报错含 extra 安装命令与 DISPLAY/EGL 约束）；`record`/`none` 语义保持。
- **依赖**：新 optional extra `newton-render`（`pyglet>=2.1.6,<3` + `imgui-bundle>=1.92.0`，与上游 examples extra 对齐），不污染纯训练环境；依赖探针纯 `find_spec`，不 import GUI 模块。
- **contract**：`BackendPlayRenderPlan` 新增纯诊断字段 `renderer: str | None`（frozen dataclass 默认值，其他后端不受影响），`log_playback_plan` 输出 `via <renderer>`；consumers 不得据此分支。
- 渲染只在 play/eval 冷路径；超过 16 个 env 时只渲染前 16 个 world。

## Validation

- `make check` 于最终 head `722baf0`：ruff 全过，**97 passed / 7 skipped**（基线 85/4；新增 plan 解析、fail-closed、renderer 选择、capabilities 动态跟随等 fake/mock 测试）。
- `uv lock --check` 通过。
- 真机（RTX 4090，X display :0，newton 1.5.1 + mujoco-warp 3.11 + torch 2.8.0+cu128，UniLab 侧 editable 集成）：
  - `uv run eval --algo sac --task g1_walk_flat --sim newton --load-run 2026-09-06_01-21-36_newton --render-mode record`（`PYOPENGL_PLATFORM=egl`）：plan 输出 `via newton-viewer-gl`，生成 800 帧 1280x720 mp4，16 个 world 渲染正常、步态正常。
  - `--render-mode interactive`：ViewerGL 窗口在 :0 持续渲染无报错（交互语义为运行至关窗，同 genesis）。

已知边界：native 路径忽略 `camera_kwargs`（MuJoCo 快照路径仍生效），已写入 `init_renderer` docstring 与 UniLab 文档；headless 离屏仍需 GL context（Linux 无显示服务器 `PYOPENGL_PLATFORM=egl`，Wayland `glx`）。

Closes #33