### PR TITLE
feat: align MuJoCo extras on the 3.11 line and drop extra conflicts (roadmap UniLab#1515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Align all MuJoCo-related extras on the 3.11 line (unilabsim/UniLab#1515,
+  unilabsim/unisim#34): the `mujoco` extra now requires `mujoco~=3.11.0` with
+  `mujoco-uni-runtime==0.5.0` (exact pin — one runtime release carries one
+  prebuilt MuJoCo binding, so a lock bump is gated on wheel availability); the
+  `mjwarp` extra moves from `mujoco-warp==3.10.0.3` to `mujoco-warp~=3.11.0`
+  with `warp-lang==1.16.0`; and the `newton` extra keeps its exact pins.
+  The extras are now jointly resolvable, so the `[tool.uv]` extra conflicts
+  are removed and the MJWarp runtime check accepts the whole
+  `mujoco-warp` 3.11 line instead of one exact version.
 - Add snapshot playback support to the Newton adapter: `get_physics_state` /
   `set_physics_state` ([time, qpos, qvel] host-cache layout), record/none
   `resolve_play_render_plan` semantics, and `run_playback` through the shared
@@ -15,9 +24,9 @@
   other contact-sensor configurations remain fail-closed.
 - Rework the README around the project overview, UniLab relationship,
   installation, and quick start, and add the Chinese `README_zh.md`.
-- Add the isolated Newton 1.5.1 runtime extra and a metadata/import probe;
-  Newton's MuJoCo-Warp 3.11.0 line is documented as mutually exclusive with
-  the existing MJWarp 3.10.0.3 extra.
+- Add the Newton 1.5.1 runtime extra and a metadata/import probe on the
+  MuJoCo-Warp 3.11 line (the 3.11 alignment above later lifted the initial
+  mutual exclusion with the `mjwarp` extra).
 - Add fail-closed Newton nconmax/njmax capacity sampling and overflow
   diagnostics for the forthcoming adapter.
 - Add the Newton `SimBackend` adapter with explicit CUDA placement, cold-path

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ installations at construction time. See
 [`docs/support-matrix.md`](docs/support-matrix.md) for the full adapter
 support matrix.
 
-The `newton` extra is isolated from `mjwarp`: it pins Newton 1.5.1 with the
-MuJoCo-Warp 3.11.0 line, while `mjwarp` uses 3.10.0.3. Install only one of
-these two extras in an environment.
+The `mujoco`, `mjwarp`, and `newton` extras share the MuJoCo 3.11 /
+MuJoCo-Warp 3.11 / warp-lang 1.16.0 line and can be installed together in one
+environment. `newton` keeps exact pins (`newton==1.5.1` with its coupled
+runtimes), while `mjwarp` follows the 3.11 line with `mujoco-warp~=3.11.0`.
 
 ## Quick start
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -31,8 +31,10 @@ pip install "unisim-core[mujoco]"      # 需要时再加装引擎 extra
 适配器在构造时发现独立的 worker 安装。完整的适配器支持矩阵见
 [`docs/support-matrix.md`](docs/support-matrix.md)。
 
-`newton` extra 与 `mjwarp` 隔离：前者固定 Newton 1.5.1 和 MuJoCo-Warp
-3.11.0，后者仍使用 3.10.0.3；同一环境不要同时安装两个 extra。安装后可运行
+`mujoco`、`mjwarp`、`newton` 三个 extra 共享 MuJoCo 3.11 / MuJoCo-Warp 3.11 /
+warp-lang 1.16.0 版本线，可以安装在同一环境中。`newton` 保留精确版本固定
+（`newton==1.5.1` 及其耦合运行时）,`mjwarp` 则通过 `mujoco-warp~=3.11.0`
+跟随 3.11 版本线。安装后可运行
 `uv run scripts/check_newton_runtime.py` 做元数据探针，必要时追加 `--import`
 显式导入原生运行时。
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -16,10 +16,11 @@ runtime discovery and raises an adapter-specific, actionable error when the
 runtime is unavailable. The matrix is an adapter/API support statement, not a
 claim that every host has every vendor SDK or GPU capability.
 
-Newton uses a separate MuJoCo-Warp line from the existing MJWarp extra:
-`newton` pins `newton==1.5.1`, `mujoco-warp==3.11.0`, `mujoco==3.11.0`, and
-`warp-lang==1.16.0`, while `mjwarp` remains on `mujoco-warp==3.10.0.3`.
-These extras are intentionally mutually exclusive in one environment. Run
+The MuJoCo-related extras share one version line (MuJoCo 3.11 / MuJoCo-Warp
+3.11 / warp-lang 1.16.0) and are jointly installable: `mjwarp` tracks the line
+with `mujoco-warp~=3.11.0`, while `newton` keeps exact upstream-coupled pins
+(`newton==1.5.1`, `mujoco-warp==3.11.0`, `mujoco==3.11.0`,
+`warp-lang==1.16.0`). Run
 `uv run scripts/check_newton_runtime.py` after installation for a metadata-only
 probe; add `--import` when the native runtime should be imported explicitly.
 The adapter's cold-path calibration samples solver counts and raises an explicit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,6 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 module-name = "unisim"
 
-[tool.uv]
-# The Newton/MuJoCo-Warp 3.11 line cannot coexist with the historical MJWarp
-# 3.10.0.3 line in one environment. Keep both extras available while making
-# the resolver fail with an explicit, actionable conflict when selected
-# together.
-conflicts = [
-    [{ extra = "mjwarp" }, { extra = "newton" }],
-    [{ extra = "mujoco" }, { extra = "newton" }],
-]
-
 [project]
 name = "unisim-core"
 version = "1.1.0"
@@ -38,15 +28,23 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-mujoco = ["mujoco>=3.5", "mujoco-uni-runtime==0.4.0"]
+# MuJoCo 3.11 alignment (unilabsim/UniLab#1515): the mujoco, mjwarp, and
+# newton extras share one MuJoCo 3.11 / MuJoCo-Warp 3.11 / warp-lang 1.16.0
+# line and are jointly installable. The `mujoco` bound is a compatible-release
+# specifier; `uv.lock` pins the exact MuJoCo version, and the
+# `mujoco-uni-runtime` pin is exact because each runtime release carries
+# exactly one prebuilt MuJoCo binding (its wheels bind mujoco==3.11.0). A
+# MuJoCo default bump therefore requires a new runtime release, and a
+# downstream lock bump is gated on that release's wheel availability.
+mujoco = ["mujoco~=3.11.0", "mujoco-uni-runtime==0.5.0"]
 motrix = ["motrixsim-core==0.8.2"]
 drake = ["drake-uni==0.1.0"]
-mjwarp = ["mujoco-warp==3.10.0.3", "warp-lang>=1.14.0"]
+mjwarp = ["mujoco-warp~=3.11.0", "warp-lang==1.16.0"]
 genesis = ["genesis-world==1.3.3"]
-# Newton 1.5.1's MuJoCo solver line is intentionally isolated from the
-# historical mjwarp extra above: Newton's sim extra requires the 3.11 line,
-# while mjwarp remains pinned to 3.10.0.3. Do not install both extras in one
-# environment.
+# Newton's upstream coupling is precise, so these stay exact pins. They sit on
+# the same 3.11 line as the extras above: newton 1.5.1 requires
+# warp-lang>=1.16.0, and mujoco-warp 3.11.0 accepts warp-lang>=1.14 and
+# mujoco>=3.9, so warp-lang==1.16.0 satisfies both.
 newton = [
     "newton==1.5.1",
     "mujoco-warp==3.11.0",

--- a/scripts/check_newton_runtime.py
+++ b/scripts/check_newton_runtime.py
@@ -70,8 +70,7 @@ def main() -> int:
         print("Newton runtime probe: FAILED")
         for diagnostic in diagnostics:
             print(f"- {diagnostic}")
-        print("Install the isolated stack with: uv sync --extra newton")
-        print("Do not combine it with: uv sync --extra mjwarp")
+        print("Install the pinned stack with: uv sync --extra newton")
         return 1
     print("Newton runtime probe: OK")
     for distribution, version in PINNED_DISTRIBUTIONS.items():

--- a/src/unisim/backend/mjwarp/dependencies.py
+++ b/src/unisim/backend/mjwarp/dependencies.py
@@ -23,7 +23,7 @@ class MjwarpDependencies:
 
 
 _REQUIRED_MODULES = ("mujoco", "mujoco_warp", "warp")
-_REQUIRED_MUJOCO_WARP_VERSION = "3.10.0.3"
+_REQUIRED_MUJOCO_WARP_LINE = "3.11"
 _INSTALL_HINT = "Install it with `uv sync --extra mjwarp`."
 
 
@@ -40,10 +40,10 @@ def load_mjwarp_dependencies() -> MjwarpDependencies:
         raise MjwarpDependencyError(
             f"mjwarp backend requires optional dependency 'mujoco-warp'. {_INSTALL_HINT}"
         ) from exc
-    if installed_version != _REQUIRED_MUJOCO_WARP_VERSION:
+    if not installed_version.startswith(f"{_REQUIRED_MUJOCO_WARP_LINE}."):
         raise MjwarpDependencyError(
-            "mjwarp backend requires exact mujoco-warp version "
-            f"{_REQUIRED_MUJOCO_WARP_VERSION}, found {installed_version}. {_INSTALL_HINT}"
+            "mjwarp backend requires the mujoco-warp "
+            f"{_REQUIRED_MUJOCO_WARP_LINE} line, found {installed_version}. {_INSTALL_HINT}"
         )
     try:
         mujoco = importlib.import_module("mujoco")

--- a/src/unisim/backend/newton/dependencies.py
+++ b/src/unisim/backend/newton/dependencies.py
@@ -37,7 +37,7 @@ _MODULES = {
     "mujoco": "mujoco",
     "warp-lang": "warp",
 }
-_INSTALL_HINT = "Install the isolated runtime with `uv sync --extra newton`."
+_INSTALL_HINT = "Install the pinned runtime with `uv sync --extra newton`."
 
 
 def newton_dependencies_available() -> bool:
@@ -57,7 +57,7 @@ def load_newton_dependencies() -> NewtonDependencies:
         if installed != expected:
             raise NewtonDependencyError(
                 f"newton backend requires {distribution}=={expected}, found {installed}. "
-                f"{_INSTALL_HINT} Do not combine the newton extra with mujoco or mjwarp."
+                f"{_INSTALL_HINT}"
             )
     modules: dict[str, Any] = {}
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -6,13 +6,6 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
-conflicts = [[
-    { package = "unisim-core", extra = "mjwarp" },
-    { package = "unisim-core", extra = "newton" },
-], [
-    { package = "unisim-core", extra = "mujoco" },
-    { package = "unisim-core", extra = "newton" },
-]]
 
 [[package]]
 name = "absl-py"
@@ -132,7 +125,7 @@ name = "cffi"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
 wheels = [
@@ -194,9 +187,9 @@ name = "coacd"
 version = "1.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/94/622a380a5c4cac78c1f19379b1d3fa193903f848311c200924309797abf8/coacd-1.0.14-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4cd9e1f327af766f6364e79e384ebfe152780a3d8dbbd09ce0756ec14f9e1256", size = 3426003, upload-time = "2026-08-28T21:53:32.005Z" },
@@ -222,7 +215,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -293,8 +286,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -437,9 +430,9 @@ name = "drake-uni"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/3a/248c89902111de84dd8bbaa947da87f80a4ec6e251197f4b82f6636eb0fc/drake_uni-0.1.0.tar.gz", hash = "sha256:46875ba06685ab73ab9b77a955f04c441c2aef21f8e15a9199a2d2c0ebb328f3", size = 36819, upload-time = "2026-09-02T07:22:39.204Z" }
 wheels = [
@@ -460,10 +453,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "importlib-resources", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "zipp", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "fsspec" },
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
 ]
 
 [[package]]
@@ -481,9 +474,9 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "zipp", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "fsspec" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
 ]
 
 [[package]]
@@ -491,7 +484,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -503,9 +496,9 @@ name = "fast-simplification"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/0a/b943887803aefecd01d30cd150bd2a6f03d90b96886e3befdcc5d4276c98/fast_simplification-0.2.0.tar.gz", hash = "sha256:ed02ea6f4968ec98f963f2d3665dbafd0297ec12aea9e4d0a87c4b3c14d608a8", size = 31865, upload-time = "2026-08-12T19:53:50.49Z" }
 wheels = [
@@ -629,22 +622,21 @@ name = "genesis-world"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "av", version = "17.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "av", version = "18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "coacd" },
     { name = "dracopy" },
     { name = "fast-simplification" },
     { name = "freetype-py" },
     { name = "frozendict" },
-    { name = "gs-madrona", marker = "(platform_machine != 'AMD64' and platform_machine != 'x86_64' and extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (platform_machine != 'AMD64' and platform_machine != 'x86_64' and extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (sys_platform != 'linux' and extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "gs-madrona", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "libigl" },
     { name = "moviepy" },
-    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
-    { name = "mujoco", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-unisim-core-newton'" },
+    { name = "mujoco" },
     { name = "numba" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "opencv-python" },
     { name = "openexr" },
     { name = "pillow" },
@@ -652,8 +644,8 @@ dependencies = [
     { name = "py-cpuinfo" },
     { name = "pycollada" },
     { name = "pydantic" },
-    { name = "pygel3d", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pygel3d", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "pygel3d", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pygel3d", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyglet" },
     { name = "pygltflib" },
     { name = "pymeshlab" },
@@ -661,8 +653,8 @@ dependencies = [
     { name = "pysplashsurf" },
     { name = "quadrants" },
     { name = "rtree" },
-    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tetgen" },
     { name = "trimesh" },
     { name = "vtk" },
@@ -708,9 +700,9 @@ name = "imageio"
 version = "2.37.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pillow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/62/aa770a9307508d2a2a2c62d536a49347bffe9e55322db27838d3c93d0b07/imageio-2.37.4.tar.gz", hash = "sha256:e45cbc5e83502047fb138f7f585f7f105a136a57eea5f4b3cfc6ce1b52720bd3", size = 390173, upload-time = "2026-07-20T05:26:11.369Z" }
@@ -849,12 +841,12 @@ name = "libigl"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/41/8b04eb112af0579790af6a04f7d0ffc9be6827ce44e99495d30c6820e1fc/libigl-2.6.3.tar.gz", hash = "sha256:e2a3ff17b88cae728cb60ea63850131315bb661045a8642db73aea98c91486ab", size = 41273089, upload-time = "2026-09-01T02:47:31.393Z" }
 wheels = [
@@ -999,15 +991,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "cycler", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "fonttools", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pillow", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pyparsing", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1062,16 +1054,16 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "cycler", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "fonttools", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pillow", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -1123,9 +1115,9 @@ version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/2a/8bc5f7dc9ead9577ac9938487b105c10b5c4cbb702f16b3ab61995c21bb1/motrixsim_core-0.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:571292c53d7580c7a83c64071ccd5e5235c9f71acd0a61d35a96a39bf2b24dd9", size = 47126258, upload-time = "2026-06-08T14:29:38.062Z" },
@@ -1154,9 +1146,9 @@ dependencies = [
     { name = "decorator" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pillow" },
     { name = "proglog" },
     { name = "python-dotenv" },
@@ -1168,65 +1160,17 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "absl-py", marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
-    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version < '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version < '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version >= '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version >= '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "glfw", marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version < '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version < '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version == '3.11.*' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version >= '3.12' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pyopengl", marker = "extra == 'extra-11-unisim-core-mjwarp' or extra == 'extra-11-unisim-core-mujoco' or extra != 'extra-11-unisim-core-newton'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/3b/c76837b7fdb007f7605ff783689a0bd23a5a49b065928bec2f1fa7ea3d67/mujoco-3.10.0.tar.gz", hash = "sha256:c9e8d5d87d82204ed5bccc87d843c0a53e75aaf381de2938ec46d04f1ac6e24e", size = 1094987, upload-time = "2026-06-22T17:40:59.904Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ed/9b8df6c801fa25542d4c2dc417063611474a070c4bef52e896fa57726d94/mujoco-3.10.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:c1c9dfb4ba3f1ef14b70968e9cd41b14fa1877f9697369953a471aa17324f443", size = 7745281, upload-time = "2026-06-22T17:39:47.198Z" },
-    { url = "https://files.pythonhosted.org/packages/09/be/3d9a1ecfe3501a84ece0d5824ff67a0933337650fb48b26c8db0b43de0cd/mujoco-3.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c8e4688d87b85be27dfcfdf957f05f1450a99131f9f8b1818613a2e4fd8d7321", size = 19324219, upload-time = "2026-06-22T17:39:49.666Z" },
-    { url = "https://files.pythonhosted.org/packages/03/37/5580b126403510a80a059a66d3ea21f3e55d47960e480e66ff2a7723b514/mujoco-3.10.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4e1e2c0c72200340d413da4211b56a8885a7ed78e893f36d97e5696e8f4af3e", size = 19628590, upload-time = "2026-06-22T17:39:53.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3c/e3768418794c4450c6bef971eaa2314e1fac7d46abc6968b6722b0b654a0/mujoco-3.10.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47a89c371cc171a38eb6c03172aff2f905e54c1261d87b3575a9d77fe3a29a55", size = 20763444, upload-time = "2026-06-22T17:39:56.559Z" },
-    { url = "https://files.pythonhosted.org/packages/af/3c/a3c5121ca9356e78dd1f09ad48e7fa034b91e02124d533e64252c314b646/mujoco-3.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:2f71cb614559cd06a8ce57bd255146e15ccb49ee7dea316aeb895838ba82e1e0", size = 17719988, upload-time = "2026-06-22T17:39:59.614Z" },
-    { url = "https://files.pythonhosted.org/packages/45/bd/c3a4ad6884e60bbbff3d77df75358570bcf9b97ff8d81a0ea3b311b0276e/mujoco-3.10.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:62b7e9faf714f1582e1dd923ba3ea769a939cc572f6d77909752cbb31db5409f", size = 7758349, upload-time = "2026-06-22T17:40:02.329Z" },
-    { url = "https://files.pythonhosted.org/packages/41/69/4c55c05fe602d72be5526d911e6802de1e67ad70c9301f556eef1d78a4bb/mujoco-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b812e0e36e8b2dde8ce4ad9b25e189b658b9c94f5e798aa64783261abb88321", size = 19348907, upload-time = "2026-06-22T17:40:04.634Z" },
-    { url = "https://files.pythonhosted.org/packages/05/19/a8a560f29f7f0137da6d41d633bc892a9e8ebc36af64c31a3db5882d26d8/mujoco-3.10.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0eff9fb64c39c21f5e29f39996c152ed9a2a5c783818b524c77abf41f6e5751", size = 19654107, upload-time = "2026-06-22T17:40:07.594Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/07/a37fc7fa55d38e9225884b80c3d241e669357e83f7e23f80b8860a7e14cd/mujoco-3.10.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5489e18a8dd09da2dd71d28563e17889a2e5a0ad07943ebcaa1446d6c4d4e1dd", size = 20789312, upload-time = "2026-06-22T17:40:10.656Z" },
-    { url = "https://files.pythonhosted.org/packages/82/84/6548d32afc49fb79015a0b98d1119628ce94dd8befb4526c2cd10429e13f/mujoco-3.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:45a27a8982e6f89f09e87e4578a5d3e7c9b5667f3db07052e518993b78c9b3ea", size = 17757305, upload-time = "2026-06-22T17:40:13.448Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a2/4dd9f4cec6ce92f836a8b2de1cc799c4458af1467d7a044ef8014217bdb4/mujoco-3.10.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:47d4a22b7667c60e24e7ef6acb027c13abe9abba9acf17cc8db6fb250ba275ea", size = 7772567, upload-time = "2026-06-22T17:40:16.539Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7d/ebe5342c136de27e0c430ba781f829df2cd66c00ed22627c1964fbd5d7fe/mujoco-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4d35e9d0b13ff9ad3196294a7dac363f1d0cdaa988832d0b687d42d98f4ee29", size = 19380823, upload-time = "2026-06-22T17:40:19.211Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5d/43d1b2b9fe97676e5af03020e132ac497b45a0333a4c61de657d0d52170a/mujoco-3.10.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb7f0d7c148a588f3633020807fc0ec3f3a9aff1f647406e3e0ffe96b05dfd57", size = 19705628, upload-time = "2026-06-22T17:40:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/11/c69199e4123935f98068ab6ab6b35955b4de0f6a91d3f9883805a5789394/mujoco-3.10.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:966d12f88e77e2b188e7530667b519d6963b9b906cff83bab534e5e4279325a0", size = 20904309, upload-time = "2026-06-22T17:40:25.861Z" },
-    { url = "https://files.pythonhosted.org/packages/47/13/07bf2550c7dcd69ee8c7fd1f5c400a4ba2e4ede0a29a463ad3ac4cc9da90/mujoco-3.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:708edb5aceee96f2767b1072641523060043b2c67000e39e6e9797addf073696", size = 17865123, upload-time = "2026-06-22T17:40:28.996Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/a9a19f025d3b323aca9d00e34fdc177e7290c5f23adf6341109a7e961920/mujoco-3.10.0-cp313-cp313-macosx_10_16_x86_64.whl", hash = "sha256:396a49c1baeb4cb1efd1fc213e54baf6d2a5ca42bcd99da82278501a32cb5d42", size = 7772943, upload-time = "2026-06-22T17:40:31.951Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ea/15dfc7cc10f44f46286a0634499f3a63e03269adb4788903f3751e964be0/mujoco-3.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db794d8b8a64e3bb6a0f226a9200293a4890f490c93411fcc531a145f373521b", size = 19381290, upload-time = "2026-06-22T17:40:34.251Z" },
-    { url = "https://files.pythonhosted.org/packages/76/82/ab50abb150805e711e02b7b7424b86bd12297bc5476fb1455ce739fa0d1b/mujoco-3.10.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:720174e7132ccf5f7e9eb86a0855c1b1e93330755f734c21fa58e7bde65bd140", size = 19705727, upload-time = "2026-06-22T17:40:36.968Z" },
-    { url = "https://files.pythonhosted.org/packages/52/49/f6f0c7c54c646adda647aa7495bdc69572419480c37d5cd0bee132ebacd6/mujoco-3.10.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0a5725cc9c9a4da1d5f2b8314ad6d39007e09430ac00aa8d023995ce1f2a3e9", size = 20904596, upload-time = "2026-06-22T17:40:40.423Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ea/53c7bcef3ef4de63563d9536e4fe6728996f0fc13e82040b1614ad0e32d9/mujoco-3.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:928dca15b06161b88153df2dc2f7c141d41f39e08e20d1804df8d53f42d9f62c", size = 17865523, upload-time = "2026-06-22T17:40:43.233Z" },
-]
-
-[[package]]
-name = "mujoco"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "absl-py", marker = "extra == 'extra-11-unisim-core-newton'" },
-    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "glfw", marker = "extra == 'extra-11-unisim-core-newton'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pyopengl", marker = "extra == 'extra-11-unisim-core-newton'" },
+    { name = "absl-py" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.11'" },
+    { name = "glfw" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pyopengl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/2d/290f3f4062eec1c0d5246de0a75f1b18b59a1961081f49ddc97333fc8263/mujoco-3.11.0.tar.gz", hash = "sha256:390856102af9547dfd87cb2791eb105a3d2e00a37323fe9a12ed17e512aff1a6", size = 1139880, upload-time = "2026-07-28T01:23:32.252Z" }
 wheels = [
@@ -1250,58 +1194,43 @@ wheels = [
 
 [[package]]
 name = "mujoco-uni-runtime"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version < '3.11' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version < '3.11' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version == '3.11.*' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mujoco') or (python_full_version >= '3.12' and extra != 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "mujoco" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/75/c4ca9dac2e86858eac44daa5d2b2a4593ffbfcf21d09f4799ddae3071893/mujoco_uni_runtime-0.4.0.tar.gz", hash = "sha256:2d5cc07866eb02cf643dbcbdae837a4f82cd47a60c4f2697650e9e9c1c8fb679", size = 54082, upload-time = "2026-08-24T02:42:37.271Z" }
-
-[[package]]
-name = "mujoco-warp"
-version = "3.10.0.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "absl-py" },
-    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "warp-lang", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/02/1687ee928ea468345546af79dcfd65da9cd5840e16d1e71a244223494e54/mujoco_warp-3.10.0.3.tar.gz", hash = "sha256:f22196465cb1350677f66d8b65aa23bf37d95e150ce3ba3c68ea934ba35e3070", size = 2074757, upload-time = "2026-07-22T15:28:01.367Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/ce/476cf50ec4f76b86b855b861e01f106b330c7d62a61574655cfe90336a07/mujoco_uni_runtime-0.5.0.tar.gz", hash = "sha256:a0c774da3607b6111d7c91155867377f9eb6d91ab6e0bbb97f15247df1ead9d7", size = 55656, upload-time = "2026-09-05T19:29:40.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/a1/a8e616daafb219fccc2d23367894d305e442e2e18bc5e0dd855d9986d979/mujoco_warp-3.10.0.3-py3-none-any.whl", hash = "sha256:9435e5d6a7061af32aecc8da38124bfccceea27fc85176b33b66b7c4b76b4c1a", size = 2152650, upload-time = "2026-07-22T15:27:59.463Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ee/61348995acb39aef26b5a1d9af57d61d6a2d042002063ab1b7bf28b0fdc8/mujoco_uni_runtime-0.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:755146199fcf8958e5dd3b74c32d93419502a6dd89751c445c5fe70cf68a0847", size = 401266, upload-time = "2026-09-05T19:29:23.366Z" },
+    { url = "https://files.pythonhosted.org/packages/87/23/7ff0ccefecbbcfbaffce7e5959ec35023c354813546424eca4ccdc12cabd/mujoco_uni_runtime-0.5.0-cp310-cp310-manylinux_2_35_aarch64.whl", hash = "sha256:3a4d8c9471298b0c30a5526d49fe623aa8a8682001e208ea4bd3421318a9de3d", size = 2332548, upload-time = "2026-09-05T19:29:24.831Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ed/c438dd170d7a6bbbbbc31cf6188ec94bd6e8cdc384e1e1619c6c24e27d7d/mujoco_uni_runtime-0.5.0-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:d00015521610a39a473a15ef350f015914f1b82372a4eae1f580934be44bbb94", size = 2392108, upload-time = "2026-09-05T19:29:26.258Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a9/3cc6a7e31140bb48749a64165698358af4422a8b948293397be4621b81a9/mujoco_uni_runtime-0.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f86a5bc75e1758b05816777b41bb3232015ce1a26d1f63bdb2da4f3b7ae87030", size = 403670, upload-time = "2026-09-05T19:29:27.892Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ed/a66e735512317bd135b2b9c806a882ff9f01f8503ce53b59874a6f4c685e/mujoco_uni_runtime-0.5.0-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:746caa1ed23237ba4a0e2d7d7afb6afa0e3c6223b8000f22bc0c6da64a538fef", size = 2346314, upload-time = "2026-09-05T19:29:29.198Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ad/f8edda197f41b2dee678faca8964cf307e6bfbdc7b2bea6b907f5bf5fdf8/mujoco_uni_runtime-0.5.0-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:3ccc49063dc34f3d657ffa7afe12c62d6a88615edcb2cc21b60ec59272dea3e3", size = 2406269, upload-time = "2026-09-05T19:29:30.476Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/fa/fe3e5173e804ac4eb1acbbd0fc9df81fe079fab7ae3d9813cd92cdf79b23/mujoco_uni_runtime-0.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9597385aaafc77ae7d6f89aedfb677ad9f67a0874afd5962330c08cebbad56b6", size = 396860, upload-time = "2026-09-05T19:29:32.052Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/9d/2b14e54f2a0c70fdd95091f2648f9c50203bc87ac238370f5f51f9dac170/mujoco_uni_runtime-0.5.0-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:61539c6287ca62600836062aefeb458e550f4ea6782d8f24e501027824aac546", size = 2366290, upload-time = "2026-09-05T19:29:33.248Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/25/7633b376c3cadffd35420f7f13a1a35ddfed86cae8842cf1206c3555b516/mujoco_uni_runtime-0.5.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:a0117a107319661dccc6657e3cc0d2545f58eb0f9b0c725acba1d4047f507847", size = 2427155, upload-time = "2026-09-05T19:29:34.677Z" },
+    { url = "https://files.pythonhosted.org/packages/de/33/c4c2d2fb73b43c8a4e331fe065d4f49f1ae70b17d4327255ccb733f917d9/mujoco_uni_runtime-0.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1831182949ace71f48e9ee7c9ef7406b4b1ef2bba9884c87e4932ba92862041b", size = 396959, upload-time = "2026-09-05T19:29:36.208Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1c/ff0cb5a53311f94200a1ecd9645d9e48442b994bb866a04e5c52f3f28537/mujoco_uni_runtime-0.5.0-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:9d22628e59ae205610e1eeba2429c21801cf8ea25d99de6d66733621c44086c2", size = 2365046, upload-time = "2026-09-05T19:29:37.558Z" },
+    { url = "https://files.pythonhosted.org/packages/56/83/df50eae1b379198bf0c2c58d36f768afe30db7dad823b9210d21c6399eb0/mujoco_uni_runtime-0.5.0-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:84f1c81819752622cb794458a731d8b1b98ec2a589380fedf55999b3fe89faed", size = 2427855, upload-time = "2026-09-05T19:29:38.944Z" },
 ]
 
 [[package]]
 name = "mujoco-warp"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "(python_full_version >= '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "mujoco", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.11'" },
+    { name = "mujoco" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "warp-lang" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/02/da883029b3661619651d0e2469ec17df92dd64ca5de25119886d516ee1de/mujoco_warp-3.11.0.tar.gz", hash = "sha256:e9e521a3809b95baa98c44bd4fcaccb035b5c700e2616efc52ebc33d29ae2eef", size = 2075418, upload-time = "2026-07-28T01:21:41.987Z" }
 wheels = [
@@ -1314,10 +1243,10 @@ version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ast-serialize" },
-    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/6a/878cc1097d4035f82bd516658d0c528d2a9955bc7b363afcbd0b07fea11b/mypy-2.3.1.tar.gz", hash = "sha256:47c1b1207258513a9d93495f69c8be9de73916186f0e52703e8c461b7a623419", size = 3992554, upload-time = "2026-08-15T03:03:38.549Z" }
@@ -1388,7 +1317,7 @@ name = "newton"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "warp-lang" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/d6a3e799c25cf04b5ab35b9903cafd09731df123a0c91f4d27caed28d431/newton-1.5.1-py3-none-any.whl", hash = "sha256:a757269fe03ca2e50edb9636b3c7eb91c2d1e359b6e9c992b33dc6d9058b5285", size = 5564220, upload-time = "2026-08-27T20:33:23.381Z" },
@@ -1400,9 +1329,9 @@ version = "0.67.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/90/2544f4e3a61e501d6c9a5418fd4b905323222693d54a02cab0106a0af865/numba-0.67.0.tar.gz", hash = "sha256:cd75aa535b33fa05d9d930b1ae8af9f97a2881e96d72dfb38ec9b78284d9f851", size = 2836515, upload-time = "2026-08-11T23:04:00.174Z" }
 wheels = [
@@ -1589,8 +1518,6 @@ version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
-    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
-    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
 ]
 
 [[package]]
@@ -1599,8 +1526,6 @@ version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
 ]
 
 [[package]]
@@ -1608,9 +1533,9 @@ name = "opencv-python"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
 wheels = [
@@ -1629,9 +1554,9 @@ name = "openexr"
 version = "3.4.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/a3/8b57f9bef539c195363cf966bbdc02951d3ce5d0a9f612d262f7fe66caad/openexr-3.4.15.tar.gz", hash = "sha256:6c9a28a4f4089379c9c4fd301edaa4dba0ed315862c029f453690a8191370a47", size = 25673422, upload-time = "2026-08-21T23:13:29.49Z" }
 wheels = [
@@ -1837,9 +1762,9 @@ name = "pycollada"
 version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/8d/52a5364a17eb96129962cae8d3ee7658775e085ad0ba38388684ad5944e9/pycollada-0.9.3.tar.gz", hash = "sha256:c34d6dcf0fe2eba5896f71c96d37a1c0fe1a61f08440fa0cfcec3dc2895d3302", size = 110826, upload-time = "2026-01-24T15:45:23.625Z" }
@@ -1965,9 +1890,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "plotly", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "plotly" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fb/eee3d9698b38c7005a500205f2559bf1f2983ecc232cb7ad2f7cc518ed4e/PyGEL3D-0.6.1-py3-none-any.whl", hash = "sha256:6403447c1a2d3c592871ad7ec7c30854e299149cd1532b46c78c5f43009d06f2", size = 4095361, upload-time = "2025-02-24T12:16:07.392Z" },
@@ -1982,11 +1907,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "plotly", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "plotly" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/4f/8e58c1f7cef75c2a4572c8db9b7cf29df8a1a4a23bd90c738935e183003a/pygel3d-0.8.0.tar.gz", hash = "sha256:cdd5407c71259226a618ced64b21fa415ef9eea35d07866dd8454cb4089311c0", size = 859598, upload-time = "2026-08-27T14:59:52.87Z" }
 wheels = [
@@ -2029,9 +1954,9 @@ name = "pymeshlab"
 version = "2025.7.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/7e/d44a74e360163ffc37f380c1be421c1594bd67e4ef9a4805691fdb662449/pymeshlab-2025.7.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5692a0a50cca49178ad9a3ceb02f60f200c7572b72f89964c7dbf915ef9e65a", size = 64994803, upload-time = "2026-01-30T08:40:19.586Z" },
@@ -2079,9 +2004,9 @@ name = "pysplashsurf"
 version = "0.14.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/c0/59a4a1a6a99c691f4fc6e254a73b4fa64986fb1ce66d2329fb4263f7c238/pysplashsurf-0.14.1.0.tar.gz", hash = "sha256:8304e3c923a8b5c6b59e9d9091fb868012053d48ae9bddf907354bd70ce063ac", size = 484484, upload-time = "2026-03-21T20:19:02.348Z" }
 wheels = [
@@ -2104,13 +2029,13 @@ name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
@@ -2192,9 +2117,9 @@ dependencies = [
     { name = "cffi" },
     { name = "colorama" },
     { name = "dill" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "setuptools" },
@@ -2280,14 +2205,14 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "imageio", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "lazy-loader", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "packaging", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pillow", marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
 wheels = [
@@ -2323,17 +2248,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "imageio", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "lazy-loader", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "pillow", marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "tifffile", version = "2026.8.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "tifffile", version = "2026.8.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
 wheels = [
@@ -2379,7 +2304,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2438,7 +2363,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2492,7 +2417,7 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
 wheels = [
@@ -2550,9 +2475,9 @@ name = "tetgen"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/15/a52fd7c1049ba8e39f7ee7ada132221ac535c6c18e6c07c27be1ef4fdf6b/tetgen-0.8.2.tar.gz", hash = "sha256:06ca8d8b9e21cdbb75334e20ee77e788e88f4b2cdb85c51b008592cb3f9af964", size = 824449, upload-time = "2026-01-27T20:48:55.271Z" }
 wheels = [
@@ -2581,7 +2506,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -2596,7 +2521,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -2611,7 +2536,7 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/07/90078f49e60718d414d5440dc498301f11ff049458e65cf8d27c62a5c9d1/tifffile-2026.8.23.tar.gz", hash = "sha256:bd3c816f166f85c93329a54a0c9a1eccc9968a6a78f91d63b65d7b17675915f2", size = 446179, upload-time = "2026-08-23T18:45:05.976Z" }
 wheels = [
@@ -2659,7 +2584,7 @@ name = "tqdm"
 version = "4.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
@@ -2671,9 +2596,9 @@ name = "trimesh"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/3f/a13d797349fdd00a8586b60d6b71df849e1766e2002729697a265b27a773/trimesh-5.1.0.tar.gz", hash = "sha256:927aa8748af8b84cb969c8f53270d929e546f2beada77a2bc234b605fddf1454", size = 870501, upload-time = "2026-08-31T18:28:55.464Z" }
 wheels = [
@@ -2719,9 +2644,9 @@ name = "unisim-core"
 version = "1.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -2732,21 +2657,21 @@ genesis = [
     { name = "genesis-world" },
 ]
 mjwarp = [
-    { name = "mujoco-warp", version = "3.10.0.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "warp-lang", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mujoco-warp" },
+    { name = "warp-lang" },
 ]
 motrix = [
     { name = "motrixsim-core" },
 ]
 mujoco = [
-    { name = "mujoco", version = "3.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mujoco" },
     { name = "mujoco-uni-runtime" },
 ]
 newton = [
-    { name = "mujoco", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "mujoco-warp", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mujoco" },
+    { name = "mujoco-warp" },
     { name = "newton" },
-    { name = "warp-lang", version = "1.16.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "warp-lang" },
 ]
 
 [package.dev-dependencies]
@@ -2761,14 +2686,14 @@ requires-dist = [
     { name = "drake-uni", marker = "extra == 'drake'", specifier = "==0.1.0" },
     { name = "genesis-world", marker = "extra == 'genesis'", specifier = "==1.3.3" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
-    { name = "mujoco", marker = "extra == 'mujoco'", specifier = ">=3.5" },
+    { name = "mujoco", marker = "extra == 'mujoco'", specifier = "~=3.11.0" },
     { name = "mujoco", marker = "extra == 'newton'", specifier = "==3.11.0" },
-    { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.4.0" },
-    { name = "mujoco-warp", marker = "extra == 'mjwarp'", specifier = "==3.10.0.3" },
+    { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.5.0" },
+    { name = "mujoco-warp", marker = "extra == 'mjwarp'", specifier = "~=3.11.0" },
     { name = "mujoco-warp", marker = "extra == 'newton'", specifier = "==3.11.0" },
     { name = "newton", marker = "extra == 'newton'", specifier = "==1.5.1" },
     { name = "numpy" },
-    { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = ">=1.14.0" },
+    { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = "==1.16.0" },
     { name = "warp-lang", marker = "extra == 'newton'", specifier = "==1.16.0" },
 ]
 provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "newton", "isaacgym", "isaacsim"]
@@ -2785,8 +2710,8 @@ name = "vtk"
 version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/51/fa0acc077a712e3ce1a683868c78fbba29d00a3a590808575160ac627bcc/vtk-9.7.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:43d327f6691e74a97b2a2e44bfd9fed7ea4e5c04f88f7398810a5c199c111f2a", size = 110868260, upload-time = "2026-08-15T21:36:12.314Z" },
@@ -2815,42 +2740,16 @@ wheels = [
 name = "warp-lang"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/8a/8be711f3b5431a6e0bdb97117d681b03cf2bb95d6fcf8869861900898d88/warp_lang-1.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:19a7590c4484e8250ab19165311d2a1774138663b361c41e8be2865c7515c4ae", size = 25221601, upload-time = "2026-08-03T02:26:38.389Z" },
     { url = "https://files.pythonhosted.org/packages/1d/3d/47feef2eee4739437e19d6949ea231ca4181c9eacbaa39144761e6130d94/warp_lang-1.16.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:96449fc1e3b354185e2f09434fb794b5953ab2e8673b104d7e7f48d5d418bb35", size = 163074225, upload-time = "2026-08-03T02:27:03.632Z" },
     { url = "https://files.pythonhosted.org/packages/db/96/0c2b070b3101c669955cafd36262548b2e8b00dfdeda3aeb7afbc0f9d65c/warp_lang-1.16.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d4715171bd6821436b82293d774c9a082ace08215c189572b4348d1e48fb8ee8", size = 167563789, upload-time = "2026-08-03T02:27:37.512Z" },
     { url = "https://files.pythonhosted.org/packages/7e/17/c98fab81156f0d25f17200f52f69210b94a9abba101066736df8cc493522/warp_lang-1.16.0-py3-none-win_amd64.whl", hash = "sha256:8690c9096e0a271985339d4aa4b37675e7d62852620ca861ac032dc85b124542", size = 146387135, upload-time = "2026-08-03T02:28:17.956Z" },
-]
-
-[[package]]
-name = "warp-lang"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'extra-11-unisim-core-mjwarp') or (extra == 'extra-11-unisim-core-mjwarp' and extra == 'extra-11-unisim-core-newton') or (extra == 'extra-11-unisim-core-mujoco' and extra == 'extra-11-unisim-core-newton')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/b0/9b1de407fa10b380f5ca4ed1c3e5b129be55ea26a927c7a49e45cdde14b0/warp_lang-1.17.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fec43afb81caa2190c0b7fa3aaf4d869f3599839f0c40b9ead84331f91e993", size = 27544218, upload-time = "2026-08-31T05:52:29.177Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/a1/e11aa6898e8bbb6910e89fe31a3338fb2566f038912010875c072e6dafd1/warp_lang-1.17.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:47cd93636828dd16e55eeb4e77a0e3547b5fb0f383000a3d228629df68f28fd8", size = 164347636, upload-time = "2026-08-31T05:53:14.441Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/4f/a17b1f0ebfeabe37326f01afb6109961f20a0165c1258242f46d10a554f5/warp_lang-1.17.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5051271048da956a8b94e2db9771ce60ce9591a3ac5bb49037f3d6812d1eea00", size = 172665443, upload-time = "2026-08-31T05:53:52.47Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/7a/36306a503085cbfc79c35a28e441c59dd1d8070d2dd65152345ebf2dfec2/warp_lang-1.17.0-py3-none-win_amd64.whl", hash = "sha256:ca35c82242a7553046f09023bbe56750b5c3d9af72625bd1a905a56d3189771d", size = 151236515, upload-time = "2026-08-31T05:54:27.944Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Roadmap: unilabsim/UniLab#1515。集成分回合入，含已审查的 child PR #36（validation 证据见该 PR）：

- 三个 extra 统一到 3.11 线：`mujoco~=3.11.0` + `mujoco-uni-runtime==0.5.0`（预编译 wheel 已发布 PyPI）；`mujoco-warp~=3.11.0` + `warp-lang==1.16.0`；newton 保持精确钉死。
- 删除 `mjwarp`×`newton`、`mujoco`×`newton` 两条 conflicts（warp-lang 1.16.0 对齐验证通过，单环境三 extra 共存实测）。
- lock 单一版本无分叉：mujoco 3.11.0 / mujoco-uni-runtime 0.5.0 / mujoco-warp 3.11.0 / warp-lang 1.16.0 / newton 1.5.1。

## Validation

- child PR #36：`make check`（ruff + 89 passed）、`uv lock --check`、三 extra 联合环境 import smoke 全部通过。
- 本 PR（base main）以远程 ci.yml 全部 job 通过为合入 gate。