### PR TITLE
release: unisim-core 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.4 - 2026-09-08
 
 - Add cold-bound selected-world mocap pose reads/writes and reset ordering to
   `SimBackend`, with an explicit unsupported default and a MJWarp implementation.
@@ -9,6 +9,7 @@
   payload tables validate before mutation, preserve unselected worlds, and
   expose cold-path defaults through the public backend contract. See
   [the owner contract](docs/mocap-reset-contract.md) and issue #40.
+- Preserve position actuator gain signs in MJWarp domain randomization.
 
 ## 1.1.3 - 2026-09-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "1.1.3"
+version = "1.1.4"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2670,7 +2670,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Bump version to 1.1.4 and finalize the changelog for the Wuji reset capabilities release.

- Selected-world mocap pose reads/writes and reset ordering on `SimBackend` (MJWarp implementation)
- MJWarp reset randomization for geom size / solref / solimp, joint damping and friction loss
- Fix: preserve position actuator gain signs in MJWarp DR

Validation: `make check` (ruff + pytest: 132 passed, 24 skipped).