### PR TITLE
feat(superdex): add audited CPU adapter and state contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Guidance for coding agents and maintainers working in this repository.
 
 UniSim is the extracted, backend-neutral physics contract used by UniLab.  The
 PyPI distribution is `unisim-core`; the import namespace is `unisim`.  The
-current `1.0.x` line contains the public `SimBackend` contract, the adapter
-factory and manifest, seven optional engine boundaries, a deterministic fake
+current `1.x` line contains the public `SimBackend` contract, the adapter
+factory and manifest, optional engine boundaries, a deterministic fake
 backend, conformance helpers, and benchmark result schemas.
 
 UniSim owns contracts, adapter lifecycle/state translation, optional-runtime
@@ -23,7 +23,7 @@ from unisim import SimBackend, create_backend
 ```
 
 `create_backend()` resolves one of the declared adapters (`mujoco`, `motrix`,
-`drake`, `mjwarp`, `genesis`, `isaacgym`, or `isaacsim`) and reports a
+`drake`, `mjwarp`, `newton`, `genesis`, `superdex`, `isaacgym`, or `isaacsim`) and reports a
 backend-specific diagnostic when its optional runtime is unavailable.  The
 base wheel must remain importable with none of those SDKs installed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Add the optional SuperDex 1.0.0 CPU adapter with native fixed-base bot and
+  audited MJCF articulation materialization, NumPy state/control translation,
+  independent scene resets, named state/contact sensors and process-owned
+  cleanup. Python 3.12 is required by the upstream wheels. See
+  `docs/superdex.md` for the experimental contact profile and explicit limits.
+  This roadmap change does not change the package version or publish a release.
+
 ## 1.1.3 - 2026-09-06
 
 - Ensure Newton ViewerGL playback shows authored static planes and supplies a

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ pip install "unisim-core[mujoco]"      # plus an engine extra when needed
 ```
 
 Available extras: `mujoco`, `motrix`, `drake`, `mjwarp`, `genesis`, `newton`,
-`isaacgym`, `isaacsim`. The Isaac extras are empty spellings because those
+`isaacgym`, `isaacsim`, `superdex`. SuperDex's Python 3.12 CPU development
+profile is described in [`docs/superdex.md`](docs/superdex.md). The Isaac extras
+are empty spellings because those
 vendor SDKs are not redistributable; their adapters discover dedicated worker
 installations at construction time. See
 [`docs/support-matrix.md`](docs/support-matrix.md) for the full adapter

--- a/README_zh.md
+++ b/README_zh.md
@@ -27,7 +27,8 @@ pip install "unisim-core[mujoco]"      # 需要时再加装引擎 extra
 ```
 
 可用 extra:`mujoco`、`motrix`、`drake`、`mjwarp`、`genesis`、`newton`、`isaacgym`、
-`isaacsim`。Isaac 两个 extra 是空声明,因为这些厂商 SDK 不可再分发;对应
+`isaacsim`、`superdex`。SuperDex 的 Python 3.12 CPU 开发接入范围见
+[`docs/superdex.md`](docs/superdex.md)。Isaac 两个 extra 是空声明,因为这些厂商 SDK 不可再分发;对应
 适配器在构造时发现独立的 worker 安装。完整的适配器支持矩阵见
 [`docs/support-matrix.md`](docs/support-matrix.md)。
 

--- a/docs/superdex.md
+++ b/docs/superdex.md
@@ -1,0 +1,166 @@
+# SuperDex CPU development profile
+
+The `superdex` adapter runs SuperDex Physics/Robotics 1.0.0 directly behind
+`SimBackend`. UniLab roadmap [#1533](https://github.com/Motphys/UniLab/issues/1533)
+tracks this development profile. Changes remain on roadmap branches; the
+version is unchanged and no PyPI release is required for local integration.
+
+## Installation and ownership
+
+Use CPython 3.12, as required by the upstream wheels. From the UniSim checkout:
+
+```sh
+uv sync --python 3.12 --extra superdex --extra mujoco
+```
+
+`superdex-physics==1.0.0` and `superdex-robotics==1.0.0` are optional. The extra
+also supplies MuJoCo 3.11 as a **cold MJCF parser**; SuperDex executes every
+physics step. Native `.superdex_bot` loading does not use that parser.
+Importing `unisim` or its `SuperDexBackend` class does not load either engine.
+SuperDex Lab, Gymnasium and a learner are not adapter dependencies.
+
+For a sibling UniLab checkout, keep both versions unchanged and install local
+editable projects together, for example `uv pip install -e './[superdex,mujoco]'
+-e ../UniLab`. Use `uv run --no-sync` (or `UV_NO_SYNC=1 make check`) while
+testing editable overrides so normal project synchronization does not replace
+them with index distributions. UniLab's local provenance test profile uses
+`UNILAB_LOCAL_UNISIM` pointing at the exact UniSim checkout. The UniLab backend
+guide describes its task and registered asset setup.
+
+The verified platform is Linux x86_64, CPU FP32. Upstream also provides
+Windows x86_64 and macOS ARM wheels, but this integration has not established
+those platforms. The default x86 build requires AVX2 and related instructions.
+The upstream source exposes optional CUDA linear solvers, but the tested wheel
+rejects them as not built with CUDA. This adapter does not enable GPU solvers.
+FP64 upstream packages require a process-wide precision choice before import;
+the integration's numerical validation currently targets FP32.
+
+Each environment owns an independent native scene. The adapter reference
+counts the process-global engine: closing one instance leaves other instances
+alive. All instances in a process use the same `superdex_num_threads` value;
+zero selects single-threaded physics. Runtime initialization must belong to
+UniSim, and live backends cannot be transferred between processes. Pass
+configuration through the existing spawn-based `EnvFactory`/collector boundary.
+Call the public `cleanup_scene_assets()` hook or `close()` before interpreter
+shutdown. UniLab's `env.close()` calls that public hook.
+
+## Native fixed-base robot
+
+Preprocessed SuperDex assets stay outside the code repositories. The FR3 example
+uses the upstream `assets/bots/arms/fr3_v2` directory including its HDF5 collision
+and GLB render files. Preserve its LICENSE/NOTICE. The native bot must have a
+HARD root and fixed/hinge/slide joints; components, cycles, tendons and
+transmissions outside this profile fail closed.
+
+```python
+import numpy as np
+from unisim import create_backend
+from unisim.scene import SceneCfg
+
+backend = create_backend(
+    "superdex",
+    SceneCfg("/path/to/project_superdex/assets/bots/arms/fr3_v2/fr3_v2.superdex_bot"),
+    num_envs=2,
+    sim_dt=0.002,
+    base_name="fr3_link0",
+    superdex_num_threads=0,
+    superdex_effort_limits=[20, 20, 20, 20, 5, 5, 5],
+)
+try:
+    backend.step(np.zeros((2, 7)), nsteps=5)
+    state = backend.get_state()
+finally:
+    backend.cleanup_scene_assets()
+```
+
+The native control vector names and ordering follow the single-DoF joint names.
+Positive finite effort limits must be present in the asset or supplied
+explicitly. The example values define a research control profile, not verified
+FR3 hardware ratings. Fixed-base `get_state()` contains only joint coordinates;
+requesting a floating-root layout for a fixed body is rejected. A named keyframe
+must actually exist in the scene; the adapter does not invent `home` for bots.
+
+## Audited MJCF profile
+
+The cold importer accepts one articulation tree, one optional free root,
+hinge/slide joints, scalar stateless motor or linear position actuators and
+authored static planes. Existing scene fragments and named keyframes are
+materialized before stepping. Joint and actuator ordering remain distinct.
+Mass, inertial frame/COM, joint frames/axes, armature, joint friction and
+control/force limits are mapped explicitly.
+
+Dynamic primitive collision geometry is triangulated and baked to SDF once
+during materialization. Separate welded geometry links retain authored
+geom-pair contact sensor identity; their mass/inertia parts sum to the original
+body's inertial properties. Mesh collision, arbitrary multiple joints per body,
+multiple articulations, equality/tendon/flex/mocap/hfield/plugin features and
+unsupported actuator/sensor semantics are rejected. Visual mesh files still
+need to be present for the source MJCF parser even though this adapter is
+headless. No model parsing or SDF baking occurs during reset, step or getters.
+
+SuperDex contact and its implicit integration are not numerically equivalent to
+MuJoCo. Primitive SDFs approximate analytic surfaces, and solver settings have
+different meanings. Torsional/rolling friction requires the explicit
+`superdex_allow_contact_approximation=True` experimental profile, which warns
+that only the sliding Coulomb component is preserved. The default rejects that
+loss of semantics. Go2's task owner opts into this profile; a finite rollout is
+not evidence of locomotion quality or equivalent contacts.
+
+The 1.0.0 wheel lacks the newer source tree's per-pair friction override API.
+The importer therefore factors authored sliding-friction pairs into native
+actor coefficients so their geometric-mean mixing reproduces the selected
+MuJoCo pair coefficient. Incompatible friction graphs are rejected; no private
+engine API or silently changed mixing rule is used.
+
+## State, controls and sensors
+
+Free-root public qpos is world xyz + **wxyz**, followed by single-DoF joints.
+Public reset qvel is world body-origin linear velocity + **body-frame angular
+velocity**, followed by joint velocity. Native SuperDex free qpos stores a
+rotation vector, but its free rotational velocity is **not** the ordinary
+derivative of that vector. With an identity native reference transform, native
+free qvel uses world origin linear velocity and world angular velocity. The
+adapter rotates the angular component at the state barrier and verifies body
+origin/COM velocity against authored MuJoCo kinematics at nontrivial poses.
+
+The pre-step control callback runs once per physics substep. Motor/position
+controls respect authored order, gains, gear and limits. Pending body forces
+are accumulated as generalized forces and submitted together with control;
+one native external-force write cannot erase a separate control contribution.
+
+Named joint position/velocity, frame pose/axis/velocity, gyro and velocimeter
+signals are reconstructed from native state into NumPy caches. Supported
+plane/geom `contact data="found" num="1"` signals use native contact points and
+the actual actor pair, not a nonzero-force proxy. Contacts represent the last
+completed physics solve. A reset clears the solved contact state; `step(0)` does
+not rebuild the contact manifold after teleportation, so the first positive
+physics step supplies fresh contact results. Do not use reset-time contact
+flags as a geometric-overlap test.
+
+Authored accelerometers are recognized but unavailable: requesting/binding one
+raises `NotImplementedError`, because the public runtime does not supply
+instantaneous point acceleration. Unused accelerometers do not prevent loading
+an otherwise supported asset; no zero or finite-difference substitute is
+presented as the authored sensor. Native bot sensor components, cameras,
+arbitrary force/touch sensors and site Jacobians are outside this profile.
+
+Reset restores a private initial dynamic snapshot, writes selected qpos/qvel,
+clears controls/external forces and refreshes kinematic caches. Other rows are
+unchanged. Snapshot bytes are not exposed as portable checkpoints. Model DR,
+rendering/video, ROM/soft/tactile state and GPU batched physics are unsupported
+and must not be advertised by callers.
+
+## Validation
+
+```sh
+uv run --no-sync pytest -q tests/test_superdex_contract.py tests/test_superdex.py tests/test_superdex_materialization.py
+UV_NO_SYNC=1 make check
+uv lock --check
+make package
+```
+
+Set `SUPERDEX_ASSETS_PATH` to the upstream `assets` directory to include the
+external native FR3 fixture. Other numerical tests use small authored models
+and require the optional Python 3.12 runtime. Contract/import tests also run
+without it. UniLab owns task rollouts, training checkpoints and sim2sim policy
+I/O validation; those outcomes are tracked in the roadmap's integration child.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -8,6 +8,7 @@
 | MJWarp | `unisim.MJWarpBackend` | `uv sync --extra mjwarp`, CUDA | available |
 | Genesis | `unisim.GenesisBackend` | `uv sync --extra genesis` | available |
 | Newton | `unisim.NewtonBackend` | `uv sync --extra newton`, Newton 1.5.1 / MuJoCo-Warp 3.11.0 | available (CUDA) |
+| SuperDex | `unisim.SuperDexBackend` | local checkout `superdex` extra, CPython 3.12 / SuperDex 1.0.0 | experimental CPU; see [profile](superdex.md) |
 | IsaacGym | `unisim.IsaacGymBackend` | `uv sync --extra isaacgym` (empty extra) + dedicated Python 3.8 worker | available |
 | IsaacSim | `unisim.IsaacSimBackend` | `uv sync --extra isaacsim` (empty extra) + dedicated IsaacSim/IsaacLab worker | available |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,14 @@ motrix = ["motrixsim-core==0.8.2"]
 drake = ["drake-uni==0.1.0"]
 mjwarp = ["mujoco-warp~=3.11.0", "warp-lang==1.16.0"]
 genesis = ["genesis-world==1.3.3"]
+# The public SuperDex wheels currently expose only the CPython 3.12 ABI.
+# Other Python versions retain the NumPy-only base and fail with a targeted
+# dependency diagnostic if this adapter is requested.
+superdex = [
+    "superdex-physics==1.0.0 ; python_version == '3.12'",
+    "superdex-robotics==1.0.0 ; python_version == '3.12'",
+    "mujoco~=3.11.0 ; python_version == '3.12'",
+]
 # Newton's upstream coupling is precise, so these stay exact pins. They sit on
 # the same 3.11 line as the extras above: newton 1.5.1 requires
 # warp-lang>=1.16.0, and mujoco-warp 3.11.0 accepts warp-lang>=1.14 and

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -25,6 +25,8 @@ __all__ = [
     "MjwarpBackend",
     "NewtonBackend",
     "NewtonDependencyError",
+    "SuperDexBackend",
+    "SuperDexDependencyError",
     "GenesisBackend",
     "IsaacGymBackend",
     "IsaacGymDependencyError",
@@ -57,6 +59,8 @@ def __getattr__(name: str):
         "MjwarpBackend": (".backend.mjwarp", "MjwarpBackend"),
         "NewtonBackend": (".backend.newton", "NewtonBackend"),
         "NewtonDependencyError": (".backend.newton", "NewtonDependencyError"),
+        "SuperDexBackend": (".backend.superdex", "SuperDexBackend"),
+        "SuperDexDependencyError": (".backend.superdex", "SuperDexDependencyError"),
         "MotrixBackend": (".backend.motrix", "MotrixBackend"),
         "MuJoCoBackend": (".backend.mujoco", "MuJoCoBackend"),
         # ``SubprocessBackend`` was the name used by the first extraction

--- a/src/unisim/adapters.py
+++ b/src/unisim/adapters.py
@@ -29,6 +29,7 @@ ADAPTER_SPECS: tuple[AdapterSpec, ...] = (
     AdapterSpec("drake", "drake", "available"),
     AdapterSpec("mjwarp", "mjwarp", "available"),
     AdapterSpec("newton", "newton", "available"),
+    AdapterSpec("superdex", "superdex", "available"),
     AdapterSpec("genesis", "genesis", "available"),
     AdapterSpec("isaacgym", "isaacgym", "available"),
     AdapterSpec("isaacsim", "isaacsim", "available"),

--- a/src/unisim/backend/superdex/__init__.py
+++ b/src/unisim/backend/superdex/__init__.py
@@ -1,0 +1,6 @@
+"""Independent SuperDex CPU adapter; SDK imports occur only at construction."""
+
+from .backend import SuperDexBackend
+from .dependencies import SuperDexDependencyError
+
+__all__ = ["SuperDexBackend", "SuperDexDependencyError"]

--- a/src/unisim/backend/superdex/backend.py
+++ b/src/unisim/backend/superdex/backend.py
@@ -1,0 +1,603 @@
+"""CPU SuperDex adapter with NumPy state barriers and independent native scenes."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
+from unisim.scene import SceneCfg
+from unisim.utils.rotation import (
+    np_quat_apply_batched as rotate,
+)
+from unisim.utils.rotation import (
+    np_quat_apply_inverse_batched as unrotate,
+)
+from unisim.utils.rotation import (
+    np_quat_conjugate_batched as conjugate,
+)
+from unisim.utils.rotation import (
+    np_quat_mul_batched as multiply,
+)
+
+from .dependencies import load_superdex_dependencies
+from .plans import ModelPlan, SensorPlan
+from .runtime import acquire_runtime, release_runtime
+
+
+class SuperDexBackend(SimBackend):
+    """One independent CPU scene per environment, initialized in its owning process.
+
+    Native engine state is translated at materialize/set_state/step barriers.
+    Public getters read detached NumPy caches; they never parse assets or query
+    native metadata. Scene mutation and stepping are serial within one backend.
+    Use existing spawn collectors to parallelize environments across processes.
+    """
+
+    backend_type = "superdex"
+
+    def __init__(
+        self,
+        scene: SceneCfg,
+        num_envs: int,
+        sim_dt: float,
+        *,
+        base_name: str | None = None,
+        num_threads: int = 0,
+        effort_limits: Sequence[float] | None = None,
+        allow_contact_approximation: bool = False,
+        **unexpected: Any,
+    ) -> None:
+        if unexpected:
+            raise TypeError(f"SuperDexBackend does not accept options: {sorted(unexpected)}")
+        if isinstance(num_envs, bool) or not isinstance(num_envs, int) or num_envs <= 0:
+            raise ValueError("num_envs must be a positive integer")
+        if not np.isfinite(sim_dt) or sim_dt <= 0:
+            raise ValueError("sim_dt must be finite and positive")
+        if isinstance(num_threads, bool) or not isinstance(num_threads, int) or num_threads < 0:
+            raise ValueError("num_threads must be a non-negative integer (0 is single-threaded)")
+        if not isinstance(allow_contact_approximation, bool):
+            raise TypeError("allow_contact_approximation must be bool")
+        self._num_envs = num_envs
+        self._dt = float(sim_dt)
+        self._pid = os.getpid()
+        self._pre_step_control_fn = None
+        self._scene_cleanup_handle = None
+        self._closed = False
+        self._acquired = False
+        self._worlds: list[Any] = []
+        self._actors: list[Any] = []
+        self._links: list[list[Any]] = []
+        self._actor_cleanups: list[Any] = []
+        self._snapshots: list[Any] = []
+        self._sensor_sources: list[dict[str, tuple[Any, Any]]] = []
+        self._plan: ModelPlan | None = None
+        self._p, self._r = load_superdex_dependencies()
+        self._dtype = np.float64 if self._p.uses_double_precision() else np.float32
+        try:
+            acquire_runtime(self._p, num_threads)
+            self._acquired = True
+            from .materialization import materialize_model
+
+            self._plan = materialize_model(
+                self._p,
+                self._r,
+                scene,
+                effort_limits=effort_limits,
+                allow_contact_approximation=allow_contact_approximation,
+            )
+            self._body_lookup = {name: i for i, name in enumerate(self._plan.body_names)}
+            self._joint_lookup = {name: i for i, name in enumerate(self._plan.joint_names)}
+            self._base_id = (
+                self._body_lookup[base_name] if base_name is not None else self._plan.root_body_id
+            )
+            self._allocate_caches()
+            self.materialize()
+        except BaseException:
+            self.close()
+            raise
+
+    @property
+    def num_envs(self) -> int:
+        return self._num_envs
+
+    @property
+    def model(self) -> ModelPlan:
+        assert self._plan is not None
+        return self._plan
+
+    @property
+    def num_actuators(self) -> int:
+        return len(self.model.actuator_names)
+
+    @property
+    def num_dof_vel(self) -> int:
+        return len(self.model.joint_names)
+
+    def _check_open(self) -> None:
+        if self._pid != os.getpid():
+            raise RuntimeError(
+                "SuperDex backend cannot cross processes; pass an EnvFactory to spawn"
+            )
+        if self._closed:
+            raise RuntimeError("SuperDex backend is closed")
+
+    def _allocate_caches(self) -> None:
+        n, m, dtype = self.num_envs, self.model, self._dtype
+        self._qpos = np.zeros((n, m.nq), dtype=dtype)
+        self._qvel = np.zeros((n, m.nv), dtype=dtype)
+        self._ctrl = np.zeros((n, self.num_actuators), dtype=dtype)
+        self._native_q = np.zeros((n, m.nv), dtype=dtype)
+        self._native_v = np.zeros_like(self._native_q)
+        self._pending_wrench = np.zeros((n, len(m.body_names), 6), dtype=dtype)
+        shape = (n, len(m.body_names), 3)
+        self._pos = np.zeros(shape, dtype=dtype)
+        self._quat = np.zeros((*shape[:2], 4), dtype=dtype)
+        self._quat[..., 0] = 1
+        self._lin = np.zeros(shape, dtype=dtype)
+        self._ang = np.zeros(shape, dtype=dtype)
+        self._unsupported_sensors = {
+            s.name: "SuperDex does not expose instantaneous point acceleration"
+            for s in m.sensors
+            if s.kind == "accelerometer"
+        }
+        self._sensor_values = {
+            s.name: np.zeros((n, s.dim), dtype=dtype)
+            for s in m.sensors
+            if s.name not in self._unsupported_sensors
+        }
+        self._all_dofs = np.arange(m.nv, dtype=np.int32)
+
+    def materialize(self) -> None:
+        self._check_open()
+        if self._actors:
+            return
+        for i in range(self.num_envs):
+            world = self._p.create_scene(f"UniSim SuperDex {i}")
+            self._worlds.append(world)
+            world.set_gravity(self.model.gravity)
+            actor, cleanup = self.model.spawn_actor(world)
+            self._actors.append(actor)
+            self._actor_cleanups.append(cleanup)
+            if actor.get_num_dofs() != self.model.nv:
+                raise ValueError("SuperDex compiled DoF count differs from audited authoring plan")
+            links = [world.get_actor(h) for h in actor.get_nested_link_actors()]
+            self._links.append(links)
+            actor_names: dict[str, Any] = {}
+            world.for_each_actor(lambda item: actor_names.__setitem__(item.get_name(), item))
+            sources: dict[str, tuple[Any, Any]] = {}
+            for sensor in self.model.sensors:
+                if sensor.kind not in {
+                    "contact",
+                    "contact_found",
+                    "contact_force",
+                    "contact_torque",
+                }:
+                    continue
+                index = sensor.native_link_index
+                if index < 0:
+                    index = int(self.model.body_link_indices[sensor.body_id])
+                source = links[index]
+                query = (
+                    self._p.QueryType.CONTACT_POINTS
+                    if sensor.kind in {"contact", "contact_found"}
+                    else self._p.QueryType.TOTAL_CONTACT_FORCE
+                )
+                source.register_query(query)
+                other = actor_names[sensor.other_actor_name] if sensor.other_actor_name else None
+                sources[sensor.name] = source, other
+            self._sensor_sources.append(sources)
+            self._snapshots.append(world.capture_state())
+        self.reset()
+
+    def _ids(self, value: np.ndarray) -> np.ndarray:
+        ids = np.asarray(value)
+        if ids.ndim != 1 or not np.issubdtype(ids.dtype, np.integer):
+            raise ValueError("env_indices must be a one-dimensional integer array")
+        if np.any(ids < 0) or np.any(ids >= self.num_envs) or np.unique(ids).size != ids.size:
+            raise ValueError("env_indices must contain unique in-range indices")
+        return ids.astype(np.intp, copy=False)
+
+    def set_state(
+        self,
+        env_indices: np.ndarray,
+        qpos: np.ndarray,
+        qvel: np.ndarray,
+        randomization: ResetRandomizationPayload | None = None,
+    ) -> None:
+        self._check_open()
+        ids = self._ids(env_indices)
+        q = np.asarray(qpos, dtype=self._dtype)
+        v = np.asarray(qvel, dtype=self._dtype)
+        if q.shape != (len(ids), self.model.nq) or v.shape != (len(ids), self.model.nv):
+            raise ValueError(
+                "set_state qpos/qvel shapes must match selected rows and model dimensions"
+            )
+        if not np.isfinite(q).all() or not np.isfinite(v).all():
+            raise ValueError("set_state requires finite qpos/qvel")
+        if randomization is not None and randomization.requested_terms():
+            raise NotImplementedError("superdex does not support reset model randomization")
+        if self.model.floating and not np.allclose(np.linalg.norm(q[:, 3:7], axis=1), 1, atol=1e-5):
+            raise ValueError("free-root quaternion must be normalized wxyz")
+        for row, i in enumerate(ids):
+            world, actor = self._worlds[i], self._actors[i]
+            world.restore_state(self._snapshots[i], release_immediately=False)
+            native_q, native_v = self._native_q[i], self._native_v[i]
+            if self.model.floating:
+                native_q[:3] = q[row, :3]
+                native_q[3:6] = np.asarray(
+                    self._p.Quaternion(q[row, [4, 5, 6, 3]]).to_rotation_vector()
+                )
+                native_q[6:] = q[row, 7:]
+                native_v[:3] = v[row, :3]
+                native_v[3:6] = rotate(q[row, 3:7], v[row, 3:6])
+                native_v[6:] = v[row, 6:]
+            else:
+                native_q[:] = q[row]
+                native_v[:] = v[row]
+            actor.set_articulated_pose_from_joints(native_q)
+            actor.set_articulated_joint_velocities(native_v)
+            actor.set_external_forces_on_dofs(self._all_dofs, np.zeros_like(native_v))
+            self._ctrl[i] = 0
+            self._pending_wrench[i] = 0
+            world.step(0)
+        self._refresh(ids)
+
+    def step(self, ctrl: np.ndarray, nsteps: int = 1) -> None:
+        self._check_open()
+        values = np.asarray(ctrl, dtype=self._dtype)
+        if values.shape != self._ctrl.shape or not np.isfinite(values).all():
+            raise ValueError(f"ctrl must be finite with shape {self._ctrl.shape}")
+        if isinstance(nsteps, bool) or not isinstance(nsteps, (int, np.integer)) or nsteps < 1:
+            raise ValueError("nsteps must be a positive integer")
+        m = self.model
+        for _ in range(nsteps):
+            converted = self._apply_pre_step_control(values)
+            if not np.isfinite(converted).all():
+                raise ValueError("pre-step control returned non-finite values")
+            self._ctrl[:] = np.clip(
+                converted, m.actuator_ctrl_ranges[:, 0], m.actuator_ctrl_ranges[:, 1]
+            )
+            q = self._qpos[:, m.actuator_qpos_indices]
+            v = self._qvel[:, m.actuator_qvel_indices]
+            # kp==0 denotes a direct motor; otherwise ctrl is a position target.
+            force = np.where(
+                m.actuator_kp > 0,
+                m.actuator_kp * (self._ctrl - q * m.actuator_gear)
+                - m.actuator_kd * v * m.actuator_gear,
+                self._ctrl,
+            )
+            if m.actuator_force_ranges is not None:
+                force = np.clip(force, m.actuator_force_ranges[:, 0], m.actuator_force_ranges[:, 1])
+            force = force * m.actuator_gear
+            for i, (world, actor) in enumerate(zip(self._worlds, self._actors)):
+                generalized = np.zeros(m.nv, dtype=self._dtype)
+                for body in np.flatnonzero(np.any(self._pending_wrench[i] != 0, axis=1)):
+                    link = self._links[i][m.body_link_indices[body]]
+                    jacobian = np.asarray(link.get_articulated_jacobian()).reshape(6, m.nv)
+                    generalized += jacobian.T @ self._pending_wrench[i, body]
+                np.add.at(generalized, m.actuator_qvel_indices, force[i])
+                actor.set_external_forces_on_dofs(self._all_dofs, generalized)
+                world.step(self._dt)
+                if (
+                    world.get_solver_stats().convergence_status
+                    == self._p.ConvergenceStatus.DIVERGED
+                ):
+                    raise RuntimeError(f"SuperDex solver diverged in environment {i}")
+            self._refresh(np.arange(self.num_envs))
+        self._pending_wrench.fill(0)
+
+    def _refresh(self, ids: np.ndarray) -> None:
+        m = self.model
+        for i in ids:
+            actor = self._actors[i]
+            actor.get_articulated_pose(self._native_q[i])
+            actor.get_articulated_joint_velocities(self._native_v[i])
+            if m.floating:
+                self._qpos[i, :3] = self._native_q[i, :3]
+                quat = self._p.Quaternion.from_rotation_vector(self._native_q[i, 3:6])
+                self._qpos[i, 3:7] = np.asarray(quat)[[3, 0, 1, 2]]
+                self._qpos[i, 7:] = self._native_q[i, 6:]
+                self._qvel[i, :3] = self._native_v[i, :3]
+                self._qvel[i, 3:6] = unrotate(self._qpos[i, 3:7], self._native_v[i, 3:6])
+                self._qvel[i, 6:] = self._native_v[i, 6:]
+            else:
+                self._qpos[i] = self._native_q[i]
+                self._qvel[i] = self._native_v[i]
+            for body_id, link_index in enumerate(m.body_link_indices):
+                if link_index < 0:
+                    continue
+                link = self._links[i][link_index]
+                pose = link.get_root_transform()
+                self._pos[i, body_id] = np.asarray(pose.translation)
+                self._quat[i, body_id] = np.asarray(pose.rotation)[[3, 0, 1, 2]]
+                self._ang[i, body_id] = np.asarray(link.get_angular_velocity())
+                com_offset = (
+                    np.asarray(link.get_center_of_mass_transform().translation)
+                    - self._pos[i, body_id]
+                )
+                self._lin[i, body_id] = np.asarray(link.get_linear_velocity()) - np.cross(
+                    self._ang[i, body_id], com_offset
+                )
+            for sensor in m.sensors:
+                if sensor.name in self._sensor_values:
+                    self._sensor_values[sensor.name][i] = self._read_sensor(i, sensor)
+        arrays = (self._qpos[ids], self._qvel[ids], self._pos[ids], self._lin[ids], self._ang[ids])
+        if any(not np.isfinite(a).all() for a in arrays):
+            raise RuntimeError("SuperDex returned non-finite physics state")
+
+    def _read_sensor(self, i: int, sensor: SensorPlan) -> np.ndarray:
+        kind, body = sensor.kind, sensor.body_id
+        quat = multiply(self._quat[i, body], np.asarray(sensor.local_quat))
+        offset = rotate(self._quat[i, body], np.asarray(sensor.local_pos))
+        if kind == "jointpos":
+            return self._qpos[i, self.model.joint_qpos_indices[sensor.joint_index]]
+        if kind == "jointvel":
+            return self._qvel[i, self.model.joint_qvel_indices[sensor.joint_index]]
+        if kind == "framepos":
+            return self._pos[i, body] + offset
+        if kind == "framequat":
+            return quat
+        if kind in {"framexaxis", "frameyaxis", "framezaxis"}:
+            return rotate(
+                quat, np.eye(3)[{"framexaxis": 0, "frameyaxis": 1, "framezaxis": 2}[kind]]
+            )
+        if kind in {"gyro", "frameangvel"}:
+            angular = self._ang[i, body]
+            return unrotate(quat, angular) if kind == "gyro" else angular
+        if kind in {"velocimeter", "framelinvel"}:
+            velocity = self._lin[i, body] + np.cross(self._ang[i, body], offset)
+            return unrotate(quat, velocity) if kind == "velocimeter" else velocity
+        if kind in {"contact", "contact_found", "contact_force", "contact_torque"}:
+            source, other = self._sensor_sources[i][sensor.name]
+            if kind == "contact_force":
+                return np.asarray(source.get_contact_force_world())
+            if kind == "contact_torque":
+                return np.asarray(source.get_contact_torque_world())
+            points = source.get_contact_points_world()
+            if other is not None:
+                # Pair filtering uses captured native actor handles, never name lookup.
+                handle = other.get_handle()
+                own = source.get_handle()
+                found = any(
+                    point.distance <= sensor.contact_distance
+                    and (
+                        (point.actor_a == own and point.actor_b == handle)
+                        or (point.actor_a == handle and point.actor_b == own)
+                    )
+                    for point in points
+                )
+            else:
+                found = any(point.distance <= sensor.contact_distance for point in points)
+            return np.array([found], dtype=self._dtype)
+        raise NotImplementedError(f"superdex sensor kind is unsupported: {kind}")
+
+    def get_state(self, fields: Any = None) -> dict[str, np.ndarray]:
+        self._check_open()
+        names = (
+            ("qpos", "qvel")
+            if fields is None
+            else ((fields,) if isinstance(fields, str) else fields)
+        )
+        values = {"qpos": self._qpos, "qvel": self._qvel, "ctrl": self._ctrl}
+        return {name: values[name].copy() for name in names}
+
+    def get_actuator_ctrl_range(self) -> np.ndarray:
+        return self.model.actuator_ctrl_ranges.copy()
+
+    def get_actuator_names(self) -> tuple[str, ...]:
+        return self.model.actuator_names
+
+    def get_actuator_joint_names(self) -> tuple[str, ...]:
+        return self.model.actuator_joint_names
+
+    def get_scene_model_file(self) -> str:
+        return self.model.source_file
+
+    def get_default_qpos(self) -> np.ndarray:
+        return self.model.default_qpos.copy()
+
+    def get_default_dof_pos(self) -> np.ndarray:
+        return self.model.default_qpos[self.model.joint_qpos_indices].copy()
+
+    def get_keyframe_qpos(self, name: str) -> np.ndarray:
+        return self.model.keyframes[name].copy()
+
+    def get_init_qvel(self) -> np.ndarray:
+        return np.zeros(self.model.nv, dtype=self._dtype)
+
+    def get_joint_range(self) -> np.ndarray:
+        return self.model.joint_ranges.copy()
+
+    def get_body_ids(self, names: Sequence[str]) -> np.ndarray:
+        try:
+            return np.array([self._body_lookup[name] for name in names], dtype=np.int32)
+        except KeyError as exc:
+            raise ValueError(f"superdex unknown body: {exc.args[0]}") from exc
+
+    def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:
+        found = {int(root_body_id)}
+        for body, parent in enumerate(self.model.body_parent_ids):
+            if body != parent and parent in found:
+                found.add(body)
+        return np.array(sorted(found), dtype=np.int32)
+
+    def get_joint_dof_pos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return np.array([self._joint_lookup[name] for name in names], dtype=np.int32)
+
+    def get_joint_dof_vel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_dof_pos_indices(names)
+
+    def get_joint_dof_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.get_joint_state_qvel_indices(names)
+
+    def get_joint_state_qpos_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.model.joint_qpos_indices[self.get_joint_dof_pos_indices(names)].copy()
+
+    def get_joint_state_qvel_indices(self, names: Sequence[str]) -> np.ndarray:
+        return self.model.joint_qvel_indices[self.get_joint_dof_vel_indices(names)].copy()
+
+    def get_root_state_layout(self, root_body_name: str) -> BackendRootStateLayout:
+        body = self.get_body_id(root_body_name)
+        if not self.model.floating or body != self.model.root_body_id:
+            raise NotImplementedError(
+                f"superdex body {root_body_name!r} does not own a floating root"
+            )
+        return BackendRootStateLayout(
+            qpos_indices=(0, 1, 2, 3, 4, 5, 6),
+            qvel_indices=(0, 1, 2, 3, 4, 5),
+        )
+
+    def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
+        return DomainRandomizationCapabilities()
+
+    def get_gravity(self) -> np.ndarray:
+        return self.model.gravity.copy()
+
+    def get_body_mass(self) -> np.ndarray:
+        return self.model.body_mass.copy()
+
+    def get_body_ipos(self) -> np.ndarray:
+        return self.model.body_ipos.copy()
+
+    def get_dof_armature(self) -> np.ndarray:
+        if self.model.dof_armature is None:
+            return np.zeros(self.model.nv, dtype=self._dtype)
+        return self.model.dof_armature.copy()
+
+    def get_sensor_data(self, name: str) -> np.ndarray:
+        self._check_open()
+        if name in self._unsupported_sensors:
+            raise NotImplementedError(
+                f"superdex sensor {name!r}: {self._unsupported_sensors[name]}"
+            )
+        return self._sensor_values[name].copy()
+
+    def get_base_pos(self) -> np.ndarray:
+        return self._pos[:, self._base_id].copy()
+
+    def get_base_quat(self) -> np.ndarray:
+        return self._quat[:, self._base_id].copy()
+
+    def get_base_lin_vel(self) -> np.ndarray:
+        return self._lin[:, self._base_id].copy()
+
+    def get_base_ang_vel(self) -> np.ndarray:
+        return self._ang[:, self._base_id].copy()
+
+    def get_dof_pos(self) -> np.ndarray:
+        return self._qpos[:, self.model.joint_qpos_indices].copy()
+
+    def get_dof_vel(self) -> np.ndarray:
+        return self._qvel[:, self.model.joint_qvel_indices].copy()
+
+    def get_body_pos_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._pos[:, body_ids].copy()
+
+    def get_body_quat_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._quat[:, body_ids].copy()
+
+    def get_body_lin_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._lin[:, body_ids].copy()
+
+    def get_body_ang_vel_w(self, body_ids: np.ndarray) -> np.ndarray:
+        return self._ang[:, body_ids].copy()
+
+    def get_body_pos_b(self, body_ids: np.ndarray) -> np.ndarray:
+        return unrotate(
+            self.get_base_quat()[:, None], self._pos[:, body_ids] - self.get_base_pos()[:, None]
+        )
+
+    def get_body_quat_b(self, body_ids: np.ndarray) -> np.ndarray:
+        return multiply(conjugate(self.get_base_quat())[:, None], self._quat[:, body_ids])
+
+    def get_body_lin_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        return unrotate(self._quat[:, body_ids], self._lin[:, body_ids])
+
+    def get_body_ang_vel_b(self, body_ids: np.ndarray) -> np.ndarray:
+        return unrotate(self._quat[:, body_ids], self._ang[:, body_ids])
+
+    def apply_body_force(
+        self,
+        body_ids: np.ndarray,
+        force: np.ndarray,
+        torque: np.ndarray | None = None,
+    ) -> None:
+        self._check_open()
+        body_ids = np.asarray(body_ids)
+        expected = (self.num_envs, len(body_ids), 3)
+        f = np.asarray(force, dtype=self._dtype)
+        t = np.zeros_like(f) if torque is None else np.asarray(torque, dtype=self._dtype)
+        if (
+            f.shape != expected
+            or t.shape != expected
+            or not np.isfinite(f).all()
+            or not np.isfinite(t).all()
+        ):
+            raise ValueError(f"body force and torque must be finite with shape {expected}")
+        if body_ids.ndim != 1 or not np.issubdtype(body_ids.dtype, np.integer):
+            raise ValueError("body_ids must be an integer vector")
+        if np.any(body_ids <= 0) or np.any(body_ids >= len(self.model.body_names)):
+            raise ValueError("body force must target an articulated body")
+        for column, body_id in enumerate(body_ids):
+            self._pending_wrench[:, body_id, :3] += f[:, column]
+            self._pending_wrench[:, body_id, 3:] += t[:, column]
+
+    def close(self) -> None:
+        if self._pid != os.getpid() or (self._closed and not self._acquired):
+            return
+        self._closed = True
+        # Cleanup must keep trying after an error so the remaining scenes do not leak.
+        errors: list[Exception] = []
+        for index, world in reversed(list(enumerate(self._worlds))):
+            if world is None:
+                continue
+            try:
+                if index < len(self._snapshots) and self._snapshots[index] is not None:
+                    world.release_state(self._snapshots[index])
+                    self._snapshots[index] = None
+            except Exception as exc:
+                errors.append(exc)
+            try:
+                if index < len(self._actor_cleanups):
+                    self._actor_cleanups[index]()
+            except Exception as exc:
+                # A live Bot/controller may still reference this scene. Keep
+                # ownership and allow a later close() to retry its cleanup.
+                errors.append(exc)
+                continue
+            try:
+                self._p.destroy_scene(world)
+                self._worlds[index] = None
+            except Exception as exc:
+                errors.append(exc)
+        if any(world is not None for world in self._worlds):
+            raise RuntimeError(f"SuperDex cleanup is incomplete; close may be retried: {errors[0]}")
+        self._worlds.clear()
+        self._actors.clear()
+        self._links.clear()
+        self._actor_cleanups.clear()
+        self._snapshots.clear()
+        self._sensor_sources.clear()
+        if self._plan is not None:
+            self._plan.cleanup()
+        if self._acquired:
+            release_runtime(self._p)
+            self._acquired = False
+        if errors:
+            raise RuntimeError(f"SuperDex cleanup failed: {errors[0]}") from errors[0]
+
+    def cleanup_scene_assets(self) -> None:
+        """Honor the public cleanup hook used by UniLab's environment lifecycle."""
+        self.close()
+
+    def __del__(self) -> None:
+        if hasattr(self, "_closed"):
+            try:
+                self.close()
+            except Exception:
+                pass

--- a/src/unisim/backend/superdex/backend.py
+++ b/src/unisim/backend/superdex/backend.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import numpy as np
 
-from unisim.backend.base import BackendRootStateLayout, SimBackend
+from unisim.backend.base import (
+    BackendPlayRenderPlan,
+    BackendRootStateLayout,
+    SimBackend,
+    normalize_play_render_mode,
+)
 from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
 from unisim.scene import SceneCfg
 from unisim.utils.rotation import (
@@ -454,6 +459,27 @@ class SuperDexBackend(SimBackend):
 
     def get_dr_capabilities(self) -> DomainRandomizationCapabilities:
         return DomainRandomizationCapabilities()
+
+    @staticmethod
+    def resolve_play_render_plan(
+        *,
+        play_render_mode: str | None,
+        play_steps: int | None,
+        output_video: str | os.PathLike[str] | None,
+    ) -> BackendPlayRenderPlan:
+        """Permit an explicit playback skip and reject unavailable renderers."""
+        if normalize_play_render_mode(play_render_mode) != "none":
+            raise NotImplementedError(
+                "superdex has no renderer in this CPU profile; select play_render_mode=none "
+                "to skip playback, or use a headless policy inference session"
+            )
+        return BackendPlayRenderPlan(
+            mode="none",
+            headless=True,
+            record_video=False,
+            num_steps=None,
+            output_video=None,
+        )
 
     def get_gravity(self) -> np.ndarray:
         return self.model.gravity.copy()

--- a/src/unisim/backend/superdex/dependencies.py
+++ b/src/unisim/backend/superdex/dependencies.py
@@ -1,0 +1,49 @@
+"""Optional, process-local loading of the supported SuperDex Python runtime."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from importlib import metadata
+from typing import Any
+
+from unisim.optional import OptionalDependencyError
+
+_DISTRIBUTIONS = ("superdex-physics", "superdex-robotics")
+_HINT = "Use Python 3.12 and install unisim-core[superdex] (SuperDex 1.0.0)."
+
+
+class SuperDexDependencyError(OptionalDependencyError):
+    """The optional SuperDex ABI or distribution is unavailable."""
+
+
+def superdex_dependencies_available() -> bool:
+    """Check package metadata without importing the native runtime."""
+    if sys.version_info[:2] != (3, 12):
+        return False
+    try:
+        return all(metadata.version(name) == "1.0.0" for name in _DISTRIBUTIONS)
+    except metadata.PackageNotFoundError:
+        return False
+
+
+def load_superdex_dependencies() -> tuple[Any, Any]:
+    """Load the precision-consistent Physics and Robotics public facades lazily."""
+    if sys.version_info[:2] != (3, 12):
+        raise SuperDexDependencyError(f"superdex requires CPython 3.12. {_HINT}")
+    for name in _DISTRIBUTIONS:
+        try:
+            installed = metadata.version(name)
+        except metadata.PackageNotFoundError as exc:
+            raise SuperDexDependencyError(f"Missing {name}==1.0.0. {_HINT}") from exc
+        if installed != "1.0.0":
+            raise SuperDexDependencyError(
+                f"superdex requires {name}==1.0.0; found {installed}. {_HINT}"
+            )
+    try:
+        return (
+            importlib.import_module("superdex.physics"),
+            importlib.import_module("superdex.robotics"),
+        )
+    except (ImportError, OSError) as exc:
+        raise SuperDexDependencyError(f"Could not load SuperDex: {exc}. {_HINT}") from exc

--- a/src/unisim/backend/superdex/geometry.py
+++ b/src/unisim/backend/superdex/geometry.py
@@ -1,0 +1,55 @@
+"""Cold construction of audited MJCF primitive collision meshes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def rotation_matrix(quat: Any) -> np.ndarray:
+    """Convert a canonical wxyz quaternion without importing an engine."""
+    q = np.asarray(quat, dtype=float)
+    q = q / np.linalg.norm(q)
+    w, x, y, z = q
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+
+
+def primitive_shape(physics: Any, kind: str, size: Any, pos: Any, quat: Any) -> Any:
+    """Bake a primitive into body coordinates and build its collision SDF.
+
+    Even spheres need a surface mesh for a dynamic SuperDex link. Mesh/SDF
+    sampling approximates the analytic MJCF surface; it is never done at reset.
+    """
+    import trimesh
+
+    size = np.asarray(size)
+    if kind == "box":
+        mesh = trimesh.creation.box(extents=2 * size[:3])
+    elif kind == "sphere":
+        mesh = trimesh.creation.icosphere(subdivisions=2, radius=float(size[0]))
+    elif kind == "cylinder":
+        mesh = trimesh.creation.cylinder(radius=float(size[0]), height=2 * size[1], sections=32)
+    elif kind == "capsule":
+        mesh = trimesh.creation.capsule(radius=float(size[0]), height=2 * size[1], count=[16, 32])
+    elif kind == "ellipsoid":
+        mesh = trimesh.creation.icosphere(subdivisions=2)
+        mesh.vertices *= size[:3]
+    else:
+        raise NotImplementedError(f"superdex collision geometry {kind!r} is unsupported")
+    vertices = np.asarray(mesh.vertices) @ rotation_matrix(quat).T + np.asarray(pos)
+    dtype = np.float64 if physics.uses_double_precision() else np.float32
+    native_mesh = physics.MeshData(
+        nodes_per_element=3,
+        coordinates=np.asarray(vertices, dtype=dtype).ravel(),
+        connectivity=np.asarray(mesh.faces, dtype=np.int32).ravel(),
+    )
+    model = physics.ModelData(mesh=native_mesh)
+    physics.model.bake_sdf(model)
+    return physics.create_model_shape(model)

--- a/src/unisim/backend/superdex/materialization.py
+++ b/src/unisim/backend/superdex/materialization.py
@@ -1,0 +1,673 @@
+"""Audited, cold-path native-bot and MJCF materialization for SuperDex."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from unisim.backend.superdex.geometry import primitive_shape, rotation_matrix
+from unisim.backend.superdex.plans import ModelPlan, SensorPlan
+from unisim.scene import SceneCfg
+
+
+def _noop() -> None:
+    pass
+
+
+def _transform(p: Any, pos: Any, quat: Any = (1, 0, 0, 0)) -> Any:
+    return p.TransformRT(translation=pos, rotation=np.asarray(quat)[[1, 2, 3, 0]])
+
+
+def _effort_ranges(values: Sequence[float], count: int) -> np.ndarray:
+    limits = np.asarray(values, dtype=float)
+    if limits.shape != (count,) or not np.isfinite(limits).all() or np.any(limits <= 0):
+        raise ValueError(f"superdex effort_limits must contain {count} finite positive values")
+    return np.column_stack((-limits, limits))
+
+
+def materialize_model(
+    physics: Any,
+    robotics: Any,
+    scene: SceneCfg,
+    *,
+    effort_limits: Sequence[float] | None = None,
+    allow_contact_approximation: bool = False,
+) -> ModelPlan:
+    """Resolve all model metadata and shapes before any rollout begins."""
+    if scene.terrain is not None:
+        raise NotImplementedError("superdex supports authored static planes, not generated terrain")
+    path = Path(scene.model_file).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    if path.suffix == ".superdex_bot":
+        if scene.fragment_files:
+            raise NotImplementedError("superdex native bot does not accept MJCF fragments")
+        return _native_plan(physics, robotics, path, effort_limits)
+    if path.suffix != ".xml":
+        raise NotImplementedError("superdex model must be .superdex_bot or audited .xml MJCF")
+    return _mjcf_plan(physics, path, scene, effort_limits, allow_contact_approximation)
+
+
+def _native_plan(p: Any, r: Any, path: Path, efforts: Sequence[float] | None) -> ModelPlan:
+    cfg = r.load_bot_prefab_from_file(str(path))
+    joints = list(cfg.joints)
+    links = list(cfg.links)
+    if len(cfg.cycles) or len(cfg.linear_transmissions) or len(cfg.spatial_tendons):
+        raise NotImplementedError(
+            "superdex native bot transmissions/cycles require a separate audit"
+        )
+    if any(len(link.sensors) or len(link.actuators) for link in links):
+        raise NotImplementedError("superdex native bot sensor/actuator components are unsupported")
+    if joints[0].type != p.ArticulatedJointType.HARD:
+        raise NotImplementedError("superdex native bot currently requires a fixed HARD root")
+    if any(
+        j.type
+        not in (
+            p.ArticulatedJointType.HARD,
+            p.ArticulatedJointType.REVOLUTE,
+            p.ArticulatedJointType.PRISMATIC,
+        )
+        for j in joints
+    ):
+        raise NotImplementedError("superdex native bot supports only fixed/hinge/slide joints")
+    active = [i for i, joint in enumerate(joints) if joint.type != p.ArticulatedJointType.HARD]
+    n = len(active)
+    if efforts is None:
+        efforts = [float(joints[i].effort_limit) for i in active]
+        if any(v <= 0 or not np.isfinite(v) for v in efforts):
+            raise ValueError("superdex native bot requires explicit finite effort_limits")
+    ctrl_ranges = _effort_ranges(efforts, n)
+    ranges = []
+    for i in active:
+        joint = joints[i]
+        axis = np.asarray(joint.axis, dtype=float)
+        axis /= np.linalg.norm(axis)
+        ranges.append(
+            [
+                -np.inf if joint.min_limit is None else np.dot(joint.min_limit, axis),
+                np.inf if joint.max_limit is None else np.dot(joint.max_limit, axis),
+            ]
+        )
+    # A temporary cold scene resolves authored/density-derived mass properties.
+    temp = p.create_scene("superdex_metadata")
+    context = r.create_context()
+    bot = None
+    try:
+        bot = r.create_bot(temp, cfg, context)
+        actor = bot.get_articulated_actor()
+        native_links = [temp.get_actor(h) for h in actor.get_nested_link_actors()]
+        masses = [0.0]
+        coms = [np.zeros(3)]
+        for link, authored in zip(native_links, links, strict=True):
+            # HARD world chains are static and do not expose get_mass().
+            if link.is_static() and authored.mass is None and authored.shape_file:
+                raise NotImplementedError(
+                    "superdex native static links with collision assets require an explicit mass"
+                )
+            masses.append(float(authored.mass or 0) if link.is_static() else link.get_mass())
+            pose = link.get_root_transform()
+            rotation = rotation_matrix(np.asarray(pose.rotation)[[3, 0, 1, 2]])
+            world_offset = np.asarray(link.get_center_of_mass_transform().translation) - np.asarray(
+                pose.translation
+            )
+            coms.append(rotation.T @ world_offset)
+        q0 = np.empty(n, dtype=np.float64 if p.uses_double_precision() else np.float32)
+        actor.get_articulated_pose(q0)
+    finally:
+        if bot is not None:
+            r.destroy_bot(temp, bot)
+        p.destroy_scene(temp)
+
+    def spawn(native_scene: Any) -> tuple[Any, Any]:
+        owner = r.create_context()
+        instance = r.create_bot(native_scene, cfg, owner)
+        live = True
+
+        def close() -> None:
+            nonlocal live, owner
+            if live:
+                live = False
+                r.destroy_bot(native_scene, instance)
+                # Keep the explicit context wrapper alive until bot teardown. The
+                # SDK owns the process singleton; Python must not destroy it here.
+                owner = None
+
+        return instance.get_articulated_actor(), close
+
+    names = tuple(str(joints[i].name) for i in active)
+    return ModelPlan(
+        source_file=str(path),
+        nq=n,
+        nv=n,
+        root_body_id=1,
+        floating=False,
+        body_names=("world", *(str(link.name) for link in links)),
+        body_parent_ids=np.array([0, *(int(link.parent_link) + 1 for link in links)]),
+        body_link_indices=np.array([-1, *range(len(links))]),
+        body_mass=np.asarray(masses),
+        body_ipos=np.asarray(coms),
+        joint_names=names,
+        joint_qpos_indices=np.arange(n),
+        joint_qvel_indices=np.arange(n),
+        joint_ranges=np.asarray(ranges).reshape(n, 2),
+        actuator_names=names,
+        actuator_joint_names=names,
+        actuator_qpos_indices=np.arange(n),
+        actuator_qvel_indices=np.arange(n),
+        actuator_ctrl_ranges=ctrl_ranges,
+        actuator_gear=np.ones(n),
+        actuator_kp=np.zeros(n),
+        actuator_kd=np.zeros(n),
+        default_qpos=q0.astype(float),
+        keyframes={},
+        gravity=np.array([0, 0, -9.81]),
+        sensors=(),
+        spawn_actor=spawn,
+        cleanup=_noop,
+        actuator_force_ranges=ctrl_ranges.copy(),
+        dof_armature=np.array([float(joints[i].inertia or 0) for i in active]),
+    )
+
+
+def _load_mjcf(path: Path, scene: SceneCfg) -> tuple[Any, Any]:
+    try:
+        import mujoco
+    except ImportError as exc:
+        raise ImportError(
+            "superdex MJCF materialization requires the optional mujoco parser"
+        ) from exc
+    composed = None
+    try:
+        if scene.fragment_files:
+            from unisim.backend.mujoco.xml import materialize_scene_fragments
+
+            composed = materialize_scene_fragments(str(path), fragment_files=scene.fragment_files)
+        model = mujoco.MjModel.from_xml_path(composed or str(path))
+    finally:
+        if composed is not None:
+            os.unlink(composed)
+    return mujoco, model
+
+
+def _audit_model(mj: Any, m: Any) -> None:
+    for field in ("neq", "ntendon", "nflex", "nmocap", "nhfield", "nplugin"):
+        if int(getattr(m, field, 0)):
+            raise NotImplementedError(f"superdex MJCF does not support {field} features")
+    if np.any(m.body_jntnum > 1):
+        raise NotImplementedError("superdex MJCF supports at most one joint per body")
+    if np.count_nonzero(np.asarray(m.body_parentid)[1:] == 0) != 1:
+        raise NotImplementedError("superdex MJCF requires one articulated body tree")
+    supported = {
+        int(mj.mjtJoint.mjJNT_FREE),
+        int(mj.mjtJoint.mjJNT_HINGE),
+        int(mj.mjtJoint.mjJNT_SLIDE),
+    }
+    if any(int(t) not in supported for t in m.jnt_type):
+        raise NotImplementedError("superdex MJCF supports free, hinge and slide joints")
+    free = np.flatnonzero(m.jnt_type == int(mj.mjtJoint.mjJNT_FREE))
+    if len(free) > 1 or (len(free) and (free[0] != 0 or m.jnt_bodyid[free[0]] != 1)):
+        raise NotImplementedError("superdex MJCF supports only one free joint on the root")
+    if np.any(m.jnt_stiffness != 0) or np.any(m.dof_armature[:6] != 0) and len(free):
+        raise NotImplementedError("superdex MJCF joint springs/free-root armature are unsupported")
+    for j, jt in enumerate(m.jnt_type):
+        if jt != int(mj.mjtJoint.mjJNT_FREE) and m.qpos0[m.jnt_qposadr[j]] != 0:
+            raise NotImplementedError("superdex MJCF nonzero joint ref is unsupported")
+    if np.any(m.body_gravcomp != 0):
+        raise NotImplementedError("superdex MJCF gravity compensation is unsupported")
+    if m.opt.disableflags or m.opt.disableactuator or m.opt.density or m.opt.viscosity:
+        raise NotImplementedError("superdex MJCF disabled dynamics/fluid options are unsupported")
+    if np.any(m.jnt_actfrclimited):
+        raise NotImplementedError(
+            "superdex MJCF joint-level summed actuator force limits unsupported"
+        )
+    if np.any(m.geom_gap):
+        raise NotImplementedError("superdex MJCF nonzero contact gap is unsupported")
+
+
+def _mjcf_plan(
+    p: Any,
+    path: Path,
+    scene: SceneCfg,
+    efforts: Sequence[float] | None,
+    allow_contact_approximation: bool,
+) -> ModelPlan:
+    mj, m = _load_mjcf(path, scene)
+    _audit_model(mj, m)
+
+    def names(obj: Any, count: int, prefix: str) -> tuple[str, ...]:
+        return tuple(mj.mj_id2name(m, obj, i) or f"{prefix}{i}" for i in range(count))
+
+    body_names = names(mj.mjtObj.mjOBJ_BODY, m.nbody, "body")
+    joint_names = names(mj.mjtObj.mjOBJ_JOINT, m.njnt, "joint")
+    actuator_names = names(mj.mjtObj.mjOBJ_ACTUATOR, m.nu, "actuator")
+    geom_names = names(mj.mjtObj.mjOBJ_GEOM, m.ngeom, "geom")
+    floating = bool(m.njnt and m.jnt_type[0] == int(mj.mjtJoint.mjJNT_FREE))
+    links, joints, geom_links, body_links, plane_params = _build_links(
+        p, mj, m, body_names, geom_names, floating, allow_contact_approximation
+    )
+    sensors = _sensors(mj, m, geom_names, geom_links)
+    actuator = _actuators(mj, m, joint_names, efforts)
+    active = np.flatnonzero(m.jnt_type != int(mj.mjtJoint.mjJNT_FREE))
+    joint_ranges = np.array(m.jnt_range[active])
+    joint_ranges[~np.asarray(m.jnt_limited[active], dtype=bool)] = [-np.inf, np.inf]
+
+    def spawn(native_scene: Any) -> tuple[Any, Any]:
+        params = p.ArticulatedActorParams(name="robot", joints=joints, links=links)
+        actor = native_scene.create_articulated_actor(params)
+        handles = list(actor.get_nested_link_actors())
+        native_geoms = {g: native_scene.get_actor(handles[li]) for g, li in geom_links.items()}
+        for g, param in plane_params:
+            native_geoms[g] = native_scene.create_rigid_actor(param)
+        # Invisible inertial carrier meshes must not sample contacts either.
+        carriers = set(body_links[1:]) - set(geom_links.values())
+        for index in carriers:
+            for other in native_geoms.values():
+                native_scene.enable_actor_contact_symmetric(
+                    handles[index], other.get_handle(), False, p.IncludeNestedActors.NO
+                )
+        # Override native adjacency defaults with the authored MJCF bitmask pairs.
+        for g1, a in native_geoms.items():
+            for g2, b in native_geoms.items():
+                if g2 <= g1:
+                    continue
+                native_scene.enable_actor_contact_symmetric(
+                    a.get_handle(),
+                    b.get_handle(),
+                    _geom_pair_allowed(m, g1, g2),
+                    p.IncludeNestedActors.NO,
+                )
+        return actor, _noop
+
+    return ModelPlan(
+        source_file=str(path),
+        nq=int(m.nq),
+        nv=int(m.nv),
+        root_body_id=1,
+        floating=floating,
+        body_names=body_names,
+        body_parent_ids=np.array(m.body_parentid),
+        body_link_indices=body_links,
+        body_mass=np.array(m.body_mass),
+        body_ipos=np.array(m.body_ipos),
+        joint_names=tuple(joint_names[i] for i in active),
+        joint_qpos_indices=np.array(m.jnt_qposadr[active]),
+        joint_qvel_indices=np.array(m.jnt_dofadr[active]),
+        joint_ranges=joint_ranges,
+        actuator_names=actuator_names,
+        default_qpos=np.array(m.qpos0),
+        keyframes={
+            mj.mj_id2name(m, mj.mjtObj.mjOBJ_KEY, i) or f"key{i}": np.array(m.key_qpos[i])
+            for i in range(m.nkey)
+        },
+        gravity=np.array(m.opt.gravity),
+        sensors=sensors,
+        spawn_actor=spawn,
+        cleanup=_noop,
+        dof_armature=np.array(m.dof_armature),
+        **actuator,
+    )
+
+
+def _build_links(
+    p: Any,
+    mj: Any,
+    m: Any,
+    body_names: tuple[str, ...],
+    geom_names: tuple[str, ...],
+    floating: bool,
+    allow_contact_approximation: bool,
+) -> tuple[Any, ...]:
+    links: list[Any] = []
+    joints: list[Any] = []
+    geom_links: dict[int, int] = {}
+    body_links = np.full(m.nbody, -1, dtype=int)
+    planes: list[tuple[int, Any]] = []
+    collisions = [g for g in range(m.ngeom) if m.geom_contype[g] or m.geom_conaffinity[g]]
+    friction = _friction_factors(m, collisions)
+    for g in collisions:
+        if m.geom_bodyid[g] == 0:
+            if m.geom_type[g] != int(mj.mjtGeom.mjGEOM_PLANE):
+                raise NotImplementedError("superdex supports only static planes in worldbody")
+            normal = rotation_matrix(m.geom_quat[g])[:, 2]
+            shape = p.create_plane_shape(normal, float(normal @ m.geom_pos[g]))
+            planes.append(
+                (
+                    g,
+                    p.RigidActorParams(
+                        name=geom_names[g],
+                        shape=shape,
+                        is_static=True,
+                        contact=_contact(p, m, g, friction[g]),
+                    ),
+                )
+            )
+    mapping = {
+        int(mj.mjtGeom.mjGEOM_BOX): "box",
+        int(mj.mjtGeom.mjGEOM_SPHERE): "sphere",
+        int(mj.mjtGeom.mjGEOM_CAPSULE): "capsule",
+        int(mj.mjtGeom.mjGEOM_CYLINDER): "cylinder",
+        int(mj.mjtGeom.mjGEOM_ELLIPSOID): "ellipsoid",
+    }
+    if int(m.npair):
+        raise NotImplementedError("superdex explicit MJCF contact pairs are unsupported")
+    if any(m.geom_condim[g] > 3 and np.any(m.geom_friction[g, 1:] > 0) for g in collisions):
+        if not allow_contact_approximation:
+            raise NotImplementedError(
+                "superdex cannot preserve MJCF torsional/rolling friction; explicitly set "
+                "allow_contact_approximation=True for the experimental sliding-only profile"
+            )
+        warnings.warn(
+            "superdex uses sliding Coulomb contact; MJCF torsional/rolling friction "
+            "and solver-specific condim/solref/solimp are not numerically equivalent",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    for body in range(1, m.nbody):
+        geoms = [g for g in collisions if m.geom_bodyid[g] == body]
+        body_links[body] = len(links)
+        parent = int(body_links[m.body_parentid[body]])
+        j = int(m.body_jntadr[body]) if m.body_jntnum[body] else -1
+        jt = int(m.jnt_type[j]) if j >= 0 else -1
+        native_type = {
+            int(mj.mjtJoint.mjJNT_FREE): p.ArticulatedJointType.FREE,
+            int(mj.mjtJoint.mjJNT_HINGE): p.ArticulatedJointType.REVOLUTE,
+            int(mj.mjtJoint.mjJNT_SLIDE): p.ArticulatedJointType.PRISMATIC,
+        }.get(jt, p.ArticulatedJointType.HARD)
+        pos = np.asarray(m.jnt_pos[j]) if j >= 0 else np.zeros(3)
+        root_free = body == 1 and floating
+        joint_transform = (
+            p.TransformRT()
+            if root_free
+            else _transform(
+                p, m.body_pos[body] + rotation_matrix(m.body_quat[body]) @ pos, m.body_quat[body]
+            )
+        )
+        args: dict[str, Any] = {}
+        if j >= 0 and not root_free:
+            dof = int(m.jnt_dofadr[j])
+            args.update(
+                axis=np.asarray(m.jnt_axis[j]),
+                inertia=float(m.dof_armature[dof]),
+                friction=p.ArticulatedJointFrictionParams(
+                    viscous=float(m.dof_damping[dof]), coulomb=float(m.dof_frictionloss[dof])
+                ),
+            )
+            if m.jnt_limited[j]:
+                args.update(
+                    min_limit=m.jnt_axis[j] * m.jnt_range[j, 0],
+                    max_limit=m.jnt_axis[j] * m.jnt_range[j, 1],
+                )
+        main_joint = p.ArticulatedJointParams(
+            name=(mj.mj_id2name(m, mj.mjtObj.mjOBJ_JOINT, j) if j >= 0 else None)
+            or f"__joint_{body}",
+            type=native_type,
+            parent_link_from_joint=joint_transform,
+            **args,
+        )
+        inertial_rot = rotation_matrix(m.body_iquat[body])
+        inertia = inertial_rot @ np.diag(m.body_inertia[body]) @ inertial_rot.T
+        parts = max(1, len(geoms))
+        for k, g in enumerate(geoms or [-1]):
+            if g >= 0:
+                kind = mapping.get(int(m.geom_type[g]))
+                if kind is None:
+                    raise NotImplementedError(
+                        f"superdex unsupported collision geom {geom_names[g]!r}"
+                    )
+                shape = primitive_shape(p, kind, m.geom_size[g], m.geom_pos[g], m.geom_quat[g])
+            elif float(m.body_mass[body]) > 0:
+                shape = primitive_shape(p, "box", [0.001] * 3, [0, 0, 0], [1, 0, 0, 0])
+            else:
+                # A massless fixed frame is a native dummy link, not a tiny
+                # density-derived solid that changes the articulation mass.
+                shape = p.ShapeHandle()
+            props: dict[str, Any] = {}
+            if float(m.body_mass[body]) > 0:
+                props.update(
+                    mass=float(m.body_mass[body]) / parts,
+                    center_of_mass=np.asarray(m.body_ipos[body]),
+                    moment_of_inertia=inertia[np.triu_indices(3)] / parts,
+                )
+            links.append(
+                p.ArticulatedLinkParams(
+                    name=body_names[body] if k == 0 else f"__geom_{g}",
+                    parent_link=parent if k == 0 else int(body_links[body]),
+                    parent_joint_from_link=_transform(
+                        p, -pos if k == 0 and not root_free else [0, 0, 0]
+                    ),
+                    shape=shape,
+                    contact=_contact(p, m, g, friction[g]) if g >= 0 else p.ContactParams(),
+                    collider_type=p.ColliderType.AUTO if g >= 0 else p.ColliderType.NONE,
+                    **props,
+                )
+            )
+            joints.append(
+                main_joint
+                if k == 0
+                else p.ArticulatedJointParams(
+                    name=f"__geom_joint_{g}", type=p.ArticulatedJointType.HARD
+                )
+            )
+            if g >= 0:
+                geom_links[g] = len(links) - 1
+    return links, joints, geom_links, body_links, planes
+
+
+def _contact(p: Any, m: Any, g: int, friction: float) -> Any:
+    params = p.ContactParams()
+    params.coulomb_friction_coefficient = friction
+    params.penalty_threshold_default = float(m.geom_margin[g])
+    return params
+
+
+def _pair_friction(m: Any, g1: int, g2: int) -> float:
+    """Preserve MJCF priority/max sliding friction, bypassing native geometric mean."""
+    if m.geom_priority[g1] != m.geom_priority[g2]:
+        chosen = g1 if m.geom_priority[g1] > m.geom_priority[g2] else g2
+        return float(m.geom_friction[chosen, 0]) if m.geom_condim[chosen] >= 3 else 0.0
+    if max(m.geom_condim[g1], m.geom_condim[g2]) < 3:
+        return 0.0
+    return float(max(m.geom_friction[g1, 0], m.geom_friction[g2, 0]))
+
+
+def _geom_pair_allowed(m: Any, g1: int, g2: int) -> bool:
+    """Apply MuJoCo's default collision filters to welded body groups."""
+    b1, b2 = int(m.geom_bodyid[g1]), int(m.geom_bodyid[g2])
+    w1, w2 = int(m.body_weldid[b1]), int(m.body_weldid[b2])
+    if w1 == w2:
+        return False
+    if w1 and w2:
+        parent1 = int(m.body_weldid[m.body_parentid[w1]])
+        parent2 = int(m.body_weldid[m.body_parentid[w2]])
+        if parent1 == w2 or parent2 == w1:
+            return False
+    signature = (min(b1, b2) << 16) + max(b1, b2)
+    if signature in m.exclude_signature:
+        return False
+    return bool(
+        (m.geom_contype[g1] & m.geom_conaffinity[g2])
+        or (m.geom_contype[g2] & m.geom_conaffinity[g1])
+    )
+
+
+def _friction_factors(m: Any, geoms: list[int]) -> dict[int, float]:
+    """Factor MJCF pair friction into native geometric-mean actor coefficients.
+
+    Published SDK 1.0.0 lacks the newer pair-override API. A floor-only star
+    graph always admits an exact factorization. Reject incompatible pair rules.
+    """
+    pairs = []
+    for i, g1 in enumerate(geoms):
+        for g2 in geoms[i + 1 :]:
+            if _geom_pair_allowed(m, g1, g2):
+                pairs.append((g1, g2, _pair_friction(m, g1, g2)))
+    positive = [(a, b, mu) for a, b, mu in pairs if mu > 0]
+    positive_vertices = {g for a, b, _ in positive for g in (a, b)}
+    indices = {g: i for i, g in enumerate(geoms)}
+    result = {g: 1.0 for g in geoms}
+    if positive:
+        matrix = np.zeros((len(positive), len(geoms)))
+        target = np.empty(len(positive))
+        for row, (a, b, mu) in enumerate(positive):
+            matrix[row, indices[a]] = matrix[row, indices[b]] = 1
+            target[row] = 2 * np.log(mu)
+        solution = np.linalg.lstsq(matrix, target, rcond=None)[0]
+        if not np.allclose(matrix @ solution, target, atol=1e-10, rtol=1e-10):
+            raise NotImplementedError("superdex cannot factor the authored pair friction rules")
+        result.update({g: float(np.exp(solution[i])) for g, i in indices.items()})
+    for a, b, mu in pairs:
+        if mu == 0:
+            if a in positive_vertices and b in positive_vertices:
+                raise NotImplementedError(
+                    "superdex cannot preserve mixed zero/positive pair friction"
+                )
+            result[a if a not in positive_vertices else b] = 0.0
+    return result
+
+
+def _actuators(
+    mj: Any, m: Any, joint_names: tuple[str, ...], efforts: Sequence[float] | None
+) -> dict[str, Any]:
+    targets, kp, kd, gears = [], [], [], []
+    for a in range(m.nu):
+        if (
+            m.actuator_trntype[a] != int(mj.mjtTrn.mjTRN_JOINT)
+            or m.actuator_dyntype[a] != int(mj.mjtDyn.mjDYN_NONE)
+            or m.actuator_gaintype[a] != int(mj.mjtGain.mjGAIN_FIXED)
+        ):
+            raise NotImplementedError("superdex supports stateless joint motor/position actuators")
+        j = int(m.actuator_trnid[a, 0])
+        if m.jnt_type[j] == int(mj.mjtJoint.mjJNT_FREE):
+            raise NotImplementedError("superdex free-joint actuators are unsupported")
+        gear = float(m.actuator_gear[a, 0])
+        if gear == 0 or np.any(m.actuator_gear[a, 1:] != 0):
+            raise NotImplementedError("superdex requires scalar nonzero joint gear")
+        gain = float(m.actuator_gainprm[a, 0])
+        bias = np.asarray(m.actuator_biasprm[a])
+        if m.actuator_biastype[a] == int(mj.mjtBias.mjBIAS_NONE):
+            if gain != 1:
+                raise NotImplementedError("superdex motor fixed gain must be one")
+            kp.append(0.0)
+            kd.append(0.0)
+        elif (
+            m.actuator_biastype[a] == int(mj.mjtBias.mjBIAS_AFFINE)
+            and bias[0] == 0
+            and bias[1] == -gain
+            and bias[2] <= 0
+            and gain > 0
+        ):
+            kp.append(gain)
+            kd.append(float(-bias[2]))
+        else:
+            raise NotImplementedError("superdex supports only motor or linear position-servo bias")
+        targets.append(j)
+        gears.append(gear)
+    targets = np.array(targets, dtype=int)
+    ctrl = np.array(m.actuator_ctrlrange)
+    ctrl[~np.asarray(m.actuator_ctrllimited, dtype=bool)] = [-np.inf, np.inf]
+    force = np.array(m.actuator_forcerange)
+    force[~np.asarray(m.actuator_forcelimited, dtype=bool)] = [-np.inf, np.inf]
+    if efforts is not None:
+        force = _effort_ranges(efforts, m.nu)
+    return dict(
+        actuator_joint_names=tuple(joint_names[j] for j in targets),
+        actuator_qpos_indices=np.array(m.jnt_qposadr[targets]),
+        actuator_qvel_indices=np.array(m.jnt_dofadr[targets]),
+        actuator_ctrl_ranges=ctrl,
+        actuator_force_ranges=force,
+        actuator_gear=np.asarray(gears),
+        actuator_kp=np.asarray(kp),
+        actuator_kd=np.asarray(kd),
+    )
+
+
+def _sensors(
+    mj: Any, m: Any, geom_names: tuple[str, ...], geom_links: dict[int, int]
+) -> tuple[SensorPlan, ...]:
+    supported = {
+        "GYRO": "gyro",
+        "ACCELEROMETER": "accelerometer",
+        "VELOCIMETER": "velocimeter",
+        "FRAMEPOS": "framepos",
+        "FRAMEQUAT": "framequat",
+        "FRAMEZAXIS": "framezaxis",
+        "FRAMELINVEL": "framelinvel",
+        "FRAMEANGVEL": "frameangvel",
+        "JOINTPOS": "jointpos",
+        "JOINTVEL": "jointvel",
+    }
+    kinds = {int(getattr(mj.mjtSensor, f"mjSENS_{key}")): val for key, val in supported.items()}
+    plans = []
+    single_dofs = {
+        int(j): i for i, j in enumerate(np.flatnonzero(m.jnt_type != int(mj.mjtJoint.mjJNT_FREE)))
+    }
+    for i in range(m.nsensor):
+        name = mj.mj_id2name(m, mj.mjtObj.mjOBJ_SENSOR, i)
+        if not name:
+            raise NotImplementedError("superdex requires named sensors")
+        if m.sensor_cutoff[i] != 0:
+            raise NotImplementedError(f"superdex sensor {name!r} cutoff is unsupported")
+        obj = int(m.sensor_objid[i])
+        if m.sensor_type[i] == int(mj.mjtSensor.mjSENS_CONTACT):
+            if (
+                m.sensor_objtype[i] != int(mj.mjtObj.mjOBJ_GEOM)
+                or m.sensor_reftype[i] != int(mj.mjtObj.mjOBJ_GEOM)
+                or m.sensor_intprm[i, 0] != 1
+                or m.sensor_intprm[i, 2] != 1
+            ):
+                raise NotImplementedError("superdex contact sensors require geom-pair found num=1")
+            other = int(m.sensor_refid[i])
+            if m.geom_bodyid[obj] != 0:
+                obj, other = other, obj
+            if m.geom_bodyid[obj] != 0 or other not in geom_links:
+                raise NotImplementedError("superdex contact sensors require static plane/link pair")
+            plans.append(
+                SensorPlan(
+                    name=name,
+                    kind="contact_found",
+                    dim=1,
+                    body_id=int(m.geom_bodyid[other]),
+                    native_link_index=geom_links[other],
+                    other_actor_name=geom_names[obj],
+                    contact_distance=float(max(m.geom_margin[obj], m.geom_margin[other])),
+                )
+            )
+            continue
+        kind = kinds.get(int(m.sensor_type[i]))
+        if kind is None or int(m.sensor_refid[i]) >= 0:
+            raise NotImplementedError(f"superdex unsupported sensor {name!r} or reference frame")
+        if kind.startswith("joint"):
+            if obj not in single_dofs:
+                raise NotImplementedError("superdex joint sensor requires a single-DoF joint")
+            plans.append(SensorPlan(name=name, kind=kind, joint_index=single_dofs[obj], dim=1))
+            continue
+        typ = int(m.sensor_objtype[i])
+        if typ == int(mj.mjtObj.mjOBJ_SITE):
+            body, pos, quat = int(m.site_bodyid[obj]), m.site_pos[obj], m.site_quat[obj]
+        elif typ == int(mj.mjtObj.mjOBJ_GEOM):
+            body, pos, quat = int(m.geom_bodyid[obj]), m.geom_pos[obj], m.geom_quat[obj]
+        elif typ in (int(mj.mjtObj.mjOBJ_BODY), int(mj.mjtObj.mjOBJ_XBODY)):
+            body = obj
+            pos, quat = (
+                ([0, 0, 0], [1, 0, 0, 0])
+                if typ == int(mj.mjtObj.mjOBJ_XBODY)
+                else (m.body_ipos[obj], m.body_iquat[obj])
+            )
+        else:
+            raise NotImplementedError(f"superdex unsupported sensor object for {name!r}")
+        plans.append(
+            SensorPlan(
+                name=name,
+                kind=kind,
+                body_id=body,
+                local_pos=tuple(pos),
+                local_quat=tuple(quat),
+                dim=int(m.sensor_dim[i]),
+            )
+        )
+    return tuple(plans)

--- a/src/unisim/backend/superdex/plans.py
+++ b/src/unisim/backend/superdex/plans.py
@@ -1,0 +1,67 @@
+"""Cold-path authoring plans shared by SuperDex materialization and runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SensorPlan:
+    name: str
+    kind: str
+    body_id: int = 0
+    local_pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    local_quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    joint_index: int = -1
+    dim: int = 3
+    native_link_index: int = -1
+    other_actor_name: str | None = None
+    contact_distance: float = 0.0
+
+
+@dataclass
+class ModelPlan:
+    """Canonical arrays and a native scene constructor; no hot-path XML access.
+
+    Body zero is the world. ``body_link_indices`` maps every other canonical
+    body to the native articulation's nested link actors. Free roots use an
+    identity native reference transform: qpos is world xyz + wxyz followed by
+    single-DoF joints; qvel is world origin velocity + body angular velocity
+    followed by single-DoF joints. Native free qvel uses world angular velocity.
+    """
+
+    source_file: str
+    nq: int
+    nv: int
+    root_body_id: int
+    floating: bool
+    body_names: tuple[str, ...]
+    body_parent_ids: np.ndarray
+    body_link_indices: np.ndarray
+    body_mass: np.ndarray
+    body_ipos: np.ndarray
+    joint_names: tuple[str, ...]
+    joint_qpos_indices: np.ndarray
+    joint_qvel_indices: np.ndarray
+    joint_ranges: np.ndarray
+    actuator_names: tuple[str, ...]
+    actuator_joint_names: tuple[str, ...]
+    actuator_qpos_indices: np.ndarray
+    actuator_qvel_indices: np.ndarray
+    actuator_ctrl_ranges: np.ndarray
+    actuator_gear: np.ndarray
+    actuator_kp: np.ndarray
+    actuator_kd: np.ndarray
+    default_qpos: np.ndarray
+    keyframes: dict[str, np.ndarray]
+    gravity: np.ndarray
+    sensors: tuple[SensorPlan, ...]
+    # Receives a native scene and returns its articulated actor and an
+    # idempotent owner cleanup callback (e.g. RoboticsContext/Bot teardown).
+    spawn_actor: Callable[[Any], tuple[Any, Callable[[], None]]]
+    cleanup: Callable[[], None]
+    actuator_force_ranges: np.ndarray | None = None
+    dof_armature: np.ndarray | None = None

--- a/src/unisim/backend/superdex/runtime.py
+++ b/src/unisim/backend/superdex/runtime.py
@@ -1,0 +1,44 @@
+"""Reference-counted ownership of SuperDex's process-global CPU runtime."""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+_LOCK = threading.RLock()
+_PID: int | None = None
+_USERS = 0
+_THREADS: int | None = None
+
+
+def acquire_runtime(physics: Any, num_threads: int) -> None:
+    """Initialize once per spawn process; reject fork and conflicting thread policies."""
+    global _PID, _USERS, _THREADS
+    with _LOCK:
+        if _PID is not None and _PID != os.getpid():
+            raise RuntimeError("superdex runtime was inherited by fork; use spawn collectors")
+        if _USERS:
+            if num_threads != _THREADS:
+                raise ValueError("superdex instances in one process must use the same num_threads")
+        else:
+            if physics.is_initialized():
+                raise RuntimeError(
+                    "SuperDex was initialized outside UniSim; close that runtime before "
+                    "constructing a backend so initialization/shutdown ownership is unambiguous"
+                )
+            physics.initialize(num_worker_threads=num_threads)
+            _PID, _THREADS = os.getpid(), num_threads
+        _USERS += 1
+
+
+def release_runtime(physics: Any) -> None:
+    """Shut down only after the last backend has destroyed its native resources."""
+    global _PID, _USERS, _THREADS
+    with _LOCK:
+        if _PID != os.getpid() or not _USERS:
+            return
+        _USERS -= 1
+        if not _USERS:
+            physics.shutdown()
+            _PID = _THREADS = None

--- a/src/unisim/factory.py
+++ b/src/unisim/factory.py
@@ -47,6 +47,9 @@ def create_backend(
     newton_nconmax = kwargs.pop("newton_nconmax", None)
     newton_njmax = kwargs.pop("newton_njmax", None)
     newton_capacity_check_steps = kwargs.pop("newton_capacity_check_steps", 1)
+    superdex_num_threads = kwargs.pop("superdex_num_threads", 0)
+    superdex_effort_limits = kwargs.pop("superdex_effort_limits", None)
+    superdex_allow_contact_approximation = kwargs.pop("superdex_allow_contact_approximation", False)
     drake_backend_mode = kwargs.pop("drake_backend_mode", "batch")
     drake_nthread = kwargs.pop("drake_nthread", None)
     isaacgym_device_id = kwargs.pop("isaacgym_device_id", None)
@@ -144,6 +147,18 @@ def create_backend(
         kwargs["njmax"] = newton_njmax
         kwargs["capacity_check_steps"] = newton_capacity_check_steps
         return NewtonBackend(scene, num_envs, sim_dt, **kwargs)
+    if backend_type == "superdex":
+        from .backend.superdex import SuperDexBackend
+
+        if position_actuator_gains is not None:
+            raise ValueError(
+                "superdex requires authored actuator gains or the pre-step control hook"
+            )
+        kwargs.pop("add_body_sensors", None)
+        kwargs["num_threads"] = superdex_num_threads
+        kwargs["effort_limits"] = superdex_effort_limits
+        kwargs["allow_contact_approximation"] = superdex_allow_contact_approximation
+        return SuperDexBackend(scene, num_envs, sim_dt, **kwargs)
     if backend_type == "genesis":
         from .backend.genesis.backend import GenesisBackend
 

--- a/tests/test_all_adapters.py
+++ b/tests/test_all_adapters.py
@@ -12,6 +12,7 @@ def test_manifest_covers_all_current_backends():
         "drake",
         "mjwarp",
         "newton",
+        "superdex",
         "genesis",
         "isaacgym",
         "isaacsim",
@@ -27,6 +28,7 @@ def test_manifest_covers_all_current_backends():
         ("drake", "DrakeBackend"),
         ("mjwarp", "MjwarpBackend"),
         ("newton", "NewtonBackend"),
+        ("superdex", "SuperDexBackend"),
         ("genesis", "GenesisBackend"),
         ("isaacgym", "IsaacGymBackend"),
         ("isaacsim", "IsaacSimBackend"),
@@ -42,7 +44,7 @@ def test_every_manifest_adapter_has_a_lazy_public_class(backend_type: str, expor
 
 
 @pytest.mark.parametrize(
-    "backend_type", ["mujoco", "motrix", "drake", "mjwarp", "newton", "genesis"]
+    "backend_type", ["mujoco", "motrix", "drake", "mjwarp", "newton", "genesis", "superdex"]
 )
 def test_in_process_adapters_require_scene(backend_type):
     with pytest.raises(ValueError, match="requires a SceneCfg"):

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -36,6 +36,7 @@ def test_adapter_manifest_covers_roadmap_backends() -> None:
         "drake",
         "mjwarp",
         "newton",
+        "superdex",
         "genesis",
         "isaacgym",
         "isaacsim",

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -9,7 +9,7 @@ def test_import_does_not_pull_unilab_or_engine_modules():
         "import sys, unisim; "
         "blocked = [name for name in sys.modules if name == 'unilab' or "
         "name.startswith(('hydra', 'torch', 'gymnasium', 'mujoco', 'motrixsim', "
-        "'newton', 'warp'))]; "
+        "'newton', 'warp', 'superdex'))]; "
         "assert not blocked, blocked"
     )
     result = subprocess.run(

--- a/tests/test_superdex.py
+++ b/tests/test_superdex.py
@@ -1,0 +1,261 @@
+"""Numerical SuperDex conformance using small, explicitly authored rigid models."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim import assert_backend_conformance, create_backend
+from unisim.scene import SceneCfg
+from unisim.utils.rotation import np_quat_apply_batched
+
+if sys.version_info[:2] != (3, 12):
+    pytest.skip("SuperDex wheels require Python 3.12", allow_module_level=True)
+pytest.importorskip("superdex.physics")
+mujoco = pytest.importorskip("mujoco")
+
+
+def _model(tmp_path, floating=False):
+    free = '<freejoint name="root"/>' if floating else ""
+    path = tmp_path / ("free.xml" if floating else "fixed.xml")
+    path.write_text(f"""<mujoco model="superdex_test">
+      <compiler angle="radian"/>
+      <option gravity="0 0 0"/>
+      <worldbody>
+        <geom name="floor" type="plane" size="1 1 .1"/>
+        <body name="base" pos="0 0 1">
+          {free}
+          <inertial mass="2" pos=".03 .02 0" diaginertia=".03 .04 .05"/>
+          <geom name="base_geom" type="box" size=".1 .1 .1"/>
+          <site name="imu" pos=".01 .02 .03"/>
+          <body name="arm" pos="0 0 .2">
+            <joint name="hinge" axis="0 1 0" range="-1 1" damping=".1"/>
+            <inertial mass="1" pos="0 0 .1" diaginertia=".02 .025 .01"/>
+            <geom name="arm_geom" type="box" pos="0 0 .1" size=".025 .025 .1"/>
+          </body>
+        </body>
+      </worldbody>
+      <actuator><motor name="motor" joint="hinge" gear="2" ctrlrange="-2 2"/></actuator>
+      <sensor>
+        <jointpos name="angle" joint="hinge"/>
+        <jointvel name="speed" joint="hinge"/>
+        <framequat name="orientation" objtype="body" objname="base"/>
+        <gyro name="gyro" site="imu"/>
+        <velocimeter name="local_linvel" site="imu"/>
+      </sensor>
+    </mujoco>""")
+    return path
+
+
+@pytest.fixture
+def fixed(tmp_path):
+    backend = create_backend("superdex", SceneCfg(str(_model(tmp_path))), 2, 0.002)
+    try:
+        yield backend
+    finally:
+        backend.close()
+
+
+def test_fixed_conformance_state_width_and_selected_reset(fixed):
+    assert_backend_conformance(fixed)
+    assert fixed.get_state()["qpos"].shape == (2, 1)
+    fixed.set_state(np.array([0, 1]), np.array([[0.2], [-0.3]]), np.array([[0.1], [0.2]]))
+    before = fixed.get_state()
+    fixed.reset(np.array([0]))
+    np.testing.assert_array_equal(fixed.get_state()["qpos"][1], before["qpos"][1])
+    np.testing.assert_array_equal(fixed.get_state()["qvel"][1], before["qvel"][1])
+    np.testing.assert_allclose(fixed.get_sensor_data("angle")[:, 0], [0, -0.3], atol=1e-6)
+    with pytest.raises(NotImplementedError, match="floating"):
+        fixed.get_root_state_layout("base")
+
+
+def test_state_reads_are_detached_and_do_not_parse_assets(fixed, monkeypatch):
+    from unisim.backend.superdex import materialization
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("cold model parsing entered hot path")
+
+    monkeypatch.setattr(materialization, "materialize_model", forbidden)
+    view = fixed.bind_sensor_data(["angle", "speed"])
+    state = fixed.get_state()
+    state["qpos"][:] = 100
+    assert np.max(abs(fixed.get_dof_pos())) < 1
+    fixed.step(np.ones((2, 1)), 2)
+    assert view.read().shape == (2, 2)
+    fixed.reset(np.array([1]))
+    assert np.isfinite(view.read()).all()
+
+
+def test_pre_step_feedback_and_control_limits(fixed):
+    seen = []
+
+    def convert(backend, action):
+        seen.append(backend.get_dof_vel().copy())
+        return action * 100
+
+    fixed.set_pre_step_control(convert)
+    fixed.step(np.ones((2, 1)), 3)
+    assert len(seen) == 3
+    assert np.max(abs(seen[1] - seen[0])) > 0
+    np.testing.assert_array_equal(fixed.get_state("ctrl")["ctrl"], 2)
+    assert np.all(fixed.get_dof_vel() > 0)
+
+
+def test_invalid_selected_state_is_rejected_without_mutation(fixed):
+    before = fixed.get_state()
+    with pytest.raises(ValueError, match="unique"):
+        fixed.set_state(np.array([0, 0]), np.ones((2, 1)), np.zeros((2, 1)))
+    with pytest.raises(ValueError, match="finite"):
+        fixed.set_state(np.array([0]), np.array([[np.nan]]), np.zeros((1, 1)))
+    for field, value in before.items():
+        np.testing.assert_array_equal(fixed.get_state()[field], value)
+
+
+def test_world_force_is_reprojected_after_every_substep(fixed, tmp_path):
+    other = create_backend("superdex", SceneCfg(str(_model(tmp_path))), 2, 0.002)
+    try:
+        q, v = np.full((2, 1), 0.4), np.full((2, 1), 1.5)
+        for backend in (fixed, other):
+            backend.set_state(np.arange(2), q, v)
+        body = fixed.get_body_ids(["arm"])
+        force = np.zeros((2, 1, 3))
+        force[:, 0, 0] = 10.0
+        fixed.apply_body_force(body, force)
+        fixed.step(np.zeros((2, 1)), nsteps=20)
+        for _ in range(20):
+            other.apply_body_force(body, force)
+            other.step(np.zeros((2, 1)))
+        for field in ("qpos", "qvel"):
+            np.testing.assert_allclose(
+                fixed.get_state()[field], other.get_state()[field], atol=2e-6
+            )
+    finally:
+        other.close()
+
+
+def test_body_torques_accumulate_with_control_instead_of_replacing_it(fixed):
+    body = fixed.get_body_ids(["arm"])
+    force = np.zeros((2, 1, 3))
+    torque = np.zeros_like(force)
+    torque[0, 0, 1] = 1.0
+    fixed.apply_body_force(body, force, torque)
+    fixed.apply_body_force(body, force, torque)
+    # Native motor gear=2: row 0 gets 1*2 plus two unit body torques;
+    # row 1 gets 2*2 directly. A second native external-force write would
+    # incorrectly erase row 0's disturbance or its control contribution.
+    fixed.step(np.array([[1.0], [2.0]]))
+    np.testing.assert_allclose(fixed.get_dof_vel()[0], fixed.get_dof_vel()[1], atol=2e-6)
+    fixed.step(np.zeros((2, 1)))
+    np.testing.assert_allclose(fixed.get_dof_vel()[0], fixed.get_dof_vel()[1], atol=2e-6)
+
+
+def test_free_root_frames_match_authored_mujoco_kinematics(tmp_path):
+    path = _model(tmp_path, floating=True)
+    backend = create_backend("superdex", SceneCfg(str(path)), 2, 0.002)
+    try:
+        q = np.tile(backend.get_default_qpos(), (2, 1))
+        q[:, :3] = [[0.2, -0.4, 1.1], [0.1, 0.3, 0.9]]
+        q[:, 3:7] = [[0.8, 0.2, -0.4, 0.4], [0.5, 0.5, 0.5, 0.5]]
+        q[:, 3:7] /= np.linalg.norm(q[:, 3:7], axis=1)[:, None]
+        q[:, 7] = [0.3, -0.2]
+        v = np.array(
+            [[0.3, -0.2, 0.1, 0.2, 0.4, -0.6, 0.7], [-0.4, 0.1, 0.3, -0.2, 0.6, 0.1, -0.5]]
+        )
+        backend.set_state(np.arange(2), q, v)
+        np.testing.assert_allclose(backend.get_state()["qpos"], q, atol=3e-6)
+        np.testing.assert_allclose(backend.get_state()["qvel"], v, atol=3e-6)
+        np.testing.assert_allclose(backend.get_base_lin_vel(), v[:, :3], atol=3e-6)
+        expected_omega = np_quat_apply_batched(q[:, 3:7], v[:, 3:6])
+        np.testing.assert_allclose(backend.get_base_ang_vel(), expected_omega, atol=3e-6)
+        np.testing.assert_allclose(backend.get_sensor_data("gyro"), v[:, 3:6], atol=3e-6)
+        model = mujoco.MjModel.from_xml_path(str(path))
+        body_ids = backend.get_body_ids(["base", "arm"])
+        for row in range(2):
+            data = mujoco.MjData(model)
+            data.qpos[:], data.qvel[:] = q[row], v[row]
+            mujoco.mj_forward(model, data)
+            for column, name in enumerate(["base", "arm"]):
+                mid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+                np.testing.assert_allclose(
+                    backend.get_body_pos_w(body_ids)[row, column], data.xpos[mid], atol=4e-6
+                )
+                jacp, jacr = np.zeros((3, model.nv)), np.zeros((3, model.nv))
+                mujoco.mj_jacBody(model, data, jacp, jacr, mid)
+                np.testing.assert_allclose(
+                    backend.get_body_lin_vel_w(body_ids)[row, column], jacp @ v[row], atol=5e-6
+                )
+                np.testing.assert_allclose(
+                    backend.get_body_ang_vel_w(body_ids)[row, column], jacr @ v[row], atol=5e-6
+                )
+        root = backend.get_root_state_layout("base")
+        assert root.qpos_indices == tuple(range(7))
+        assert root.qvel_indices == tuple(range(6))
+        before = backend.get_state()
+        backend.reset(np.array([0]))
+        np.testing.assert_array_equal(backend.get_state()["qpos"][1], before["qpos"][1])
+    finally:
+        backend.close()
+
+
+def test_closing_one_backend_preserves_another(fixed, tmp_path):
+    other = create_backend("superdex", SceneCfg(str(_model(tmp_path))), 1, 0.002)
+    other.cleanup_scene_assets()
+    other.close()
+    fixed.step(np.ones((2, 1)))
+    assert np.isfinite(fixed.get_dof_vel()).all()
+    with pytest.raises(RuntimeError, match="closed"):
+        other.step(np.zeros((1, 1)))
+
+
+def test_unlimited_joint_does_not_acquire_a_zero_width_manager_limit(tmp_path):
+    path = _model(tmp_path)
+    path.write_text(path.read_text().replace('range="-1 1"', 'limited="false"'))
+    backend = create_backend("superdex", SceneCfg(str(path)), 1, 0.002)
+    try:
+        np.testing.assert_array_equal(backend.get_joint_range(), [[-np.inf, np.inf]])
+        backend.set_state(np.array([0]), np.array([[7.0]]), np.zeros((1, 1)))
+        np.testing.assert_allclose(backend.get_dof_pos(), [[7.0]], atol=2e-6)
+    finally:
+        backend.close()
+
+
+def test_native_fr3_when_registered_assets_are_available(monkeypatch):
+    assets = os.environ.get("SUPERDEX_ASSETS_PATH")
+    if not assets:
+        pytest.skip("Set SUPERDEX_ASSETS_PATH to validate the external FR3 fixture")
+    path = Path(assets) / "bots/arms/fr3_v2/fr3_v2.superdex_bot"
+    import superdex.robotics as robotics
+
+    load = robotics.load_bot_prefab_from_file
+
+    def load_with_derived_com(path):
+        prefab = load(path)
+        prefab.links[2].center_of_mass = None
+        prefab.links[2].moment_of_inertia = None
+        return prefab
+
+    monkeypatch.setattr(robotics, "load_bot_prefab_from_file", load_with_derived_com)
+    backend = create_backend(
+        "superdex",
+        SceneCfg(str(path)),
+        2,
+        0.002,
+        base_name="fr3_link0",
+        superdex_effort_limits=[20, 20, 20, 20, 5, 5, 5],
+    )
+    try:
+        assert_backend_conformance(backend)
+        assert backend.get_state()["qpos"].shape == (2, 7)
+        assert backend.get_actuator_names() == tuple(f"fr3_joint{i}" for i in range(1, 8))
+        # The SDK infers a nonzero COM from this asymmetric link's mesh;
+        # omitted authoring metadata must not silently turn it into zero.
+        com = backend.get_body_ipos()[backend.get_body_id("fr3_link1")]
+        np.testing.assert_allclose(com, [0.0000043, -0.03405, -0.06730], atol=1e-5)
+        backend.step(np.ones((2, 7)), 5)
+        assert np.isfinite(backend.get_dof_pos()).all()
+    finally:
+        backend.close()

--- a/tests/test_superdex_contract.py
+++ b/tests/test_superdex_contract.py
@@ -1,0 +1,63 @@
+"""SuperDex optional boundary checks that run without the engine installed."""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from unisim import SuperDexBackend, create_backend
+from unisim.backend.superdex.dependencies import (
+    SuperDexDependencyError,
+    load_superdex_dependencies,
+)
+from unisim.scene import SceneCfg
+
+
+def test_superdex_class_is_concrete_and_does_not_import_runtime():
+    assert not SuperDexBackend.__abstractmethods__
+    code = (
+        "import sys; from unisim import SuperDexBackend; "
+        "assert not [n for n in sys.modules if n.startswith(('superdex', 'mujoco', 'torch'))]"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_unsupported_python_has_actionable_diagnostic():
+    with patch("unisim.backend.superdex.dependencies.sys.version_info", (3, 11, 0)):
+        with pytest.raises(SuperDexDependencyError, match="Python 3.12"):
+            load_superdex_dependencies()
+
+
+def test_factory_routes_only_superdex_options(monkeypatch):
+    seen = {}
+
+    def construct(scene, num_envs, sim_dt, **kwargs):
+        seen.update(kwargs)
+        return "backend"
+
+    monkeypatch.setattr("unisim.backend.superdex.SuperDexBackend", construct)
+    result = create_backend(
+        "superdex",
+        SceneCfg("robot.superdex_bot"),
+        superdex_num_threads=2,
+        superdex_effort_limits=[3.0],
+        superdex_allow_contact_approximation=True,
+        newton_device="cuda:0",
+        body_state_required=True,
+    )
+    assert result == "backend"
+    assert seen == {"num_threads": 2, "effort_limits": [3.0], "allow_contact_approximation": True}
+
+
+@pytest.mark.parametrize("num_envs", [True, 0, -1, 1.5])
+def test_invalid_batch_is_rejected_before_loading_engine(num_envs):
+    with pytest.raises(ValueError, match="num_envs"):
+        SuperDexBackend(SceneCfg("unused"), num_envs, 0.01)
+
+
+@pytest.mark.parametrize("dt", [float("nan"), float("inf"), 0.0, -0.01])
+def test_invalid_step_size_is_rejected_before_loading_engine(dt):
+    with pytest.raises(ValueError, match="sim_dt"):
+        SuperDexBackend(SceneCfg("unused"), 1, dt)

--- a/tests/test_superdex_contract.py
+++ b/tests/test_superdex_contract.py
@@ -30,6 +30,22 @@ def test_unsupported_python_has_actionable_diagnostic():
             load_superdex_dependencies()
 
 
+def test_render_capability_allows_explicit_skip_only():
+    plan = SuperDexBackend.resolve_play_render_plan(
+        play_render_mode="none",
+        play_steps=10,
+        output_video=None,
+    )
+    assert plan.mode == "none" and not plan.record_video
+    for mode in ("auto", "record", "interactive"):
+        with pytest.raises(NotImplementedError, match="no renderer"):
+            SuperDexBackend.resolve_play_render_plan(
+                play_render_mode=mode,
+                play_steps=10,
+                output_video=None,
+            )
+
+
 def test_factory_routes_only_superdex_options(monkeypatch):
     seen = {}
 

--- a/tests/test_superdex_materialization.py
+++ b/tests/test_superdex_materialization.py
@@ -1,0 +1,232 @@
+"""Cold authoring checks and optional native SuperDex numerical probes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim.backend.superdex.materialization import (
+    _actuators,
+    _audit_model,
+    _geom_pair_allowed,
+    materialize_model,
+)
+from unisim.scene import SceneCfg
+
+MODEL = """<mujoco>
+  <worldbody>
+    <geom name="floor" type="plane" size="1 1 .1"/>
+    <body name="base" pos="0 0 1">
+      <freejoint name="root"/>
+      <inertial mass="2" pos=".03 .02 0" diaginertia=".03 .04 .05"/>
+      <geom name="left" type="box" size=".1 .1 .1" pos="-.15 0 0"/>
+      <geom name="right" type="sphere" size=".1" pos=".15 0 0"/>
+      <body name="arm" pos=".2 .1 0" quat=".9238795 0 0 .3826834">
+        <joint name="hinge" axis="0 0 1" pos=".04 0 0" range="-70 70"
+               damping=".2" armature=".01" frictionloss=".03"/>
+        <geom type="box" size=".08 .03 .03"/>
+        <body name="tip" pos=".15 0 0">
+          <joint name="slide" type="slide" axis="1 0 0" range="-.1 .1"/>
+          <geom type="sphere" size=".03"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="slide_motor" joint="slide" gear="2" ctrlrange="-3 3"/>
+    <position name="hinge_servo" joint="hinge" kp="20" forcerange="-5 5"/>
+  </actuator>
+  <sensor>
+    <jointpos name="angle" joint="hinge"/>
+    <framepos name="body_pos" objtype="xbody" objname="arm"/>
+    <contact name="left_contact" geom1="floor" geom2="left" data="found" num="1"/>
+    <contact name="right_contact" geom1="floor" geom2="right" data="found" num="1"/>
+  </sensor>
+  <keyframe><key name="home" qpos="0 0 1 1 0 0 0 .2 .01"/></keyframe>
+</mujoco>"""
+
+
+def test_actuator_order_is_independent_of_joint_order():
+    mj = pytest.importorskip("mujoco")
+    m = mj.MjModel.from_xml_string(MODEL)
+    result = _actuators(mj, m, ("root", "hinge", "slide"), None)
+    assert result["actuator_joint_names"] == ("slide", "hinge")
+    np.testing.assert_array_equal(result["actuator_qpos_indices"], [8, 7])
+    np.testing.assert_array_equal(result["actuator_qvel_indices"], [7, 6])
+    np.testing.assert_array_equal(result["actuator_gear"], [2, 1])
+    np.testing.assert_array_equal(result["actuator_kp"], [0, 20])
+    np.testing.assert_array_equal(result["actuator_force_ranges"][1], [-5, 5])
+
+
+@pytest.mark.parametrize("floating", [False, True])
+def test_welded_parent_contact_filter_matches_mujoco(floating):
+    mj = pytest.importorskip("mujoco")
+    root = '<freejoint name="root"/>' if floating else ""
+    xml = f"""<mujoco><worldbody><body name="base">{root}
+      <geom name="a" type="sphere" size=".1"/>
+      <body name="spacer"><body name="child">
+        <joint name="hinge"/>
+        <geom name="b" type="sphere" size=".1" pos=".15 0 0"/>
+      </body></body>
+    </body></worldbody></mujoco>"""
+    model = mj.MjModel.from_xml_string(xml)
+    data = mj.MjData(model)
+    mj.mj_forward(model, data)
+    assert bool(data.ncon) is (not floating)
+    assert _geom_pair_allowed(model, 0, 1) is bool(data.ncon)
+
+
+def test_massless_fixed_frame_does_not_gain_carrier_mass(tmp_path: Path, native):
+    p, r = native
+    source = tmp_path / "spacer.xml"
+    source.write_text("""<mujoco><worldbody><body name="base"><freejoint/>
+      <geom name="a" type="sphere" size=".1"/>
+      <body name="spacer"><body name="child" pos=".3 0 0">
+        <joint name="hinge"/>
+        <geom name="b" type="sphere" size=".1"/>
+      </body></body></body></worldbody>
+      <actuator><motor joint="hinge"/></actuator></mujoco>""")
+    plan = materialize_model(p, r, SceneCfg(str(source)))
+    scene = p.create_scene("massless_frame")
+    cleanup = None
+    try:
+        actor, cleanup = plan.spawn_actor(scene)
+        spacer = scene.get_actor(actor.get_nested_link_actors()[plan.body_link_indices[2]])
+        assert spacer.get_mass() == 0
+        assert plan.body_mass[2] == 0
+    finally:
+        if cleanup is not None:
+            cleanup()
+        p.destroy_scene(scene)
+
+
+def test_audit_rejects_springs_and_multijoint_bodies():
+    mj = pytest.importorskip("mujoco")
+    spring = MODEL.replace('damping=".2"', 'stiffness="1" damping=".2"')
+    with pytest.raises(NotImplementedError, match="springs"):
+        _audit_model(mj, mj.MjModel.from_xml_string(spring))
+    multiple = MODEL.replace(
+        '<joint name="slide"', '<joint name="extra" axis="0 1 0"/><joint name="slide"'
+    )
+    multiple = multiple[: multiple.index("<keyframe>")] + "</mujoco>"
+    with pytest.raises(NotImplementedError, match="one joint"):
+        _audit_model(mj, mj.MjModel.from_xml_string(multiple))
+
+
+@pytest.fixture
+def native():
+    p = pytest.importorskip("superdex.physics")
+    r = pytest.importorskip("superdex.robotics")
+    was_initialized = p.is_initialized()
+    if not was_initialized:
+        p.initialize(0)
+    yield p, r
+    if not was_initialized:
+        p.shutdown()
+
+
+def test_split_geometry_preserves_inertia_and_kinematics(tmp_path: Path, native):
+    mj = pytest.importorskip("mujoco")
+    p, r = native
+    source = tmp_path / "scene.xml"
+    source.write_text(MODEL)
+    plan = materialize_model(p, r, SceneCfg(str(source)))
+    assert plan.joint_names == ("hinge", "slide")
+    assert plan.sensors[0].joint_index == 0
+    assert plan.sensors[2].native_link_index != plan.sensors[3].native_link_index
+    np.testing.assert_allclose(plan.keyframes["home"][-2:], [0.2, 0.01])
+    scene = p.create_scene("materialization_test")
+    cleanup = None
+    try:
+        actor, cleanup = plan.spawn_actor(scene)
+        native_links = [scene.get_actor(h) for h in actor.get_nested_link_actors()]
+        a = native_links[plan.body_link_indices[1]]
+        b = native_links[plan.sensors[3].native_link_index]
+        assert a.get_mass() + b.get_mass() == pytest.approx(2)
+        np.testing.assert_allclose(a.get_rigid_center_of_mass_local(), [0.03, 0.02, 0])
+        np.testing.assert_allclose(
+            a.get_rigid_moment_of_inertia_local(), [0.015, 0, 0, 0.02, 0, 0.025], atol=1e-6
+        )
+        dtype = np.float64 if p.uses_double_precision() else np.float32
+        q = np.array([0.1, 0.2, 1, 0.4, -0.2, 0.3, 0.2, 0.01], dtype=dtype)
+        actor.set_articulated_pose_from_joints(q)
+        m = mj.MjModel.from_xml_path(str(source))
+        d = mj.MjData(m)
+        d.qpos[:3] = q[:3]
+        quat = np.asarray(p.Quaternion.from_rotation_vector(q[3:6]))
+        d.qpos[3:7] = quat[[3, 0, 1, 2]]
+        d.qpos[7:] = q[6:]
+        mj.mj_forward(m, d)
+        for body in range(1, m.nbody):
+            link = native_links[plan.body_link_indices[body]]
+            np.testing.assert_allclose(
+                link.get_root_transform().translation, d.xpos[body], atol=2e-6
+            )
+            got = np.asarray(link.get_root_transform().rotation)[[3, 0, 1, 2]]
+            assert abs(np.dot(got, d.xquat[body])) == pytest.approx(1, abs=2e-6)
+    finally:
+        if cleanup is not None:
+            cleanup()
+        p.destroy_scene(scene)
+        plan.cleanup()
+
+
+def test_contact_approximation_requires_explicit_opt_in(tmp_path: Path, native):
+    pytest.importorskip("mujoco")
+    p, r = native
+    source = tmp_path / "contact.xml"
+    source.write_text(MODEL.replace('name="left" type="box"', 'name="left" condim="6" type="box"'))
+    with pytest.raises(NotImplementedError, match="allow_contact_approximation"):
+        materialize_model(p, r, SceneCfg(str(source)))
+
+
+def test_contact_queries_keep_separate_geoms_on_same_body(tmp_path: Path, native):
+    pytest.importorskip("mujoco")
+    p, r = native
+    source = tmp_path / "scene.xml"
+    source.write_text(
+        MODEL.replace(
+            'name="left" type="box"', 'name="left" priority="2" friction=".25" type="box"'
+        )
+    )
+    plan = materialize_model(p, r, SceneCfg(str(source)))
+    scene = p.create_scene("separate_contact_geoms")
+    cleanup = None
+    try:
+        actor, cleanup = plan.spawn_actor(scene)
+        actors = {}
+        scene.for_each_actor(lambda a: actors.setdefault(a.get_name(), a))
+        floor = actors["floor"].get_handle()
+        links = [scene.get_actor(h) for h in actor.get_nested_link_actors()]
+        left, right = [links[s.native_link_index] for s in plan.sensors[2:]]
+        left_mu = left.get_contact_params().coulomb_friction_coefficient
+        floor_mu = actors["floor"].get_contact_params().coulomb_friction_coefficient
+        assert np.sqrt(left_mu * floor_mu) == pytest.approx(0.25)
+        left.register_query(p.QueryType.CONTACT_POINTS)
+        right.register_query(p.QueryType.CONTACT_POINTS)
+        dtype = np.float64 if p.uses_double_precision() else np.float32
+        # Tilt around Y: right sphere intersects the plane; left box stays above it.
+        actor.set_articulated_pose_from_joints(np.array([0, 0, 0.16, 0, 0.5, 0, 0, 0], dtype=dtype))
+        # step(0) refreshes state queries but does not rebuild this contact manifold.
+        # A positive solver step is required before reading geometric contact results.
+        scene.step(0.0001)
+
+        def has_contact(link):
+            own = link.get_handle()
+            return any(
+                cp.distance <= 0
+                and (
+                    (cp.actor_a == own and cp.actor_b == floor)
+                    or (cp.actor_b == own and cp.actor_a == floor)
+                )
+                for cp in link.get_contact_points_world()
+            )
+
+        assert not has_contact(left)
+        assert has_contact(right)
+    finally:
+        if cleanup is not None:
+            cleanup()
+        p.destroy_scene(scene)

--- a/uv.lock
+++ b/uv.lock
@@ -121,6 +121,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -180,6 +189,100 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
     { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
     { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/aa/554e2614f38fc34c58ff1d0911ae8535ad2516440d5482d76fe59f1088b0/charset_normalizer-3.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1ee1e296209fdce05b81b663250eefa02213a2da7b41bf26f7829b8ba3545aa", size = 369072, upload-time = "2026-08-15T08:16:22.964Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6d/439231dfc3ccfa6f8c06477b7da2219cbd41a2de3d49084df8ec7b5100f2/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9fbdce1e47394b09bc9f26ab117dfc8d6491977a11d86f592bb42c779db2fda", size = 251142, upload-time = "2026-08-15T08:16:24.81Z" },
+    { url = "https://files.pythonhosted.org/packages/55/53/7d819bd23a00ef45039146fa2cce1daa2f0771e758c5653ee1f6edac91ed/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:00668ebb0609751758682eb0b5857e7c35b9f00e84dfdef062e103244ec94d45", size = 240714, upload-time = "2026-08-15T08:16:26.392Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2c/45847198c16f4b38090cc7423b2b6a9008e438704d8ab413211832498d31/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba2f37ee79e6338845261a3c5b1784e5d1acdff2c0785b284f1b633033d136ab", size = 279637, upload-time = "2026-08-15T08:16:27.961Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2b/d8be3523ddf9f0b0f3e56d1359034aa10653a4d11564c697f802b4775766/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ce854f5f478050ade5a238731c4ca985a7d3b3cb53ff600a9b5c3b689b5f0a7a", size = 276543, upload-time = "2026-08-15T08:16:29.399Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cd/4f564b8f132de25db594efc706897069f016790cea63a5669c9df2675f64/charset_normalizer-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:96eefc178f8636b9c760c5829345307fd81cfae9ab1e80997dbddeb0f54ee9a3", size = 261644, upload-time = "2026-08-15T08:16:30.722Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e3/38b975422534a608f98c360e79c2f07c763d66dd4272300d45fb1fee54b0/charset_normalizer-3.5.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:366ec70f5547c640d3ce1985722490f23faf4eb5216a7eeba78277490e78dacb", size = 259609, upload-time = "2026-08-15T08:16:32.248Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bd/fbc24d825c66f1c74f6ccdea3742c3d8354a4888e86d1315a197fee69061/charset_normalizer-3.5.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:950f23cb393f85543777b0433f082cddd25b51ab398eac7971146495679efe5f", size = 252457, upload-time = "2026-08-15T08:16:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2d/918d0e98a0e679469ed05bb2d90c2088b4d315bb612969d8499f76fb5210/charset_normalizer-3.5.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:c1dcc36dcb96abc02236e182d17e0f71430152a6c2c7447421da2d2dc144edea", size = 242240, upload-time = "2026-08-15T08:16:35.396Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c8/c36f6e0b2dfec351bd38cbc05362697e58bcd073d7dbd95154290c9714ce/charset_normalizer-3.5.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:07ffd07412fc5d5e84cd8952acf9ff7e4ed7a708e69d1bada19d8ba91711353f", size = 280308, upload-time = "2026-08-15T08:16:36.825Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/7b/311b3e02e8c4092400c449c850a760d8c45d900983c83a70cc07208c551d/charset_normalizer-3.5.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f5542f9b941279d82d41eb0aa9f98eba36fe4df5c7086c651df7944935b37182", size = 258679, upload-time = "2026-08-15T08:16:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/90/082cc45599c392f28c036a497f49e0634041a785fc3849c80ccf396d096f/charset_normalizer-3.5.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a545775cfe815855ea32d7c27731d79da358ef2055b4a25830231b1622dd18aa", size = 277221, upload-time = "2026-08-15T08:16:39.62Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ad/b9aecf38d805cbcf84fa94f14c5d972a16561e20296a11dc799a5dcf3763/charset_normalizer-3.5.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:494b70049a4d69aec6e8137c13af4cf8db8c9f9820a1392ac293b0dd2987a818", size = 263799, upload-time = "2026-08-15T08:16:40.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/b38a20598d5a825f85d9d7636860e56ff0db1479f86497a6e485aa9326f7/charset_normalizer-3.5.1-cp310-cp310-win32.whl", hash = "sha256:94fbf1c0c6cc0d3d5e50f9a9313a8cdca90dd696d34b381cd1704f8c9e939f20", size = 182037, upload-time = "2026-08-15T08:16:42.198Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/21/83fffb77864408b8bf0fe1ca603926401d6f8775a8e150b39aacc9958f8a/charset_normalizer-3.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:be47f99644b208bff7766314013f9acf57b056b04191d570d68ad14022cf5b1d", size = 206030, upload-time = "2026-08-15T08:16:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2e/b93135b5034b1157fb29554b0d06d4844ce62282f0e0a14036f93d7ee2e7/charset_normalizer-3.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:a6d095662e73e74f0a49988e0593373e243e3a52e27bfeea0a859e88acf4a0f5", size = 185092, upload-time = "2026-08-15T08:16:45.177Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b6/034f6802e9c3f6418966cfabb7db8c9252cc2429c5098f41cc43af804149/charset_normalizer-3.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eda059b6bc8bc0812d626fd91a7ce01bf583df0a61296eff390fd94141a34e30", size = 363585, upload-time = "2026-08-15T08:16:46.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fa/6a7e2a7c4b5451912b8c417732df79574354443592a88d616de03da66ae5/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa2bb0b37202dca27175591f761108b5d34096ade1191ffe4808bdf6b1571488", size = 251189, upload-time = "2026-08-15T08:16:48.287Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c8/ab42b07cfd82e919f427fcfaa7c41abae8242833ad1aad66d42bae40b669/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b2b1b3fa5670c127b246df1d0c059defd41f689a868a3b9d79df9b1cac42d22", size = 239724, upload-time = "2026-08-15T08:16:49.67Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/80/b9348b5d3041209f98b4cdad7655766369233f1d533f4f4f7558e9717bec/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e5e4d73d588ca5ed09df1b7dcd1b203d1df3c542e3f50d126c947d432b10731", size = 280078, upload-time = "2026-08-15T08:16:51.228Z" },
+    { url = "https://files.pythonhosted.org/packages/82/38/083a24028304bc85bb9e376fed801178423dcbb67495f73b6ea0624e1894/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b54e7e13267d49ffbfe68e25b3cbd774dab38fa37238f71265e91b36146eb21c", size = 276650, upload-time = "2026-08-15T08:16:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/35/731ac04aa0a097fc1c97f0994c375bdb230c6c96619db794208fe664e9ce/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7b742bf31c88566b4bb6335a7f393bb322e580b6bb98df7bd0c25e6e3519ce8", size = 262325, upload-time = "2026-08-15T08:16:54.085Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/28/c2028e7021fb89c6e56868ed0e387b8e9aa811abdd2ab3208d6578d2c930/charset_normalizer-3.5.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ba32c4d2abf1d2fe7cf27d280f4cca5664233b0f885549c7761719eb977f486", size = 261140, upload-time = "2026-08-15T08:16:55.604Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f0/0c0ceec6d98b7daa62e361e418135d59685811d79ba11529aad5cdf15e84/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0722590aabf9dc6a6c0343d523c05458fa2b5047dbe6302fd526bb570600753f", size = 252791, upload-time = "2026-08-15T08:16:57.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3e/48f4cd187b1c33189d86039e9cbe4f92c05454175504b44ff81806d4d1bf/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:aa1099b956fb795e686d073568f6dc002a0bb89765ea6d5b055dd7d9bf1b116c", size = 240730, upload-time = "2026-08-15T08:16:58.418Z" },
+    { url = "https://files.pythonhosted.org/packages/42/85/f9e22af69af67c54cce42be9455d9c81294f918b4ccc454db01f66efcac2/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bd6c173f04743d483881bffa1478d5a4624475b8cd1d2194956a75548e191c18", size = 280791, upload-time = "2026-08-15T08:16:59.918Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4c/9044135f42127630b6fa742feb51256353f6ab87a78f2fdd1de3de955a7f/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f298e218441525d3794428b4c8b8fb8662c6d3ea79925d4807ee6b9a96a3bca5", size = 259598, upload-time = "2026-08-15T08:17:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ed/1dd7cfebb4e75812934c49ca3b79757d11948053f7937ab7070c151f3c55/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:6e2912d4babbc65196ac13c2f53468dc57fb8b9c25ef913e8c59ddf7c6dc0e1b", size = 278217, upload-time = "2026-08-15T08:17:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/eb/239c84503cc9e3ba6eb34686a24bc66e84f3924efdd7e38e751a19f6bc10/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3d27167433c0d5f18dc850f07d0b3816221984fecdc405d6c157a6f0b8f8e9e6", size = 263417, upload-time = "2026-08-15T08:17:04.216Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ab/4e4510e1e288478e2c8333131d1c1382382ba8cd2165053c79e39d1da961/charset_normalizer-3.5.1-cp311-cp311-win32.whl", hash = "sha256:ac00177c4831ffa650f8609e4bdddd5fe09c03b1c0c47acece7e6ea20421598b", size = 181774, upload-time = "2026-08-15T08:17:05.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/57/32f0ccea59e8612057c61d6fd22ef2cb63cca93c9fe594094919696ac170/charset_normalizer-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:f9b1e28d0e8dbfa858abdba91d6b547beaf2df1a59bec6da6faae7b96a4991a9", size = 206653, upload-time = "2026-08-15T08:17:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d4/b65c433fc521e58b5f54293982a5e51c05cb5f2dd3f1c7a6acb65b75324e/charset_normalizer-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:ae31a1a1db2ee6cc2942fccaf695c934bc7f3db9f2133a3fef1f367cf1a4ab10", size = 185630, upload-time = "2026-08-15T08:17:08.502Z" },
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
 ]
 
 [[package]]
@@ -392,6 +495,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
 ]
 
 [[package]]
@@ -696,6 +813,15 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
 name = "imageio"
 version = "2.37.4"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +834,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/62/aa770a9307508d2a2a2c62d536a49347bffe9e55322db27838d3c93d0b07/imageio-2.37.4.tar.gz", hash = "sha256:e45cbc5e83502047fb138f7f585f7f105a136a57eea5f4b3cfc6ce1b52720bd3", size = 390173, upload-time = "2026-07-20T05:26:11.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/2d/ca050652104bab2cf55e569db2a178b1b61cb041fef28307f2db383f6d9f/imageio-2.37.4-py3-none-any.whl", hash = "sha256:1ab2e22c8debf700f24c3ac43e8f95f3b3a8110c83b93411e97b4b0b2cd1c7e6", size = 318000, upload-time = "2026-07-20T05:26:09.874Z" },
+]
+
+[package.optional-dependencies]
+ffmpeg = [
+    { name = "imageio-ffmpeg" },
+    { name = "psutil" },
 ]
 
 [[package]]
@@ -1744,6 +1876,69 @@ wheels = [
 ]
 
 [[package]]
+name = "polyscope"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/57/bf8bfc975ff6ab7547ae68db4f87ffb3fc7861acbe0fdd08cd4de9b66db1/polyscope-2.5.0.tar.gz", hash = "sha256:3a97e57297b231a9fc93a98c4f9eab852819d79f0807ce64071cdc9dabd53868", size = 14746772, upload-time = "2025-08-19T08:32:52.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/13/2e7e68e9e8f4e2070962074b958c4e2556ed21c0a60b26c06bca4c9c81ac/polyscope-2.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1aac3166ee5d41c5519dcf63012fdf8f45313c2619a7dc83eff96d3a04eef0af", size = 6996607, upload-time = "2025-08-19T08:29:13.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/34c955570de97cd4e4ca067361ad648b141ed4da4fab1a86c7c4a495fe47/polyscope-2.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7bbb9e630b55154cc04bfbde06534d0b982bc46eac26161598d8633b84082cb7", size = 6768481, upload-time = "2025-08-19T08:29:15.681Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e1/482a5b4af5a36525b097e76fcb72040ff609124931cd640423a4da372610/polyscope-2.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6390144616b920908ab2e1c6c470f6029875c12ca670145a8ed069d30c8f375d", size = 7688941, upload-time = "2025-08-19T08:29:17.873Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ef/aff80ba43b249be09f15342303314b3fcd5c399f6cbd22d34051e5d8e314/polyscope-2.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:651f4ce7a4d75f5f54822eec554d4299016ddde25341a7cb35b3a2370ba1a342", size = 8027960, upload-time = "2025-08-19T08:29:19.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6e/f430ff90f08cfa4f01b730c3ad80e5304a91a61241d657ab6317d78d9f96/polyscope-2.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:211b80b35e50ed4e48cff6a31630ff1cc3961b38c7f79408fd4f29f1e70eed8b", size = 7815655, upload-time = "2025-08-19T08:29:21.862Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/89/735944e749f0dae9f031f96e960865c7cbdd770c9cae119db7ddfb9f0416/polyscope-2.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ad54a32f89a531b813acc4bbde3edacd48e983ca1f55d8d4014bc9a221dcea13", size = 9491130, upload-time = "2025-08-19T08:29:23.75Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d9/6e19cf8af91931c9d517b24daf0d5d8a63fe6576bb3687a7f3b996573989/polyscope-2.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:aeaf914637d99618a7f35819d1bdc6d6aaf5cc7ddbcf16754574e500fd987805", size = 10456708, upload-time = "2025-08-19T08:29:26.387Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4d/4ddc9be541c37044087b612e43eaeb3ff630f317ae6c0f4de2a69b4ff7b3/polyscope-2.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0788ffe1bd8f2a5fc21eb2528634345ce02fb756d7b7c297513aa5e03294ce52", size = 10004583, upload-time = "2025-08-19T08:29:28.649Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/977ba7ee3c3ab34db56135a11bfe951c8f487ce4a48517cf845fa0dae71f/polyscope-2.5.0-cp310-cp310-win32.whl", hash = "sha256:75146f22202ae19f2c23ab7bb9df4f635258a8ead667c5aef513f7ff724c3ace", size = 7219742, upload-time = "2025-08-19T08:29:31.061Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/85/b20992d1f2413b3722ca4aaa9526a42430a97fb134bf091d86b2fb3d0825/polyscope-2.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:24f5b9955c25d251fce84a2c4bee143a6af47bd09b8122a4a0ef3e005fc47bc6", size = 8666163, upload-time = "2025-08-19T08:29:33.179Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/97/9684b48b47a313cbc712a3ae375356083406b78a87c6d57fc0b9b20b20ce/polyscope-2.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aef99812585b7e8641add906943dffaf848da14616a99df02ed6ab4d6f568169", size = 6997888, upload-time = "2025-08-19T08:29:35.315Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ab/fa322697b26ecdda1d33dfc6d14bc22b4150a8fdff5a366d50609eee8ea6/polyscope-2.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19cbea41e4b85a4fb55296d47bd473e75144920ba50b3aecfdcf5e07d5445439", size = 6769877, upload-time = "2025-08-19T08:29:37.586Z" },
+    { url = "https://files.pythonhosted.org/packages/37/91/24dd74d2b6fe030d35f0623d498c8a66a8baec60334bf6e870f5ac7f8e5c/polyscope-2.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26ef0c47e600bbd6ce413e297d6bc23c196887058b9320bf855f3d864575a46f", size = 7691878, upload-time = "2025-08-19T08:29:40.118Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/65/095c37e4552bb89ab0ad0c2d42826d1ff12ec0d417dca363f3d8ef8c044c/polyscope-2.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:555e6a85f5ddbe77b66584e22e924cc0fede31a5bcc9f6fc79af90378184f765", size = 8028828, upload-time = "2025-08-19T08:29:42.03Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/55/188740d8c1e55b02bf0e21c12775a7f374f293ff33044b7aef1d86ad9ea3/polyscope-2.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88302bfe110c64c8ae3a1433911aca29a9b881285c8b0d7ee333304fbdf05fce", size = 7814868, upload-time = "2025-08-19T08:29:44.024Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/6e/d8e3e460353ce405ff82b79d19c465de5421864e884843cabd63a54db79a/polyscope-2.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5e092849cd0d53f086621efd0a745631d83638c07ce77dcae27e108d8a5f23e2", size = 9492934, upload-time = "2025-08-19T08:29:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0d/8b22c6746dbb472c24c5c235b2aa0159e337fb83b297ed0b0bb4ef099f44/polyscope-2.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a3f98b2d852c2bae14e637ff22328e7de41cf86b99d883c99d0952a381350f20", size = 10457257, upload-time = "2025-08-19T08:29:48.075Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ab/9d3e22b1f1c128dd19f365f9c8a36cbf6e210cd45fe0a5b2dacc00962128/polyscope-2.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fe386475e8dff9072eb6a1ea191aa870236f2fb99b6bd77745b29092b6a539e0", size = 10010058, upload-time = "2025-08-19T08:29:50.24Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f4/37406c301bfeaa8742fbb669eede5353ea4a21e76c0f68278c6d3c64cac9/polyscope-2.5.0-cp311-cp311-win32.whl", hash = "sha256:1bfaea90917d327edd37f5b6171de2e93264ee785f6cfebdd0a24ecba2380d86", size = 7220468, upload-time = "2025-08-19T08:29:52.419Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3a/75596d7cca715e4d6ed64e4e74590d73d3b2ac3687800d406fd4cbb2aa1d/polyscope-2.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:a2b9594632d2cca39845e05082b2984a91426da99512910e54b5c423775c125b", size = 8666670, upload-time = "2025-08-19T08:29:54.853Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/25/c0f6647624e0e24902f4d2dcf7b4ad646858f7fe2de542c6752052d97365/polyscope-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:22df5c1be72846d7be247f0dec1a9fd88a85360cc561efbdedbf51c326ad35d3", size = 7022623, upload-time = "2025-08-19T08:29:56.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/84/32e15cccbafbc61b986081e9128199929e4b0018fdd22a24c6727eaa93b4/polyscope-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:04b720ca35fa39d21dbf127a032212a8b91a76e6e2be8fa43696ce49d833d082", size = 6779665, upload-time = "2025-08-19T08:29:58.699Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/6d/f6bd89a3bac460b3fcdeaacee4ff2dbae8f29f06a336a57a7e4f455601ad/polyscope-2.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1d375dd24e82831a00484723037f33bb92d895bd26ce4a7541d693dddb18b45", size = 7689595, upload-time = "2025-08-19T08:30:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a7/840ece674328a0b6ad860a0d1ad38663cdf4cf3cfbcacf8cc935d870e67c/polyscope-2.5.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9aa3a926600a22bc5138f179b5a0bac71bc0782e1ed7fcdf737dc2d06d405bb1", size = 8041248, upload-time = "2025-08-19T08:30:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4e/82ea84c9e90125eba5c73e28c1caa01d03f304e06936759150a7a3565827/polyscope-2.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c093803adb7a74540e4f536812978d44acfdaf585238da8e118a7a5ecbad35e6", size = 7826546, upload-time = "2025-08-19T08:30:04.203Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2c/e60d6c88eef4d755bfe10a13ea530e8ae407f9257638c2ac7f6d545bcc84/polyscope-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3885178f793043a186eb4e75b4786d006c2063e341ccfe4c68feea0fd1e782d0", size = 9481108, upload-time = "2025-08-19T08:30:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/47/0d/7f749ff35a99df8883d4c79967531cec5970753ebf8b455233cdee592e60/polyscope-2.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:fdec04499a38b49ad6a366fc63bc9eeb76422f01eb56f2ae54ed801c078be6fc", size = 10448338, upload-time = "2025-08-19T08:30:09.298Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ff/7bac1e8ce7e1d8bc7cacd70e62ad4361b3dcc10553dff313bc51ac82c0a8/polyscope-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a5c98845a7e938a6c08829daeeb733bee6c0ad9c95cbf461614dacdae2d31360", size = 10001021, upload-time = "2025-08-19T08:30:11.543Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/54/f176207da4ddf065b6a3f22c2072af17f21b005eae590f7265c9a0286c3f/polyscope-2.5.0-cp312-cp312-win32.whl", hash = "sha256:249bc1cf313c5d61f3c5e98c441cdf06ec25a2582bbffa746b53ce68eb25ea45", size = 7225386, upload-time = "2025-08-19T08:30:13.64Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/76/ed2e4b52f8cf29b4e815a1c4cbed1979edf6d61a67085e8c02ff58b06cee/polyscope-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:dbb0d030611d72db8f7e282285bd2cf7f6488af82d52160fbe4fe9bee50f9ab6", size = 8667705, upload-time = "2025-08-19T08:30:15.409Z" },
+    { url = "https://files.pythonhosted.org/packages/45/86/736d08f6715e1965a1cd904e77ffb4456c295d5af95ac7f3df1ab341b9e4/polyscope-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ede57b05a352f81c8abe9f4979e21ceb025cc7f6b5c63cbe78a8eff4d57245fe", size = 7022730, upload-time = "2025-08-19T08:30:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e0/c09266d5bf2aa7fc031febbe80294c6cdbe029c96593a0ea61ade25681a9/polyscope-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9512af145f1c688d47ebbebe2a9b3a4dae81f61ce69cb8df07cf17daf8f72124", size = 6779665, upload-time = "2025-08-19T08:30:20.475Z" },
+    { url = "https://files.pythonhosted.org/packages/88/eb/2471503819f54c37b675a8de998afae0965babc0842599c79a34fc04769e/polyscope-2.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd92636964204907a0631bfd15b58e35119963e745a2c8ce3070cce31f992744", size = 7690303, upload-time = "2025-08-19T08:30:22.711Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/231a407c1a778fd00ee12ab5e138c8f3242541c6552b52a4c16cd0c02533/polyscope-2.5.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a08732e78a91067a855417ce60fcac83e100b65af611dc94008cbb161aacef4f", size = 8041385, upload-time = "2025-08-19T08:30:24.613Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/33/d9df9f22e65fcad83e7c340c2d06ffe34934f606d0c56ae04f9de962228d/polyscope-2.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccc1d04e3d0c6b071bc1d1acbad4209dbdfd7f9350e229c07e485d1f668947d0", size = 7827660, upload-time = "2025-08-19T08:30:26.425Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/11/5642fad122abf44f10e64080cce33203fee9b5c24d33ba33389a7120fbc2/polyscope-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0819e8b4ef543a64075b943767ff3245d64fc9780934a634e3f0dd51a8dc6ff9", size = 9480984, upload-time = "2025-08-19T08:30:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/c0/3bfcb016d39c789d82d71804093244715293328be92ab7519c7a51708868/polyscope-2.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e4cdf6bfb07e5353f52b8877994f984dc9e3fc35a99f70d65ed94da4ef38e592", size = 10448343, upload-time = "2025-08-19T08:30:31.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/02/8399e1ede1daea62e3ea3e25e39b615f5c0eb5ac233e534f34db18c9a70e/polyscope-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ea87f39c6c8809b9d92c743fdba00127811107d495f97365060422f04ed84d2", size = 10001404, upload-time = "2025-08-19T08:30:34.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/12/ff66809bcfb8f6883cef7a61d5602368000e123893db21346649d693e755/polyscope-2.5.0-cp313-cp313-win32.whl", hash = "sha256:def6926f3ac66ab956cfea43a3d6d34ede5cdff2be36ad4f09901aeeed9da66b", size = 7225140, upload-time = "2025-08-19T08:30:36.419Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fa/7afeaba5dbebfda50f7ad1f360529651554dc8d4c905ba5074677cdfeadd/polyscope-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:b98cd39478f17f08977ebbdf099aa760806916c7b84ec8a9ee926642c5a67e70", size = 8667698, upload-time = "2025-08-19T08:30:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/12/3d/79782a271d1083928ec251b6f4a876b09da50229fded027d84989d899a7f/polyscope-2.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:de7cfc2df0bfb14f180ab6c4e0424d7ad6558cafc8763ec40a82e72d27a6cbce", size = 6996947, upload-time = "2025-08-19T08:31:44.904Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ae/300cde099df56b519e62ce6dd42dbadbc31452b1e03d4d99c203de3dc89d/polyscope-2.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:ab474f6e240c07f9e0c70cfd84e483dac062119f58700c70b70e55b8ef98e627", size = 6776398, upload-time = "2025-08-19T08:31:47.122Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ae/1089ec6532f2512a425cde8575654ef9457b5da4b5757d51ee038241676a/polyscope-2.5.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c92f34e6cdbdca62f04c9534c3a8f316ca2fab440161876db897bfbc26f184", size = 7692173, upload-time = "2025-08-19T08:31:54.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6a/42e06a5a0297981ae687ffa744db06b41d1910c93ec20fe542bd5856a28f/polyscope-2.5.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b69b4bb4e19fdb84b8cd7a0ee041285757be3461e0a3f38cfcf2b5d88bd94aa7", size = 8035362, upload-time = "2025-08-19T08:31:56.036Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/27/8304649d0ee809e2f0cb12dbdf749bf4e50ca9eabe5eeae688726840af8d/polyscope-2.5.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d65b41febd5c6b8df8e376937a853c79410ed4163edb26b83361042cc47b4f50", size = 7826880, upload-time = "2025-08-19T08:31:58.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/79/df5f4d1c4b077154d9c9d7c7f4ae1b0f624296dab972cf8e4353afb3e9f5/polyscope-2.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2c0d47868a1ce0367bc583a3fb5e9cf1c31d22140c44405e83cf3e759164d751", size = 8665997, upload-time = "2025-08-19T08:32:00.308Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bb/fd55cee3adfa8cc0457f6f66db89cd33ea341ee174cfc5a4df84b6b615c0/polyscope-2.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f2079956a4be247c91615bcbf8766c6d3f82a507943377ad3599a6953701c544", size = 6998010, upload-time = "2025-08-19T08:32:03.389Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0e/9aba0ae09e1d524d4a00b9f33698018c1f886fc8d1567aa452432fee3b56/polyscope-2.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:03bb1ac26fb1dd7bf31ffee0775a2f8424a138f1ebc51b1be10b21de9767dc60", size = 6778568, upload-time = "2025-08-19T08:32:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/65/307074995d5749a6a68e17de80647b591e7a7b278a3dd3e7fbe9469f0aef/polyscope-2.5.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d0ab47ab1eb035b7071f4d6a9344a1512b7d3897f8b2c79afca3f8c299db2ee", size = 7693466, upload-time = "2025-08-19T08:32:07.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/81/878f73e779b3ee7feec35a6029c5f0367b88bf8889d91905010254653bf8/polyscope-2.5.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf496e4ce2e1c4e08f3bd787e24096144f4e27a7a620cf68370b5f6b31e7de9e", size = 8036662, upload-time = "2025-08-19T08:32:09.193Z" },
+    { url = "https://files.pythonhosted.org/packages/66/af/c664d6233ba125073b49458837836e7c8c978ba417390b21c83623f1c8f1/polyscope-2.5.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d3921c03a2826b0655142991e2d3454385a19462f893ce032b8a0319d0d7329", size = 7828694, upload-time = "2025-08-19T08:32:10.995Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b3/8190d038a20189cf516acea8ada2475c1502c30ebf00ed6aed1482806fbb/polyscope-2.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a2e226e5cee090b2481ed6a526ae71d5714455120385b5635dbd8340360a21a5", size = 8666786, upload-time = "2025-08-19T08:32:12.968Z" },
+]
+
+[[package]]
 name = "proglog"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2029,6 +2224,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyre-extensions"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/53/5bc2532536e921c48366ad1047c1344ccef6afa5e84053f0f6e20a453767/pyre_extensions-0.0.32.tar.gz", hash = "sha256:5396715f14ea56c4d5fd0a88c57ca7e44faa468f905909edd7de4ad90ed85e55", size = 10852, upload-time = "2024-11-22T19:26:44.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7a/9812cb8be9828ab688203c5ac5f743c60652887f0c00995a6f6f19f912bd/pyre_extensions-0.0.32-py3-none-any.whl", hash = "sha256:a63ba6883ab02f4b1a9f372ed4eb4a2f4c6f3d74879aa2725186fdfcfe3e5c68", size = 12766, upload-time = "2024-11-22T19:26:42.465Z" },
+]
+
+[[package]]
 name = "pysplashsurf"
 version = "0.14.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2090,6 +2298,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
 ]
 
 [[package]]
@@ -2170,6 +2397,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/5f/fd875f16b75e3f021e9fd6f89cbd5a862e2b2b32de275044ffee3fb40544/quadrants-1.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_34_aarch64.whl", hash = "sha256:e84d152b6bcb7ace8604918f157023f1890703d591ba3dda235d52ea71667688", size = 38293514, upload-time = "2026-08-11T21:07:59.306Z" },
     { url = "https://files.pythonhosted.org/packages/59/dc/ab888de75da5604d8a604822a32be2761d5716195d04e467347681215f53/quadrants-1.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2593e5a1078c511dd33e22225da8ea024023564feac331f17820d71ce577194", size = 40974418, upload-time = "2026-08-11T21:07:57.525Z" },
     { url = "https://files.pythonhosted.org/packages/0c/2f/f6ab0908b931e347789634b2f65bc5f1fd07137bc847376fb2abe982bacd/quadrants-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:70c2985fa986b908b1e12564f9ed40b3cd45bae8986d0e5bd41d033d7cf48daf", size = 30988240, upload-time = "2026-08-11T19:52:12.915Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -2491,6 +2733,52 @@ wheels = [
 ]
 
 [[package]]
+name = "superdex-physics"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio", extra = ["ffmpeg"] },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "polyscope" },
+    { name = "pycollada" },
+    { name = "pyre-extensions" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "tabulate" },
+    { name = "trimesh" },
+    { name = "typing-extensions" },
+    { name = "unrealcv" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/c3/50fca36b687a98593597dabd8ce419bf19f202ef4c0614a8adc3248cd803/superdex_physics-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c30a5a36ffc4232e0ca8a0117a43a7af6b1880b674c6a2d3f6b9b67babe1887e", size = 9577424, upload-time = "2026-08-24T17:39:11.543Z" },
+    { url = "https://files.pythonhosted.org/packages/82/38/bbf8e5a47efbdd8f1330713c29a21fdc961c5d0ac3441b38ce6383a9b6c9/superdex_physics-1.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:46fa446ed0bb86815d6970d14e11f2777bcc7391119c4ebe582ac698e1373377", size = 12671509, upload-time = "2026-08-24T17:39:14.15Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3c/b75e94799ed8b0d93517c3eb1f11cb4e9c89e1c7f21414307ba894e42b3b/superdex_physics-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:7715adfada7ca6fbae6edad54a2de4904bcf00d3ee3a6b4be968774f009d4c93", size = 11075998, upload-time = "2026-08-24T17:39:16.964Z" },
+]
+
+[[package]]
+name = "superdex-robotics"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "superdex-physics" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/bb/25626721cffc8cf1bc84e6171dd557d3cb4b86b45e23244c2d6743e64dd1/superdex_robotics-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:79786ef4740eecc2cd3c133cf6143d14dc289e5e7821ad7451be50c93e0357b7", size = 956393, upload-time = "2026-08-24T17:33:45.655Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1f/c449a2baafa4d9248c3b5124d9f727873cc42732028795e2d318fc79f75e/superdex_robotics-1.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9de8feaf989f7ebae285b5bd2a57880c27abf91d0a98db1d4ef5f7ccdd306b2", size = 1078554, upload-time = "2026-08-24T17:33:47.524Z" },
+    { url = "https://files.pythonhosted.org/packages/54/46/c137f1daac1ecfe2886d22ee0b2712680ac50e6275d0e3b831a68e6e9919/superdex_robotics-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:23cd8942bf08364311517bf1e4e616a3efadf30acf658e4159c82cdb89f37c6d", size = 1332524, upload-time = "2026-08-24T17:33:49.092Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2704,6 +2992,11 @@ newton = [
     { name = "pyglet" },
     { name = "warp-lang" },
 ]
+superdex = [
+    { name = "mujoco", marker = "python_full_version == '3.12.*'" },
+    { name = "superdex-physics", marker = "python_full_version == '3.12.*'" },
+    { name = "superdex-robotics", marker = "python_full_version == '3.12.*'" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2718,6 +3011,7 @@ requires-dist = [
     { name = "genesis-world", marker = "extra == 'genesis'", specifier = "==1.3.3" },
     { name = "imgui-bundle", marker = "extra == 'newton'", specifier = ">=1.92.0" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
+    { name = "mujoco", marker = "python_full_version == '3.12.*' and extra == 'superdex'", specifier = "~=3.11.0" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = "~=3.11.0" },
     { name = "mujoco", marker = "extra == 'newton'", specifier = "==3.11.0" },
     { name = "mujoco-uni-runtime", marker = "extra == 'mujoco'", specifier = "==0.5.0" },
@@ -2726,16 +3020,43 @@ requires-dist = [
     { name = "newton", marker = "extra == 'newton'", specifier = "==1.5.1" },
     { name = "numpy" },
     { name = "pyglet", marker = "extra == 'newton'", specifier = ">=2.1.6,<3" },
+    { name = "superdex-physics", marker = "python_full_version == '3.12.*' and extra == 'superdex'", specifier = "==1.0.0" },
+    { name = "superdex-robotics", marker = "python_full_version == '3.12.*' and extra == 'superdex'", specifier = "==1.0.0" },
     { name = "warp-lang", marker = "extra == 'mjwarp'", specifier = "==1.16.0" },
     { name = "warp-lang", marker = "extra == 'newton'", specifier = "==1.16.0" },
 ]
-provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "newton", "isaacgym", "isaacsim"]
+provides-extras = ["mujoco", "motrix", "drake", "mjwarp", "genesis", "superdex", "newton", "isaacgym", "isaacsim"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+]
+
+[[package]]
+name = "unrealcv"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/cb/f52971b2750e1df4e810a4980ce00ba81b3bd51516939cf52e4776f3e1eb/unrealcv-1.3.2.tar.gz", hash = "sha256:fb6eacfd0bd6a19a14c8695770960ce9ddc76a8dd7aa696b557601aeeb345ad2", size = 49617, upload-time = "2026-09-03T08:58:47.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/b4/6b0b4b77aeae30522c19bbabf1a9eda36cceec01fda4e749032ac88d4310/unrealcv-1.3.2-py3-none-any.whl", hash = "sha256:f41c8942d2ebfd6c2e619632792f267ff937ed823a6946fbb71f322d4a78d637", size = 52178, upload-time = "2026-09-03T08:58:46.518Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Result

Adds an independent, optional SuperDex 1.0.0 CPU adapter through the NumPy `SimBackend` boundary. Supports fixed native FR3 bots and an audited MJCF articulation subset, including free-root frame translation, separate joint/actuator ordering, controls and external forces at each substep, independent selected resets, named state/contact caches and explicit process cleanup. The MuJoCo dependency is used only to parse MJCF on the cold path.

Fixes #38; parent roadmap: https://github.com/Motphys/UniLab/issues/1533. Governing ADRs are UniLab ADR-0007 (ownership), ADR-0006 (NumPy), ADR-0002 (capabilities), linked in the roadmap. This PR targets **`dev/issue-1533-superdex`**, never `main`. Version remains **1.1.3**; local editable links connect UniLab; no publishing or release tag.

## Validation

Validated head `1108187d3a09cc19ce3018aaa38c7cff6b3bee16`, Linux x86_64 / Python 3.12.3 / SuperDex 1.0.0 FP32:

```sh
UV_NO_SYNC=1 SUPERDEX_ASSETS_PATH=/home/user/ws/simulator/project_superdex/assets make check
uv lock --check
make package
git diff --check
```

Results: **132 passed, 4 skipped**; Ruff, lock and local sdist/wheel build passed. Native regressions cover nontrivial root orientation/COM velocity against MuJoCo, per-geom contacts and welded-parent filtering, derived COM, unlimited joints, per-substep world forces, lifecycle coexistence and FR3. UniLab's locally linked integration also passed full `make test-all`, real FR3 PPO and a MuJoCo Go2 checkpoint rollout; see [validation child #1535](https://github.com/Motphys/UniLab/issues/1535).

Read-only cross-review identified and fixed welded collision grouping, derived COM metadata, cleanup ownership, world-force reprojection and config diagnostics. No changes to other engine implementations. Remote CI is not the merge gate for this non-main roadmap base; default CI does not establish optional SuperDex platform support.

## Limits

Experimental CPU profile only. No model DR, cameras/rendering, soft/tactile public states or GPU runtime. Analytic primitives become SDF meshes; Go2 explicitly opts into sliding-only contact approximation, with no dynamics-equivalence claim. Unsupported friction graphs fail closed. Accelerometers cannot be bound; reset clears solved contacts until a positive physics step. New native/converted scene combinations must pass the cold audit rather than silently dropping semantics. Full support details are in `docs/superdex.md`.
