### PR TITLE
fix: preserve position actuator gain signs in mjwarp DR

### DIFF
--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -1550,10 +1550,14 @@ class MjwarpBackend(SimBackend):
         if randomization.kp is not None:
             kp = self._coerce_dr_field("kp", randomization.kp, num_reset, (self._nu,))
             self._dr_actuator_gainprm[rows, :, 0] = kp
+            self._dr_actuator_biasprm[rows, :, 1] = -kp
             self._upload(self._device_model.actuator_gainprm, self._dr_actuator_gainprm)
+            self._upload(self._device_model.actuator_biasprm, self._dr_actuator_biasprm)
         if randomization.kd is not None:
             kd = self._coerce_dr_field("kd", randomization.kd, num_reset, (self._nu,))
-            self._dr_actuator_biasprm[rows, :, 2] = kd
+            # MuJoCo position actuators encode velocity damping as the negative
+            # third bias coefficient.  The public API exposes a positive kd.
+            self._dr_actuator_biasprm[rows, :, 2] = -kd
             self._upload(self._device_model.actuator_biasprm, self._dr_actuator_biasprm)
         return True
 

--- a/tests/test_mjwarp_required_capabilities.py
+++ b/tests/test_mjwarp_required_capabilities.py
@@ -34,7 +34,7 @@ MODEL = """<mujoco>
     </body>
   </worldbody>
   <actuator><motor joint="slide" ctrlrange="-10 10"/>
-    <motor joint="hinge" ctrlrange="-10 10"/></actuator>
+    <position joint="hinge" kp="3" kv="0.7" ctrlrange="-10 10"/></actuator>
   <sensor>
     <framepos name="tip_position" objtype="site" objname="tip"/>
     <contact name="ball_found" geom1="ball" geom2="floor" data="found" num="1"/>
@@ -120,6 +120,27 @@ def test_extended_model_rows_bounds_and_contact_effect(backend) -> None:
     np.testing.assert_array_equal(backend.get_sensor_data("ball_found")[[0, 2]], 0)
     backend.step(np.zeros((3, 2), dtype=np.float32), nsteps=2)
     assert np.isfinite(backend.get_sensor_data("ball_force")).all()
+
+
+def test_positive_kd_payload_preserves_mujoco_position_actuator_sign(backend) -> None:
+    rows = np.array([1], dtype=np.int32)
+    kp, kd = backend.get_actuator_gains()
+    requested_kp = kp[None] * 1.1
+    requested_kd = kd[None] * 1.2
+
+    _reset(
+        backend,
+        rows,
+        ResetRandomizationPayload(kp=requested_kp, kd=requested_kd),
+        position=0.08,
+    )
+
+    device_gain = backend._device_model.actuator_gainprm.numpy()
+    device_bias = backend._device_model.actuator_biasprm.numpy()
+    np.testing.assert_allclose(device_gain[1, :, 0], requested_kp[0])
+    np.testing.assert_allclose(device_bias[1, :, 1], -requested_kp[0])
+    np.testing.assert_allclose(device_bias[1, :, 2], -requested_kd[0])
+    np.testing.assert_allclose(device_bias[[0, 2], :, 2], np.broadcast_to(-kd, (2, kd.size)))
 
 
 @pytest.mark.parametrize("field,amount", (("dof_damping", 10.0), ("dof_frictionloss", 5.0)))


### PR DESCRIPTION
Closes #43.\n\n`mjwarp` now maps the public positive position-actuator gains to MuJoCo model fields consistently: `gainprm[..., 0] = kp`, `biasprm[..., 1] = -kp`, and `biasprm[..., 2] = -kd`. Previously the gain/bias contract was incomplete and `kd` was applied with the wrong sign.\n\nValidation:\n\n- `uv run --no-sync pytest tests/test_mjwarp_required_capabilities.py -q` (18 passed)\n- `make check` (132 passed, 24 skipped)\n\nReal CUDA regression uses a nonzero MuJoCo position actuator and verifies the selected and unselected model rows. It is prompted by the approved Wuji roadmap P5 diagnosis; it changes no upstream `main`, release tag, or package publication.