### PR TITLE
feat(mjwarp): add Wuji reset capabilities and fix actuator DR signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Add cold-bound selected-world mocap pose reads/writes and reset ordering to
+  `SimBackend`, with an explicit unsupported default and a MJWarp implementation.
+- Add MJWarp reset randomization for primitive geometry size (including derived
+  bounds), contact solref/solimp, joint damping and joint friction loss. New
+  payload tables validate before mutation, preserve unselected worlds, and
+  expose cold-path defaults through the public backend contract. See
+  [the owner contract](docs/mocap-reset-contract.md) and issue #40.
+
 ## 1.1.3 - 2026-09-06
 
 - Ensure Newton ViewerGL playback shows authored static planes and supplies a

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ spellings as a migration fallback.
   runtime requirements
 - [`docs/migration.md`](docs/migration.md) — migrating from the historical
   UniLab backend layer
+- [`docs/mocap-reset-contract.md`](docs/mocap-reset-contract.md) — selected-world
+  mocap poses and MJWarp primitive/contact/joint randomization
 - [`docs/benchmark-api.md`](docs/benchmark-api.md) — reserved benchmark
   schemas
 - [`docs/release.md`](docs/release.md) — TestPyPI and automated production

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,6 +75,8 @@ benchmark 包保留的 schema 扩展点,本仓库不实现负载运行器。
 - [`docs/support-matrix.md`](docs/support-matrix.md) — 适配器安装与运行时
   要求
 - [`docs/migration.md`](docs/migration.md) — 从历史上的 UniLab 后端层迁移
+- [`docs/mocap-reset-contract.md`](docs/mocap-reset-contract.md) — 选中环境的
+  mocap 姿态与 MJWarp 基本几何体、接触、关节随机化
 - [`docs/benchmark-api.md`](docs/benchmark-api.md) — 保留的 benchmark schema
 - [`docs/release.md`](docs/release.md) — TestPyPI 与自动化生产发布流程
 

--- a/docs/mocap-reset-contract.md
+++ b/docs/mocap-reset-contract.md
@@ -1,0 +1,87 @@
+# Mocap poses and geometry reset randomization
+
+Status: accepted implementation of [owner issue #40](https://github.com/unilabsim/unisim/issues/40),
+under the approved [Wuji roadmap](https://github.com/unilabsim/wuji_unilab/issues/1).
+This owner decision extends the existing backend boundary; it introduces no
+second environment lifecycle, tensor protocol, or engine implementation.
+
+## Decision
+
+`SimBackend.bind_mocap_pose(body_name)` resolves one fixed mocap body on the
+cold path and returns `BackendMocapPoseBinding` from `unisim.backend.base`.
+The immutable binding contains `backend_type`, `body_name`, `num_envs`, a
+detached read-only `default_pose` with shape `(7,)`, and backend-owned callbacks.
+Its public methods are:
+
+- `read() -> np.ndarray`: detached `(num_envs, 7)` world poses.
+- `write(env_ids, poses) -> None`: unique integer environment IDs and floating
+  `(len(env_ids), 7)` poses. Layout is world xyz followed by a unit wxyz
+  quaternion. An empty selection is a validated no-op.
+
+The adapter applies pose writes, forwards physics to refresh derived state,
+and refreshes its sensor/state caches before returning. Generalized positions
+and velocities and unselected mocap poses are preserved. Consumers must not
+retain native model/data handles or resolve names in reset/step code.
+Unknown names, non-mocap bodies, invalid shapes/dtypes/IDs, non-finite values
+and non-unit quaternions fail explicitly. The default implementation on other
+backends raises `NotImplementedError` at binding; no capability is inferred
+from a class name or a private method.
+
+`set_state` retains the existing reset semantics: selected environments reset
+their mocap poses to model defaults. A consumer that changes generalized state
+and mocap pose commits `set_state` first, then the bound mocap pose writes.
+These are ordered operations, not an atomic multi-backend transaction. This
+keeps the established `set_state` signature stable and gives the environment
+owner responsibility for ordering and prevalidating a composed reset. Existing
+bindings remain valid across reset and stepping.
+
+## Reset randomization tables
+
+`ResetRandomizationPayload` adds these dense tables for `R` selected rows:
+
+| Field / capability term | Shape | Meaning |
+| --- | --- | --- |
+| `geom_size` | `(R, ngeom, 3)` | MuJoCo primitive dimensions |
+| `geom_solref` | `(R, ngeom, 2)` | Contact reference parameters |
+| `geom_solimp` | `(R, ngeom, 5)` | Contact impedance parameters |
+| `dof_damping` | `(R, nv)` | Non-negative joint damping |
+| `dof_frictionloss` | `(R, nv)` | Non-negative joint friction loss |
+
+Constants in `unisim.dr.types` are `RESET_TERM_GEOM_SIZE`,
+`RESET_TERM_GEOM_SOLREF`, `RESET_TERM_GEOM_SOLIMP`, `RESET_TERM_DOF_DAMPING`
+and `RESET_TERM_DOF_FRICTIONLOSS`. `get_geom_sizes`, `get_geom_solref`,
+`get_geom_solimp`, `get_dof_damping`, and `get_dof_frictionloss` expose detached
+default tables for cold-path consumer binding; they are not per-world current
+model views. Model randomization persists across state-only resets.
+
+MJWarp validates the new tables before changing state or uploading model data.
+Solref accepts either two positive time-constant/damping-ratio values or two
+non-positive direct-format values. Solimp requires impedance endpoints in
+`[0,1]`, positive width, midpoint in `(0,1)`, and power at least one. Geometry
+size writes require positive primitive radii/extents; unused components may
+be zero. All table values must be representable as finite float32 values.
+
+Sphere, capsule, ellipsoid, cylinder and box resizing is supported. The
+adapter classifies geometry once, derives `geom_rbound` and `geom_aabb` from
+the new dimensions using cached index groups, and uploads all three fields in
+place before forwarding. Consumers cannot independently provide inconsistent
+bounds. Dense payloads may include unchanged mesh/plane/hfield/SDF columns;
+attempting to resize these unsupported types fails. Geometry resizing does
+not implicitly change mass or inertia; consumers request those fields
+explicitly when desired. Fixed-address per-world expansion precedes CUDA graph
+capture, so later writes preserve captured pointers.
+
+## Evidence and limits
+
+`tests/test_reset_capability_contract.py` covers strict binding/default-backend
+behavior and payload term filtering. `tests/test_mjwarp_required_capabilities.py`
+covers selected-world mocap translation/rotation and reset, geometry/contact
+effects, contact-parameter force changes, damping/friction motion effects,
+invalid requests, and primitive bounds against official MuJoCo compilation.
+Numerical tests require the 3.11 MJWarp extra and CUDA; a skipped runtime test
+is not numerical evidence for a support claim.
+
+This change does not add camera/raycast/terrain, post-substep sensor hooks,
+arbitrary scene variants, torque perturbation or mesh resizing. Existing native
+named sensor bindings remain the mechanism for contact, actuator-force and
+site-velocity reads.

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -19,6 +19,71 @@ TerrainHeightSampleFn = Callable[[np.ndarray], np.ndarray]
 SensorReadFn = Callable[[], np.ndarray]
 
 
+@dataclass(frozen=True)
+class BackendMocapPoseBinding:
+    """Cold-bound world-space pose access for one fixed mocap body.
+
+    Poses use xyz + unit wxyz quaternion. Writes affect only selected worlds,
+    preserve generalized state and refresh derived state before returning.
+    A subsequent ``set_state`` resets that world's mocap poses to defaults;
+    reset owners therefore commit generalized state before their mocap writes.
+    """
+
+    backend_type: str
+    body_name: str
+    num_envs: int
+    default_pose: np.ndarray
+    _reader: Callable[[], np.ndarray] = field(repr=False, compare=False)
+    _writer: Callable[[np.ndarray, np.ndarray], None] = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.backend_type, str) or not self.backend_type:
+            raise ValueError("mocap binding backend_type must be a non-empty string")
+        if not isinstance(self.body_name, str) or not self.body_name:
+            raise ValueError("mocap binding body_name must be a non-empty string")
+        if isinstance(self.num_envs, bool) or not isinstance(self.num_envs, int):
+            raise TypeError("mocap binding num_envs must be an integer")
+        if self.num_envs <= 0:
+            raise ValueError("mocap binding num_envs must be positive")
+        if not callable(self._reader) or not callable(self._writer):
+            raise TypeError("mocap binding reader and writer must be callable")
+        default = np.array(self.default_pose, copy=True)
+        self._validate_poses(default[None, :] if default.ndim == 1 else default, 1)
+        if default.shape != (7,):
+            raise ValueError("mocap default_pose must have shape (7,)")
+        default.setflags(write=False)
+        object.__setattr__(self, "default_pose", default)
+
+    @staticmethod
+    def _validate_poses(poses: np.ndarray, count: int) -> None:
+        if not isinstance(poses, np.ndarray) or not np.issubdtype(poses.dtype, np.floating):
+            raise TypeError("mocap poses must be a floating NumPy array")
+        if poses.shape != (count, 7):
+            raise ValueError(f"mocap poses must have shape {(count, 7)}, got {poses.shape}")
+        if not np.isfinite(poses).all():
+            raise ValueError("mocap poses must be finite")
+        if not np.allclose(np.linalg.norm(poses[:, 3:], axis=1), 1.0, rtol=1e-5, atol=1e-6):
+            raise ValueError("mocap poses require unit wxyz quaternions")
+
+    def read(self) -> np.ndarray:
+        """Return a detached (num_envs, 7) pose snapshot."""
+        poses = self._reader()
+        self._validate_poses(poses, self.num_envs)
+        return poses.copy()
+
+    def write(self, env_ids: np.ndarray, poses: np.ndarray) -> None:
+        """Write selected rows without changing any other world's state."""
+        if not isinstance(env_ids, np.ndarray) or not np.issubdtype(env_ids.dtype, np.integer):
+            raise TypeError("mocap env_ids must be an integer NumPy array")
+        if env_ids.ndim != 1 or np.unique(env_ids).size != env_ids.size:
+            raise ValueError("mocap env_ids must be one-dimensional and unique")
+        if np.any(env_ids < 0) or np.any(env_ids >= self.num_envs):
+            raise IndexError("mocap env_ids are outside the backend batch")
+        self._validate_poses(poses, env_ids.size)
+        if env_ids.size:
+            self._writer(env_ids, poses)
+
+
 class RenderClosedError(RuntimeError):
     """Interface-level signal that the user closed the backend render window.
 
@@ -451,6 +516,30 @@ class SimBackend(abc.ABC):
     def get_geom_size(self, name: str) -> np.ndarray:
         """Return one geom size vector through the backend contract."""
         raise NotImplementedError(f"{self.__class__.__name__} does not expose geom sizes")
+
+    def get_geom_sizes(self) -> np.ndarray:
+        """Return default geometry sizes, shape (ngeom, 3)."""
+        raise NotImplementedError(f"{self.__class__.__name__} does not expose geom size defaults")
+
+    def get_geom_solref(self) -> np.ndarray:
+        """Return default contact reference parameters, shape (ngeom, 2)."""
+        raise NotImplementedError(f"{self.__class__.__name__} does not expose geom solref")
+
+    def get_geom_solimp(self) -> np.ndarray:
+        """Return default contact impedance parameters, shape (ngeom, 5)."""
+        raise NotImplementedError(f"{self.__class__.__name__} does not expose geom solimp")
+
+    def get_dof_damping(self) -> np.ndarray:
+        """Return default joint damping, shape (nv,)."""
+        raise NotImplementedError(f"{self.__class__.__name__} does not expose dof damping")
+
+    def get_dof_frictionloss(self) -> np.ndarray:
+        """Return default joint friction loss, shape (nv,)."""
+        raise NotImplementedError(f"{self.__class__.__name__} does not expose dof frictionloss")
+
+    def bind_mocap_pose(self, body_name: str) -> BackendMocapPoseBinding:
+        """Resolve a mocap body once; unavailable capabilities fail at binding."""
+        raise NotImplementedError(f"{self.__class__.__name__} does not support mocap pose writes")
 
     def create_hfield_scanner(
         self,

--- a/src/unisim/backend/genesis/backend.py
+++ b/src/unisim/backend/genesis/backend.py
@@ -647,6 +647,14 @@ class GenesisBackend(SimBackend):
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
     ) -> dict[str, dict[str, float]]:
+        if randomization is not None:
+            unsupported = self.get_dr_capabilities().get_unsupported_reset_terms(
+                randomization.requested_terms()
+            )
+            if unsupported:
+                raise NotImplementedError(
+                    f"Genesis reset randomization does not support terms: {sorted(unsupported)}"
+                )
         self._require_state("set_state")
         rows = self._validate_rows(env_indices)
         qpos_array = np.asarray(qpos, dtype=np.float32)

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -14,12 +14,14 @@ import time
 import warnings
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
+from functools import partial
 from os import PathLike
 from typing import Any, NoReturn
 
 import numpy as np
 
 from unisim.backend.base import (
+    BackendMocapPoseBinding,
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
@@ -38,7 +40,12 @@ from unisim.dr.types import (
     RESET_TERM_BODY_IQUAT,
     RESET_TERM_BODY_MASS,
     RESET_TERM_DOF_ARMATURE,
+    RESET_TERM_DOF_DAMPING,
+    RESET_TERM_DOF_FRICTIONLOSS,
     RESET_TERM_GEOM_FRICTION,
+    RESET_TERM_GEOM_SIZE,
+    RESET_TERM_GEOM_SOLIMP,
+    RESET_TERM_GEOM_SOLREF,
     RESET_TERM_KD,
     RESET_TERM_KP,
     DomainRandomizationCapabilities,
@@ -52,7 +59,7 @@ from ..body_state import copy_selected_body_state
 from .dependencies import load_mjwarp_dependencies
 from .materialization import materialize_mjwarp_scene
 from .playback import run_mjwarp_playback, validate_mjwarp_visual_model
-from .randomization import expand_model_fields
+from .randomization import PrimitiveGeomBounds, expand_model_fields
 
 _GRAPH_CAPTURE_MIN_DRIVER = (12, 4)
 # Reset scratch storage is deliberately bounded.  The original 128-world
@@ -252,6 +259,17 @@ class MjwarpBackend(SimBackend):
         # arrays and therefore stay graph-safe.
         expand_model_fields(self._warp, self._device_model, self._num_envs)
         self._bind_dr_host_mirrors()
+        self._geom_bounds = PrimitiveGeomBounds(self._cpu_model.geom_type, deps.mujoco.mjtGeom)
+        mocap_bodies = np.flatnonzero(self._cpu_model.body_mocapid >= 0)
+        mocap_bodies = mocap_bodies[np.argsort(self._cpu_model.body_mocapid[mocap_bodies])]
+        self._default_mocap_pos = self._cpu_model.body_pos[mocap_bodies].astype(np.float32)
+        self._default_mocap_quat = self._cpu_model.body_quat[mocap_bodies].astype(np.float32)
+        self._mocap_pos = np.broadcast_to(
+            self._default_mocap_pos, (self._num_envs, len(mocap_bodies), 3)
+        ).copy()
+        self._mocap_quat = np.broadcast_to(
+            self._default_mocap_quat, (self._num_envs, len(mocap_bodies), 4)
+        ).copy()
         self._xfrc_staging = np.zeros((self._num_envs, self._nbody, 6), dtype=np.float32)
         self._xfrc_pending = False
         self._actuator_names = tuple(
@@ -437,6 +455,21 @@ class MjwarpBackend(SimBackend):
         self._dr_actuator_biasprm = np.broadcast_to(
             np.asarray(cpu.actuator_biasprm, dtype=np.float32), (num_envs, self._nu, 10)
         ).copy()
+        for name in (
+            "geom_size",
+            "geom_rbound",
+            "geom_aabb",
+            "geom_solref",
+            "geom_solimp",
+            "dof_damping",
+            "dof_frictionloss",
+        ):
+            default = np.asarray(getattr(cpu, name), dtype=np.float32)
+            if name == "geom_aabb":
+                default = default.reshape(int(cpu.ngeom), 2, 3)
+            setattr(
+                self, f"_dr_{name}", np.broadcast_to(default, (num_envs, *default.shape)).copy()
+            )
 
     def _bind_tracked_body_state(self) -> None:
         """Bind zero-copy tracked-body views into the per-step sensor cache.
@@ -733,6 +766,9 @@ class MjwarpBackend(SimBackend):
         self._sensor_cache[row_ids] = cache[: len(row_ids)]
 
     def _validate_rows(self, env_indices: np.ndarray) -> np.ndarray:
+        raw = np.asarray(env_indices)
+        if not np.issubdtype(raw.dtype, np.integer):
+            raise TypeError("env_indices must contain integer row IDs")
         rows = np.asarray(env_indices, dtype=np.intp)
         if rows.ndim != 1:
             raise ValueError(f"env_indices must be one-dimensional, got shape {rows.shape}")
@@ -866,6 +902,56 @@ class MjwarpBackend(SimBackend):
         return np.asarray(
             self._cpu_model.geom_size[self.get_geom_id(name)], dtype=np.float32
         ).copy()
+
+    def get_geom_sizes(self) -> np.ndarray:
+        return np.asarray(self._cpu_model.geom_size, dtype=np.float32).copy()
+
+    def get_geom_solref(self) -> np.ndarray:
+        return np.asarray(self._cpu_model.geom_solref, dtype=np.float32).copy()
+
+    def get_geom_solimp(self) -> np.ndarray:
+        return np.asarray(self._cpu_model.geom_solimp, dtype=np.float32).copy()
+
+    def get_dof_damping(self) -> np.ndarray:
+        return np.asarray(self._cpu_model.dof_damping, dtype=np.float32).copy()
+
+    def get_dof_frictionloss(self) -> np.ndarray:
+        return np.asarray(self._cpu_model.dof_frictionloss, dtype=np.float32).copy()
+
+    def bind_mocap_pose(self, body_name: str) -> BackendMocapPoseBinding:
+        if not isinstance(body_name, str) or not body_name:
+            raise TypeError("mjwarp mocap body_name must be a non-empty string")
+        if body_name not in self._body_ids:
+            raise KeyError(f"mjwarp mocap body {body_name!r} does not exist")
+        mocap_id = int(self._cpu_model.body_mocapid[self._body_ids[body_name]])
+        if mocap_id < 0:
+            raise NotImplementedError(f"mjwarp body {body_name!r} is not a mocap body")
+        return BackendMocapPoseBinding(
+            backend_type=self.backend_type,
+            body_name=body_name,
+            num_envs=self.num_envs,
+            default_pose=np.concatenate(
+                (self._default_mocap_pos[mocap_id], self._default_mocap_quat[mocap_id])
+            ),
+            _reader=partial(self._read_mocap_pose, mocap_id),
+            _writer=partial(self._write_mocap_pose, mocap_id),
+        )
+
+    def _read_mocap_pose(self, mocap_id: int) -> np.ndarray:
+        return np.concatenate((self._mocap_pos[:, mocap_id], self._mocap_quat[:, mocap_id]), axis=1)
+
+    def _write_mocap_pose(self, mocap_id: int, rows: np.ndarray, poses: np.ndarray) -> None:
+        with np.errstate(over="ignore", invalid="ignore"):
+            poses = np.asarray(poses, dtype=np.float32)
+        if not np.isfinite(poses).all():
+            raise ValueError("mjwarp mocap poses must be finite float32 values")
+        self._mocap_pos[rows, mocap_id] = poses[:, :3]
+        self._mocap_quat[rows, mocap_id] = poses[:, 3:]
+        self._upload(self._device_data.mocap_pos, self._mocap_pos)
+        self._upload(self._device_data.mocap_quat, self._mocap_quat)
+        self._execute_device_forward()
+        self._synchronize()
+        self._refresh_host_cache()
 
     def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:
         root = int(root_body_id)
@@ -1184,6 +1270,9 @@ class MjwarpBackend(SimBackend):
             raise ValueError(f"qpos must have shape {expected_qpos}, got {qpos_array.shape}")
         if qvel_array.shape != expected_qvel:
             raise ValueError(f"qvel must have shape {expected_qvel}, got {qvel_array.shape}")
+        if not np.isfinite(qpos_array).all() or not np.isfinite(qvel_array).all():
+            raise ValueError("mjwarp reset state must be finite")
+        extended_fields: dict[str, np.ndarray] = {}
         if randomization is not None and not randomization.is_empty():
             unsupported = self.get_dr_capabilities().get_unsupported_reset_terms(
                 randomization.requested_terms()
@@ -1194,6 +1283,7 @@ class MjwarpBackend(SimBackend):
                     "mjwarp host_numpy profile does not support reset domain randomization "
                     f"terms: {requested}."
                 )
+            extended_fields = self._validate_extended_randomization(rows, randomization)
         timing: dict[str, float] = {key: 0.0 for key in self._SET_STATE_TIMING_ZERO_KEYS}
         timing.update(
             {
@@ -1213,11 +1303,17 @@ class MjwarpBackend(SimBackend):
         if randomization is not None and not randomization.is_empty():
             t0 = time.perf_counter()
             has_model_dr = self._apply_reset_randomization(rows, randomization)
+            for name, values in extended_fields.items():
+                mirror = getattr(self, f"_dr_{name}")
+                mirror[rows] = values
+                self._upload(getattr(self._device_model, name), mirror)
             self._synchronize()
             timing["set_state_reset_rand_ms"] = (time.perf_counter() - t0) * 1000.0
         # reset_data clears device xfrc_applied on the reset rows; keep the
         # staged host mirror consistent so a pending push cannot resurrect.
         self._xfrc_staging[rows] = 0.0
+        self._mocap_pos[rows] = self._default_mocap_pos
+        self._mocap_quat[rows] = self._default_mocap_quat
         timings = self._execute_host_reset(
             rows,
             self._qpos_cache,
@@ -1250,7 +1346,12 @@ class MjwarpBackend(SimBackend):
                     RESET_TERM_BODY_IPOS,
                     RESET_TERM_BODY_MASS,
                     RESET_TERM_DOF_ARMATURE,
+                    RESET_TERM_DOF_DAMPING,
+                    RESET_TERM_DOF_FRICTIONLOSS,
                     RESET_TERM_GEOM_FRICTION,
+                    RESET_TERM_GEOM_SIZE,
+                    RESET_TERM_GEOM_SOLREF,
+                    RESET_TERM_GEOM_SOLIMP,
                     RESET_TERM_KP,
                     RESET_TERM_KD,
                 }
@@ -1274,6 +1375,56 @@ class MjwarpBackend(SimBackend):
     # ------------------------------------------------------------------ #
     # Reset domain randomization: per-world model row writes              #
     # ------------------------------------------------------------------ #
+
+    def _validate_extended_randomization(
+        self, rows: np.ndarray, payload: ResetRandomizationPayload
+    ) -> dict[str, np.ndarray]:
+        """Validate every new field before mutating state or device buffers."""
+        staged: dict[str, np.ndarray] = {}
+        for name in ("geom_size", "geom_solref", "geom_solimp", "dof_damping", "dof_frictionloss"):
+            values = getattr(payload, name)
+            if values is None:
+                continue
+            if not isinstance(values, np.ndarray) or not np.issubdtype(values.dtype, np.floating):
+                raise TypeError(f"mjwarp {name} must be a floating NumPy array")
+            mirror = getattr(self, f"_dr_{name}")
+            expected = (rows.size, *mirror.shape[1:])
+            if values.shape != expected:
+                raise ValueError(f"mjwarp {name} must have shape {expected}, got {values.shape}")
+            with np.errstate(over="ignore", invalid="ignore"):
+                array = np.asarray(values, dtype=np.float32)
+            if not np.isfinite(array).all():
+                raise ValueError(f"mjwarp {name} must be finite float32 values")
+            if name in ("dof_damping", "dof_frictionloss") and np.any(array < 0):
+                raise ValueError(f"mjwarp {name} must be non-negative")
+            if name == "geom_solref":
+                valid = np.all(array > 0, axis=-1) | np.all(array <= 0, axis=-1)
+                if not np.all(valid):
+                    raise ValueError(
+                        "mjwarp geom_solref requires two positive or two non-positive values"
+                    )
+            if name == "geom_solimp" and (
+                np.any(array[..., :2] < 0)
+                or np.any(array[..., :2] > 1)
+                or np.any(array[..., 2] <= 0)
+                or np.any(array[..., 3] <= 0)
+                or np.any(array[..., 3] >= 1)
+                or np.any(array[..., 4] < 1)
+            ):
+                raise ValueError(
+                    "mjwarp geom_solimp requires impedance [0,1], width>0, midpoint (0,1), power>=1"
+                )
+            staged[name] = array
+        if "geom_size" in staged:
+            rbound, aabb = self._geom_bounds.compute(
+                staged["geom_size"],
+                self._dr_geom_size[rows],
+                self._dr_geom_rbound[rows],
+                self._dr_geom_aabb[rows],
+            )
+            staged["geom_rbound"] = rbound
+            staged["geom_aabb"] = aabb
+        return staged
 
     @staticmethod
     def _coerce_dr_field(
@@ -1419,9 +1570,7 @@ class MjwarpBackend(SimBackend):
         if self._interval_term_handler_cache is None:
             self._interval_term_handler_cache = {
                 INTERVAL_TERM_PUSH: lambda op: self.push_robots(op.payload),
-                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(
-                    op.body_ids, op.payload
-                ),
+                INTERVAL_TERM_BODY_FORCE: lambda op: self.apply_body_force(op.body_ids, op.payload),
                 INTERVAL_TERM_BODY_LINEAR_VELOCITY_DELTA: (
                     lambda op: self._apply_body_linear_velocity_delta(op.body_ids, op.payload)
                 ),

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -1550,10 +1550,14 @@ class MjwarpBackend(SimBackend):
         if randomization.kp is not None:
             kp = self._coerce_dr_field("kp", randomization.kp, num_reset, (self._nu,))
             self._dr_actuator_gainprm[rows, :, 0] = kp
+            self._dr_actuator_biasprm[rows, :, 1] = -kp
             self._upload(self._device_model.actuator_gainprm, self._dr_actuator_gainprm)
+            self._upload(self._device_model.actuator_biasprm, self._dr_actuator_biasprm)
         if randomization.kd is not None:
             kd = self._coerce_dr_field("kd", randomization.kd, num_reset, (self._nu,))
-            self._dr_actuator_biasprm[rows, :, 2] = kd
+            # MuJoCo position actuators encode velocity damping as the negative
+            # third bias coefficient.  The public API exposes a positive kd.
+            self._dr_actuator_biasprm[rows, :, 2] = -kd
             self._upload(self._device_model.actuator_biasprm, self._dr_actuator_biasprm)
         return True
 

--- a/src/unisim/backend/mjwarp/randomization.py
+++ b/src/unisim/backend/mjwarp/randomization.py
@@ -9,7 +9,7 @@ operation: the backend expands the declared set once during construction,
 uploads into the same fixed-address arrays (graph-safe).
 
 The field list is ported from mjlab's ``expand_model_fields`` usage and checked
-against the pinned mujoco-warp 3.10 ``Model`` dataclass.  Derived fields are
+against the pinned mujoco-warp 3.11 ``Model`` dataclass.  Derived fields are
 expanded alongside their inputs because the ``set_const*`` recompute kernels
 size their launch grid from the *output* field's leading dimension.
 """
@@ -26,7 +26,18 @@ SET_CONST_FIELDS = ("body_mass", "body_ipos", "body_iquat")
 # Payload-writable fields that require ``mujoco_warp.set_const_0`` afterwards.
 SET_CONST_0_FIELDS = ("body_inertia", "dof_armature")
 # Payload-writable fields that need no derived-quantity recomputation.
-NO_RECOMPUTE_FIELDS = ("geom_friction", "actuator_gainprm", "actuator_biasprm")
+NO_RECOMPUTE_FIELDS = (
+    "geom_friction",
+    "actuator_gainprm",
+    "actuator_biasprm",
+    "geom_size",
+    "geom_rbound",
+    "geom_aabb",
+    "geom_solref",
+    "geom_solimp",
+    "dof_damping",
+    "dof_frictionloss",
+)
 # Derived fields recomputed by the ``set_const*`` family.  They must be
 # per-world as well: the recompute kernels launch over ``field.shape[0]`` and
 # the step/forward kernels index them per world.
@@ -42,6 +53,73 @@ DERIVED_FIELDS = (
 EXPANDED_MODEL_FIELDS: tuple[str, ...] = (
     SET_CONST_FIELDS + SET_CONST_0_FIELDS + NO_RECOMPUTE_FIELDS + DERIVED_FIELDS
 )
+
+
+class PrimitiveGeomBounds:
+    """Cold-path geometry classification for batch-only bounds recomputation.
+
+    Uses official MuJoCo primitive geometry formulas. Meshes, planes, height
+    fields and SDFs may appear in dense payloads unchanged, but resizing them
+    is unsupported. No model/XML metadata is consulted during reset.
+    """
+
+    def __init__(self, geom_types: np.ndarray, geom_enum: Any) -> None:
+        count = geom_types.size
+        self.halfsize_map = np.zeros((count, 3, 3), dtype=np.float32)
+        self.radius_axes = np.zeros((count, 3), dtype=np.float32)
+        self.required_positive = np.zeros((count, 3), dtype=bool)
+        supported = np.zeros(count, dtype=bool)
+        for kind, mapping, radius_axes, positive in (
+            ("SPHERE", ((1, 0, 0),) * 3, (1, 0, 0), (True, False, False)),
+            ("CAPSULE", ((1, 0, 0), (1, 0, 0), (1, 1, 0)), (1, 1, 0), (True, False, False)),
+            ("ELLIPSOID", np.eye(3), (1, 1, 1), (True, True, True)),
+            ("CYLINDER", ((1, 0, 0), (1, 0, 0), (0, 1, 0)), (1, 1, 0), (True, True, False)),
+            ("BOX", np.eye(3), (1, 1, 1), (True, True, True)),
+        ):
+            ids = np.flatnonzero(geom_types == int(getattr(geom_enum, f"mjGEOM_{kind}")))
+            self.halfsize_map[ids] = mapping
+            self.radius_axes[ids] = radius_axes
+            self.required_positive[ids] = positive
+            supported[ids] = True
+        self.supported_ids = np.flatnonzero(supported)
+        self.unsupported_ids = np.flatnonzero(~supported)
+        self.capsule_ids = np.flatnonzero(geom_types == int(geom_enum.mjGEOM_CAPSULE))
+        self.ellipsoid_ids = np.flatnonzero(geom_types == int(geom_enum.mjGEOM_ELLIPSOID))
+
+    def compute(
+        self,
+        sizes: np.ndarray,
+        previous_sizes: np.ndarray,
+        previous_rbound: np.ndarray,
+        previous_aabb: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Validate a dense size update and derive detached selected-row bounds."""
+        unsupported = self.unsupported_ids
+        if np.any(sizes[:, unsupported] != previous_sizes[:, unsupported]):
+            raise NotImplementedError(
+                "mjwarp geom_size supports resizing sphere, capsule, ellipsoid, cylinder and "
+                "box primitives only; a non-primitive geometry was changed"
+            )
+        if np.any(sizes[:, self.supported_ids] < 0) or np.any(
+            (sizes <= 0) & self.required_positive[None, :, :]
+        ):
+            raise ValueError(
+                "geom_size primitive dimensions must be non-negative with positive radii/extents"
+            )
+        radius_vector = sizes * self.radius_axes[None, :, :]
+        with np.errstate(over="ignore", invalid="ignore"):
+            radii = np.linalg.norm(radius_vector, axis=-1)
+        radii[:, self.capsule_ids] = radius_vector[:, self.capsule_ids].sum(axis=-1)
+        radii[:, self.ellipsoid_ids] = sizes[:, self.ellipsoid_ids].max(axis=-1)
+        halves = np.einsum("gij,rgj->rgi", self.halfsize_map, sizes)
+        if not np.isfinite(radii).all() or not np.isfinite(halves).all():
+            raise ValueError("geom_size derived bounds must be finite float32 values")
+        rbound = previous_rbound.copy()
+        aabb = previous_aabb.copy()
+        rbound[:, self.supported_ids] = radii[:, self.supported_ids]
+        aabb[:, self.supported_ids, 0] = 0
+        aabb[:, self.supported_ids, 1] = halves[:, self.supported_ids]
+        return rbound, aabb
 
 
 def expand_model_fields(warp: Any, model: Any, nworld: int) -> tuple[str, ...]:

--- a/src/unisim/backend/motrix/backend.py
+++ b/src/unisim/backend/motrix/backend.py
@@ -725,6 +725,14 @@ class MotrixBackend(SimBackend):
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
     ) -> dict | None:
+        if randomization is not None:
+            unsupported = self.get_dr_capabilities().get_unsupported_reset_terms(
+                randomization.requested_terms()
+            )
+            if unsupported:
+                raise NotImplementedError(
+                    f"Motrix reset randomization does not support terms: {sorted(unsupported)}"
+                )
         timing: dict[str, float] = {
             "set_state_mask_ms": 0.0,
             "set_state_data_slice_ms": 0.0,

--- a/src/unisim/backend/mujoco/backend.py
+++ b/src/unisim/backend/mujoco/backend.py
@@ -1100,6 +1100,14 @@ class MuJoCoBackend(SimBackend):
         qvel: np.ndarray,
         randomization: ResetRandomizationPayload | None = None,
     ) -> dict | None:
+        if randomization is not None:
+            unsupported = self.get_dr_capabilities().get_unsupported_reset_terms(
+                randomization.requested_terms()
+            )
+            if unsupported:
+                raise NotImplementedError(
+                    f"MuJoCo reset randomization does not support terms: {sorted(unsupported)}"
+                )
         timing: dict[str, float] = {
             "set_state_mask_ms": 0.0,
             "set_state_data_slice_ms": 0.0,

--- a/src/unisim/dr/types.py
+++ b/src/unisim/dr/types.py
@@ -23,7 +23,12 @@ RESET_TERM_BODY_INERTIA = "body_inertia"
 RESET_TERM_BODY_IPOS = "body_ipos"
 RESET_TERM_BODY_MASS = "body_mass"
 RESET_TERM_DOF_ARMATURE = "dof_armature"
+RESET_TERM_DOF_DAMPING = "dof_damping"
+RESET_TERM_DOF_FRICTIONLOSS = "dof_frictionloss"
 RESET_TERM_GEOM_FRICTION = "geom_friction"
+RESET_TERM_GEOM_SIZE = "geom_size"
+RESET_TERM_GEOM_SOLREF = "geom_solref"
+RESET_TERM_GEOM_SOLIMP = "geom_solimp"
 RESET_TERM_KP = "kp"
 RESET_TERM_KD = "kd"
 
@@ -129,6 +134,21 @@ class DomainRandomizationCapabilities:
             ),
             kp=payload.kp if self.supports_reset_term(RESET_TERM_KP) else None,
             kd=payload.kd if self.supports_reset_term(RESET_TERM_KD) else None,
+            geom_size=payload.geom_size if self.supports_reset_term(RESET_TERM_GEOM_SIZE) else None,
+            geom_solref=(
+                payload.geom_solref if self.supports_reset_term(RESET_TERM_GEOM_SOLREF) else None
+            ),
+            geom_solimp=(
+                payload.geom_solimp if self.supports_reset_term(RESET_TERM_GEOM_SOLIMP) else None
+            ),
+            dof_damping=(
+                payload.dof_damping if self.supports_reset_term(RESET_TERM_DOF_DAMPING) else None
+            ),
+            dof_frictionloss=(
+                payload.dof_frictionloss
+                if self.supports_reset_term(RESET_TERM_DOF_FRICTIONLOSS)
+                else None
+            ),
         )
         return (None if filtered.is_empty() else filtered), unsupported
 
@@ -146,6 +166,13 @@ class ResetRandomizationPayload:
     geom_friction: np.ndarray | None = None
     kp: np.ndarray | None = None
     kd: np.ndarray | None = None
+    # Dense model-column tables for selected reset rows. Geometry bounds are
+    # derived by the adapter; callers must never supply independent bounds.
+    geom_size: np.ndarray | None = None
+    geom_solref: np.ndarray | None = None
+    geom_solimp: np.ndarray | None = None
+    dof_damping: np.ndarray | None = None
+    dof_frictionloss: np.ndarray | None = None
 
     def requested_terms(self) -> frozenset[str]:
         terms: set[str] = set()
@@ -171,6 +198,15 @@ class ResetRandomizationPayload:
             terms.add(RESET_TERM_KP)
         if self.kd is not None:
             terms.add(RESET_TERM_KD)
+        for term in (
+            RESET_TERM_GEOM_SIZE,
+            RESET_TERM_GEOM_SOLREF,
+            RESET_TERM_GEOM_SOLIMP,
+            RESET_TERM_DOF_DAMPING,
+            RESET_TERM_DOF_FRICTIONLOSS,
+        ):
+            if getattr(self, term) is not None:
+                terms.add(term)
         return frozenset(terms)
 
     def is_empty(self) -> bool:

--- a/tests/test_mjwarp_required_capabilities.py
+++ b/tests/test_mjwarp_required_capabilities.py
@@ -34,7 +34,7 @@ MODEL = """<mujoco>
     </body>
   </worldbody>
   <actuator><motor joint="slide" ctrlrange="-10 10"/>
-    <motor joint="hinge" ctrlrange="-10 10"/></actuator>
+    <position joint="hinge" kp="3" kv="0.7" ctrlrange="-10 10"/></actuator>
   <sensor>
     <framepos name="tip_position" objtype="site" objname="tip"/>
     <contact name="ball_found" geom1="ball" geom2="floor" data="found" num="1"/>
@@ -120,6 +120,27 @@ def test_extended_model_rows_bounds_and_contact_effect(backend) -> None:
     np.testing.assert_array_equal(backend.get_sensor_data("ball_found")[[0, 2]], 0)
     backend.step(np.zeros((3, 2), dtype=np.float32), nsteps=2)
     assert np.isfinite(backend.get_sensor_data("ball_force")).all()
+
+
+def test_positive_kd_payload_preserves_mujoco_position_actuator_sign(backend) -> None:
+    rows = np.array([1], dtype=np.int32)
+    kp, kd = backend.get_actuator_gains()
+    requested_kp = kp[None] * 1.1
+    requested_kd = kd[None] * 1.2
+
+    _reset(
+        backend,
+        rows,
+        ResetRandomizationPayload(kp=requested_kp, kd=requested_kd),
+        position=0.08,
+    )
+
+    device_gain = backend._device_model.actuator_gainprm.numpy()
+    device_bias = backend._device_model.actuator_biasprm.numpy()
+    np.testing.assert_allclose(device_gain[1, :, 0], requested_kp[0])
+    np.testing.assert_allclose(device_bias[1, :, 1], -requested_kp[0])
+    np.testing.assert_allclose(device_bias[1, :, 2], -requested_kd[0])
+    np.testing.assert_allclose(device_bias[[0, 2], :, 2], np.broadcast_to(-kd, (2, kd.size)))
 
 
 @pytest.mark.parametrize("field,amount", (("dof_damping", 10.0), ("dof_frictionloss", 5.0)))

--- a/tests/test_mjwarp_required_capabilities.py
+++ b/tests/test_mjwarp_required_capabilities.py
@@ -1,0 +1,257 @@
+"""Real-CUDA reset effects for the Wuji-required public capabilities (#40)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim import MjwarpBackend
+from unisim.backend.mjwarp.randomization import PrimitiveGeomBounds
+from unisim.dr.types import ResetRandomizationPayload
+from unisim.scene import SceneCfg
+
+mujoco = pytest.importorskip("mujoco")
+pytest.importorskip("mujoco_warp")
+warp = pytest.importorskip("warp")
+
+MODEL = """<mujoco>
+  <option timestep="0.005" gravity="0 0 0"/>
+  <worldbody>
+    <geom name="floor" type="plane" size="2 2 0.1"/>
+    <body name="object" pos="0 0 0.045"><freejoint/>
+      <geom name="ball" type="sphere" size="0.05" mass="1"/>
+    </body>
+    <body name="slider" pos="1 0 0.5">
+      <joint name="slide" type="slide" axis="1 0 0"/>
+      <geom name="slide_geom" type="box" size="0.05 0.06 0.07" mass="1"/>
+    </body>
+    <body name="hand_root" mocap="true" pos="0 1 0.5">
+      <body name="finger" pos="0.2 0 0">
+        <joint name="hinge" axis="0 0 1"/>
+        <geom name="finger_geom" type="capsule" size="0.02 0.1" mass="0.1"/>
+        <site name="tip" pos="0.1 0 0"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><motor joint="slide" ctrlrange="-10 10"/>
+    <motor joint="hinge" ctrlrange="-10 10"/></actuator>
+  <sensor>
+    <framepos name="tip_position" objtype="site" objname="tip"/>
+    <contact name="ball_found" geom1="ball" geom2="floor" data="found" num="1"/>
+    <contact name="ball_force" geom1="ball" geom2="floor" data="force" reduce="netforce"/>
+  </sensor>
+</mujoco>"""
+
+
+@pytest.fixture(scope="module")
+def backend(tmp_path_factory):
+    warp.init()
+    if not warp.get_device().is_cuda:
+        pytest.skip("required-capability numerical tests require CUDA")
+    path = tmp_path_factory.mktemp("required-mjwarp") / "scene.xml"
+    path.write_text(MODEL)
+    return MjwarpBackend(SceneCfg(model_file=str(path)), 3, 0.005, base_name="object")
+
+
+def _reset(backend, rows=None, payload=None, velocity=None, position=None):
+    if rows is None:
+        rows = np.arange(backend.num_envs, dtype=np.int32)
+    qpos = np.tile(backend.get_default_qpos(), (len(rows), 1))
+    qvel = np.tile(backend.get_init_qvel(), (len(rows), 1))
+    if velocity is not None:
+        qvel[:, 6] = velocity
+    if position is not None:
+        qpos[:, 2] = position
+    backend.set_state(rows, qpos, qvel, randomization=payload)
+
+
+def test_mocap_sparse_pose_effect_reset_and_other_worlds(backend) -> None:
+    _reset(backend)
+    binding = backend.bind_mocap_pose("hand_root")
+    before = backend.get_sensor_data("tip_position").copy()
+    qpos_before = backend.get_state(("qpos",))["qpos"].copy()
+    poses = np.tile(binding.default_pose, (2, 1))
+    poses[0, 0] += 0.4
+    poses[1, 3:] = [np.sqrt(0.5), 0, 0, np.sqrt(0.5)]
+    binding.write(np.array([0, 2]), poses)
+    after = backend.get_sensor_data("tip_position").copy()
+    np.testing.assert_allclose(after[0], before[0] + [0.4, 0, 0], atol=1e-6)
+    np.testing.assert_allclose(after[2], [0, 1.3, 0.5], atol=1e-6)
+    np.testing.assert_array_equal(after[1], before[1])
+    np.testing.assert_array_equal(backend.get_state(("qpos",))["qpos"], qpos_before)
+    _reset(backend, np.array([0], dtype=np.int32))
+    np.testing.assert_allclose(binding.read()[0], binding.default_pose)
+    np.testing.assert_allclose(binding.read()[2], poses[1])
+    np.testing.assert_allclose(backend.get_sensor_data("tip_position")[2], after[2])
+    with pytest.raises(KeyError, match="does not exist"):
+        backend.bind_mocap_pose("missing")
+    with pytest.raises(NotImplementedError, match="not a mocap"):
+        backend.bind_mocap_pose("object")
+
+
+def test_extended_model_rows_bounds_and_contact_effect(backend) -> None:
+    _reset(backend, position=0.08)
+    sizes = backend.get_geom_sizes()[None].copy()
+    ball = backend.get_geom_id("ball")
+    sizes[0, ball, 0] = 0.1
+    solref = backend.get_geom_solref()[None] * 1.2
+    solimp = backend.get_geom_solimp()[None].copy()
+    solimp[..., 2] *= 2
+    damping = backend.get_dof_damping()[None] + 0.1
+    frictionloss = backend.get_dof_frictionloss()[None] + 0.01
+    payload = ResetRandomizationPayload(
+        geom_size=sizes,
+        geom_solref=solref,
+        geom_solimp=solimp,
+        dof_damping=damping,
+        dof_frictionloss=frictionloss,
+    )
+    _reset(backend, np.array([1], dtype=np.int32), payload, position=0.08)
+    for field in payload.requested_terms():
+        values = getattr(backend._device_model, field).numpy()
+        np.testing.assert_allclose(values[1], getattr(payload, field)[0])
+        defaults = getattr(backend._cpu_model, field)
+        np.testing.assert_allclose(
+            values[[0, 2]], np.tile(defaults[None], (2, *([1] * defaults.ndim)))
+        )
+    np.testing.assert_allclose(backend._device_model.geom_rbound.numpy()[1, ball], 0.1)
+    np.testing.assert_allclose(backend._device_model.geom_aabb.numpy()[1, ball, 1], [0.1] * 3)
+    assert backend.get_sensor_data("ball_found")[1, 0] > 0
+    np.testing.assert_array_equal(backend.get_sensor_data("ball_found")[[0, 2]], 0)
+    backend.step(np.zeros((3, 2), dtype=np.float32), nsteps=2)
+    assert np.isfinite(backend.get_sensor_data("ball_force")).all()
+
+
+@pytest.mark.parametrize("field,amount", (("dof_damping", 10.0), ("dof_frictionloss", 5.0)))
+def test_dof_randomization_changes_selected_world_motion(backend, field, amount) -> None:
+    # Reset both fields explicitly because model DR persists across state resets.
+    baseline = ResetRandomizationPayload(
+        dof_damping=np.tile(backend.get_dof_damping(), (3, 1)),
+        dof_frictionloss=np.tile(backend.get_dof_frictionloss(), (3, 1)),
+    )
+    _reset(backend, payload=baseline, velocity=1.0, position=1.0)
+    values = np.zeros((1, backend.get_init_qvel().size), dtype=np.float32)
+    values[0, 6] = amount
+    _reset(
+        backend,
+        np.array([1], dtype=np.int32),
+        ResetRandomizationPayload(**{field: values}),
+        velocity=1.0,
+        position=1.0,
+    )
+    for _ in range(10):
+        backend.step(np.zeros((3, 2), dtype=np.float32), nsteps=4)
+    velocity = backend.get_state(("qvel",))["qvel"][:, 6]
+    assert abs(velocity[1]) < abs(velocity[0]) * 0.6
+    np.testing.assert_allclose(velocity[[0, 2]], 1, atol=1e-5)
+
+
+def test_new_field_validation_precedes_state_or_model_mutation(backend) -> None:
+    before = backend.get_state(("qpos",))["qpos"].copy()
+    size_before = backend._device_model.geom_size.numpy().copy()
+    rows = np.array([0], dtype=np.int32)
+    payload = ResetRandomizationPayload(geom_size=backend.get_geom_sizes()[None].copy())
+    payload.geom_size[0, backend.get_geom_id("ball"), 0] = 0.2
+    payload.dof_damping = np.full((1, backend.get_init_qvel().size), np.nan)
+    with pytest.raises(ValueError, match="finite"):
+        _reset(backend, rows, payload, position=10.0)
+    np.testing.assert_array_equal(backend.get_state(("qpos",))["qpos"], before)
+    np.testing.assert_array_equal(backend._device_model.geom_size.numpy(), size_before)
+    payload.dof_damping = None
+    payload.geom_size[0, backend.get_geom_id("floor"), 0] += 1
+    with pytest.raises(NotImplementedError, match="non-primitive"):
+        _reset(backend, rows, payload)
+
+
+@pytest.mark.parametrize("field", ("geom_solref", "geom_solimp"))
+def test_contact_parameters_change_selected_world_contact_force(backend, field) -> None:
+    defaults = {
+        "geom_size": backend.get_geom_sizes(),
+        "geom_solref": backend.get_geom_solref(),
+        "geom_solimp": backend.get_geom_solimp(),
+    }
+    payload = ResetRandomizationPayload(
+        **{name: np.tile(value[None], (3, 1, 1)) for name, value in defaults.items()}
+    )
+    _reset(backend, payload=payload, position=0.045)
+    original_force = backend.get_sensor_data("ball_force").copy()
+    assert np.linalg.norm(original_force[0]) > 0
+    values = defaults[field][None].copy()
+    if field == "geom_solref":
+        values[..., 0] = 0.08
+    else:
+        # Put this penetration inside a changed impedance transition rather
+        # than changing both saturated endpoints equally (which cancels for
+        # this one-contact zero-gravity system).
+        values[..., 0] = 0.1
+        values[..., 1] = 0.95
+        values[..., 2] = 0.02
+    _reset(
+        backend,
+        np.array([1], dtype=np.int32),
+        ResetRandomizationPayload(**{field: values}),
+        position=0.045,
+    )
+    changed_force = backend.get_sensor_data("ball_force")
+    assert np.linalg.norm(changed_force[1] - original_force[1]) > 1e-3
+    np.testing.assert_allclose(changed_force[[0, 2]], original_force[[0, 2]], atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "field,kind",
+    (
+        ("geom_size", "shape"),
+        ("geom_size", "negative"),
+        ("geom_solref", "mixed"),
+        ("geom_solimp", "negative"),
+        ("dof_damping", "negative"),
+        ("dof_frictionloss", "negative"),
+        ("geom_solref", "nan"),
+        ("dof_damping", "integer"),
+    ),
+)
+def test_extended_field_shapes_ranges_and_dtypes_fail_before_mutation(backend, field, kind) -> None:
+    getter = backend.get_geom_sizes if field == "geom_size" else getattr(backend, f"get_{field}")
+    values = getter()[None]
+    if kind == "shape":
+        values = values[:, :-1]
+    elif kind == "mixed":
+        values[..., 0] = -1
+    elif kind == "nan":
+        values[...] = np.nan
+    elif kind == "integer":
+        values = values.astype(np.int32)
+    else:
+        values[...] = -1
+    before = backend.get_state(("qpos",))["qpos"].copy()
+    error = TypeError if kind == "integer" else (ValueError, NotImplementedError)
+    with pytest.raises(error):
+        _reset(backend, np.array([0]), ResetRandomizationPayload(**{field: values}), position=3)
+    np.testing.assert_array_equal(backend.get_state(("qpos",))["qpos"], before)
+
+
+def test_mocap_large_coordinates_rejected_before_cast_mutation(backend) -> None:
+    binding = backend.bind_mocap_pose("hand_root")
+    before = binding.read()
+    poses = binding.default_pose[None].astype(np.float64)
+    poses[0, 0] = np.finfo(np.float64).max
+    with pytest.raises(ValueError, match="float32"):
+        binding.write(np.array([1]), poses)
+    np.testing.assert_array_equal(binding.read(), before)
+
+
+def test_primitive_bounds_match_official_model_compilation(tmp_path: Path) -> None:
+    xml = """<mujoco><worldbody>
+      <geom type='plane' size='1 1 0.1'/>
+      <geom type='sphere' size='0.2'/>
+      <geom type='capsule' size='0.2 0.3'/>
+      <geom type='ellipsoid' size='0.2 0.3 0.4'/>
+      <geom type='cylinder' size='0.2 0.3'/>
+      <geom type='box' size='0.2 0.3 0.4'/>
+    </worldbody></mujoco>"""
+    model = mujoco.MjModel.from_xml_string(xml)
+    bounds = PrimitiveGeomBounds(model.geom_type, mujoco.mjtGeom)
+    sizes = model.geom_size[None].astype(np.float32)
+    rbound, aabb = bounds.compute(sizes, sizes, np.zeros((1, 6)), np.zeros((1, 6, 2, 3)))
+    np.testing.assert_allclose(rbound[0, 1:], model.geom_rbound[1:], atol=1e-7)
+    np.testing.assert_allclose(aabb[0, 1:], model.geom_aabb.reshape(6, 2, 3)[1:], atol=1e-7)

--- a/tests/test_reset_capability_contract.py
+++ b/tests/test_reset_capability_contract.py
@@ -1,0 +1,121 @@
+"""Engine-independent negative paths for selected-row reset capabilities."""
+
+import numpy as np
+import pytest
+
+from unisim import FakeBackend
+from unisim.backend.base import BackendMocapPoseBinding
+from unisim.dr.types import DomainRandomizationCapabilities, ResetRandomizationPayload
+
+
+def test_new_reset_terms_are_never_silently_advertised_or_filtered() -> None:
+    fields = ("geom_size", "geom_solref", "geom_solimp", "dof_damping", "dof_frictionloss")
+    payload = ResetRandomizationPayload(**{name: np.zeros((1, 1)) for name in fields})
+    assert payload.requested_terms() == frozenset(fields)
+    assert not payload.is_empty()
+    filtered, unsupported = DomainRandomizationCapabilities().filter_reset_payload(payload)
+    assert filtered is None
+    assert unsupported == frozenset(fields)
+    caps = DomainRandomizationCapabilities(supported_reset_terms=frozenset(fields))
+    assert caps.filter_reset_payload(payload) == (payload, frozenset())
+    partial_caps = DomainRandomizationCapabilities(supported_reset_terms=frozenset({"geom_size"}))
+    filtered, unsupported = partial_caps.filter_reset_payload(payload)
+    assert filtered.requested_terms() == frozenset({"geom_size"})
+    assert unsupported == frozenset(fields[1:])
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "get_geom_sizes",
+        "get_geom_solref",
+        "get_geom_solimp",
+        "get_dof_damping",
+        "get_dof_frictionloss",
+        "bind_mocap_pose",
+    ),
+)
+def test_unimplemented_backends_fail_explicitly(name: str) -> None:
+    backend = FakeBackend(num_envs=2, num_actuators=1)
+    with pytest.raises(NotImplementedError):
+        getattr(backend, name)(*(("root",) if name == "bind_mocap_pose" else ()))
+
+
+@pytest.mark.parametrize("adapter", ("mujoco", "motrix", "genesis"))
+@pytest.mark.parametrize(
+    "field", ("geom_size", "geom_solref", "geom_solimp", "dof_damping", "dof_frictionloss")
+)
+def test_legacy_adapter_rejects_new_payload_before_any_state_access(adapter, field) -> None:
+    # Construction requires optional SDKs. Calling the unbound method on an
+    # object with only the documented capability query proves the rejection
+    # precedes every state/native-runtime access, without mocking an engine.
+    import importlib
+
+    class CapabilityOnly:
+        def get_dr_capabilities(self):
+            return DomainRandomizationCapabilities()
+
+    module = importlib.import_module(f"unisim.backend.{adapter}.backend")
+    class_name = {
+        "mujoco": "MuJoCoBackend",
+        "motrix": "MotrixBackend",
+        "genesis": "GenesisBackend",
+    }[adapter]
+    backend_class = getattr(module, class_name)
+    with pytest.raises(NotImplementedError, match=field):
+        backend_class.set_state(
+            CapabilityOnly(),
+            np.array([0]),
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
+            ResetRandomizationPayload(**{field: np.zeros((1, 1))}),
+        )
+
+
+def _binding():
+    state = np.tile(np.array([0, 0, 0, 1, 0, 0, 0], dtype=np.float32), (3, 1))
+    writes = []
+
+    def write(rows, poses):
+        writes.append(rows.copy())
+        state[rows] = poses
+
+    return BackendMocapPoseBinding("test", "root", 3, state[0], lambda: state, write), writes
+
+
+@pytest.mark.parametrize(
+    "rows,poses,error",
+    (
+        (np.array([0.5]), np.zeros((1, 7)), TypeError),
+        (np.array([True]), np.zeros((1, 7)), TypeError),
+        (np.array([0, 0]), np.zeros((2, 7)), ValueError),
+        (np.array([-1]), np.zeros((1, 7)), IndexError),
+        (np.array([3]), np.zeros((1, 7)), IndexError),
+        (np.array([0]), np.zeros((1, 6)), ValueError),
+        (np.array([0]), np.zeros((1, 7), dtype=np.int32), TypeError),
+        (np.array([0]), np.full((1, 7), np.nan), ValueError),
+        (np.array([0]), np.zeros((1, 7)), ValueError),
+    ),
+)
+def test_mocap_invalid_writes_do_not_call_adapter(rows, poses, error) -> None:
+    binding, writes = _binding()
+    before = binding.read()
+    with pytest.raises(error):
+        binding.write(rows, poses)
+    assert not writes
+    np.testing.assert_array_equal(binding.read(), before)
+
+
+def test_mocap_sparse_write_default_snapshot_and_empty_ids() -> None:
+    binding, writes = _binding()
+    pose = binding.default_pose.copy()
+    pose[:3] = [1, 2, 3]
+    binding.write(np.array([2]), pose[None])
+    np.testing.assert_array_equal(binding.read()[2], pose)
+    np.testing.assert_array_equal(binding.read()[:2], np.tile(binding.default_pose, (2, 1)))
+    binding.read()[:] = 8  # Detached read must not let consumers mutate physics.
+    assert binding.read()[2, 0] == 1
+    with pytest.raises(ValueError):
+        binding.default_pose[0] = 2
+    binding.write(np.array([], dtype=np.int32), np.zeros((0, 7), dtype=np.float32))
+    assert len(writes) == 1


### PR DESCRIPTION
## Summary

Promotes the reviewed UniSim owner work required by `unilabsim/wuji_unilab#1` to `main`.

- Adds explicit SimBackend contracts for selected-world mocap binding and reset randomization of geometry size/contact parameters and DOF damping/friction.
- Implements the capability in mjwarp and makes unsupported adapters fail before state mutation.
- Repairs mjwarp position-actuator DR signs: positive `kp`/`kd` now write `gainprm[..., 0] = kp`, `biasprm[..., 1] = -kp`, and `biasprm[..., 2] = -kd`.
- Documents the mocap/reset contract and adds capability and physical-effect coverage.

The position-actuator repair resolved the bounded Wuji DR instability that ejected the object under positive feedback. It is required by the downstream lock at this exact integration head.

## Linked Work

- Issues: unilabsim/unisim#40, #42, #43
- Reviewed integration PRs: #42 and #44
- Parent roadmap: unilabsim/wuji_unilab#1
- Base branch: `main`

## Validation

```bash
uv sync --locked --extra mujoco --extra mjwarp
make check
uv run ruff check .
uv run pytest -q
uv build --out-dir /tmp/unisim-pr-dist
```

Results: `make check` passed on the final integration head; `uv run pytest -q` passed with 132 passed and 24 skipped; source distribution and wheel built successfully. CUDA 3.11 probes covered selected-world mocap isolation and DR physical effects.

## Impact

- Backend impact: mjwarp implementation; all non-mjwarp adapters explicitly reject unsupported capability use.
- Platform impact: Linux GPU evidence; public base package stays engine-lazy.
- Training effect expected: yes, for Wuji reset randomization and fixed-hand-pose behavior.

No release tag was created and no PyPI package was published.
