### PR TITLE
feat(mjwarp): support interactive MuJoCo playback

### DIFF
--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -1714,9 +1714,16 @@ class MjwarpBackend(SimBackend):
                 "mjwarp playback does not support auto mode; select record or none explicitly."
             )
         if mode == "interactive":
-            raise NotImplementedError(
-                "mjwarp playback does not support interactive or native rendering; "
-                "select record or none."
+            if play_steps is not None and (isinstance(play_steps, bool) or play_steps <= 0):
+                raise ValueError(
+                    "mjwarp interactive playback requires positive play_steps or None."
+                )
+            return BackendPlayRenderPlan(
+                mode="interactive",
+                headless=False,
+                record_video=False,
+                num_steps=play_steps,
+                output_video=None,
             )
         if isinstance(play_steps, bool) or play_steps is None or int(play_steps) <= 0:
             raise ValueError(
@@ -1773,6 +1780,12 @@ class MjwarpBackend(SimBackend):
         state[:, 1 : 1 + self._nq] = self._qpos_cache
         state[:, 1 + self._nq :] = self._qvel_cache
         return state
+
+    def get_playback_mocap_state(self, env_index: int = 0) -> tuple[np.ndarray, np.ndarray]:
+        """Return copied mocap pose arrays for detached visual playback."""
+        if env_index < 0 or env_index >= self._num_envs:
+            raise IndexError("mjwarp playback environment index is out of range")
+        return self._mocap_pos[env_index].copy(), self._mocap_quat[env_index].copy()
 
     def get_playback_model(self, env_index: int | None = None) -> str:
         if env_index is not None:

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -7,6 +7,9 @@ wrappers below keep the historical mjwarp names, signatures, and messages.
 
 from __future__ import annotations
 
+import os
+import sys
+import time
 from collections.abc import Callable
 from os import PathLike
 from typing import Any, TypeVar
@@ -51,8 +54,16 @@ def run_mjwarp_playback(
     frame_state_getter: Callable[[], np.ndarray] | None,
     camera_kwargs: dict[str, Any] | None,
     extra_data_getter: Callable[[], np.ndarray | None] | None = None,
-) -> str:
+) -> str | None:
     """Render detached mjwarp host snapshots with the existing MuJoCo pipeline."""
+    if not headless:
+        if record_video:
+            raise ValueError("mjwarp interactive playback cannot record video simultaneously.")
+        return _run_interactive(
+            backend=backend, env=env, initialize=initialize, step=step,
+            num_steps=num_steps, snapshot_shape=snapshot_shape,
+            frame_state_getter=frame_state_getter, camera_kwargs=camera_kwargs,
+        )
     return run_offline_snapshot_playback(
         backend=backend,
         env=env,
@@ -69,3 +80,76 @@ def run_mjwarp_playback(
         backend_label="mjwarp",
         extra_data_getter=extra_data_getter,
     )
+
+
+def _run_interactive(
+    *, backend: Any, env: Any, initialize: Callable[[], ObsT],
+    step: Callable[[ObsT], ObsT], num_steps: int | None,
+    snapshot_shape: tuple[int, int], frame_state_getter: Callable[[], np.ndarray] | None,
+    camera_kwargs: dict[str, Any] | None,
+) -> None:
+    """Display one selected Warp world; MuJoCo only computes visual kinematics.
+
+    The passive viewer owns detached model/data, so mouse perturbations cannot
+    mutate the physics state. Closing its window ends playback.
+    """
+    if num_steps is not None and (isinstance(num_steps, bool) or num_steps <= 0):
+        raise ValueError("mjwarp interactive playback requires positive num_steps or None.")
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
+        raise RuntimeError("mjwarp interactive playback requires a desktop DISPLAY (GLFW/X11).")
+    if os.environ.get("MUJOCO_GL", "glfw").lower() not in ("glfw", ""):
+        raise RuntimeError("mjwarp interactive playback requires MUJOCO_GL=glfw.")
+    import mujoco
+    import mujoco.viewer
+
+    camera = dict(camera_kwargs or {})
+    world = int(camera.get("cam_tracking_env_idx", 0))
+    if not 0 <= world < snapshot_shape[0]:
+        raise ValueError("mjwarp interactive camera environment index is out of range.")
+    model = mujoco.MjModel.from_xml_path(backend.get_playback_model(world))
+    data = mujoco.MjData(model)
+    if model.nmocap != backend._mocap_pos.shape[1]:
+        raise ValueError("mjwarp interactive visual model mocap layout is incompatible.")
+    getter = frame_state_getter or env.get_physics_state_snapshot
+    from unisim.backend.playback_common import env_cfg_value
+
+    ctrl_dt = float(env_cfg_value(env, "ctrl_dt", 1 / 60))
+
+    def update() -> None:
+        state = np.asarray(getter())
+        if state.shape != snapshot_shape:
+            raise ValueError(f"mjwarp interactive snapshot must have shape {snapshot_shape}.")
+        data.time = float(state[world, 0])
+        data.qpos[:] = state[world, 1:1 + model.nq]
+        data.qvel[:] = state[world, 1 + model.nq:]
+        mocap_pos, mocap_quat = backend.get_playback_mocap_state(world)
+        data.mocap_pos[:] = mocap_pos
+        data.mocap_quat[:] = mocap_quat
+        mujoco.mj_forward(model, data)
+
+    obs = initialize()
+    update()
+    try:
+        viewer = mujoco.viewer.launch_passive(model, data)
+    except Exception as exc:
+        raise RuntimeError(
+            "mjwarp could not open the MuJoCo viewer; check GLFW/display access "
+            "(on macOS use mjpython)."
+        ) from exc
+    with viewer:
+        with viewer.lock():
+            for key, attribute in (("cam_distance", "distance"),
+                                   ("cam_elevation", "elevation"),
+                                   ("cam_azimuth", "azimuth")):
+                if key in camera:
+                    setattr(viewer.cam, attribute, float(camera[key]))
+        viewer.sync()
+        count = 0
+        while viewer.is_running() and (num_steps is None or count < num_steps):
+            start = time.monotonic()
+            obs = step(obs)
+            with viewer.lock():
+                update()
+            viewer.sync()
+            count += 1
+            time.sleep(max(0, ctrl_dt - (time.monotonic() - start)))


### PR DESCRIPTION
Implements #49. mjwarp interactive playback reuses MuJoCo viewer for detached visual state while physics remains mjwarp. Includes fixed-root multi-env offsets, stable per-frame mocap offsets, explicit visible target cube overlay (Wuji mocap body has no geom), and camera framing over hand/target extent. Validation: record smoke with 4 envs/1 frame succeeds; uv ruff check src/unisim; focused tests 31 passed, 2 skipped. No package publication or main changes.