### PR TITLE
feat(playback)!: typed debug overlay primitives replace extra_data_getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **Breaking:** replace `run_playback(..., extra_data_getter=...)` with
+  `debug_overlay_getter`. The new callback returns per-frame, per-env
+  sequences of typed `DebugPrimitive` values (`sphere`, `box`, `frame`,
+  `arrow`, `ghost_geom`, `text`) with env-local poses instead of a single
+  `(num_envs, 3)` marker-position array; grid offsets are applied by the
+  renderer. `BackendPlayCapabilities` gains `supports_debug_overlay`; the
+  MuJoCo-family offline snapshot pipeline (mujoco, mjwarp, drake, newton,
+  superdex) advertises it, while other backends fail closed with
+  `NotImplementedError` when a getter is supplied. `ghost_geom` primitives
+  resolve `mesh_asset` against playback-model mesh names or mesh asset files
+  injected into the render model; `text` primitives are a documented no-op on
+  the MuJoCo off-screen path. Newton record playback with overlays routes to
+  the offline MuJoCo snapshot renderer (the native ViewerGL path cannot
+  inject user geoms); mjwarp interactive playback fails closed with overlays.
+- **Breaking:** `camera_kwargs` is normalized into the typed frozen
+  `CameraCfg` at the `run_playback`/`init_renderer` boundary. Unknown keys —
+  including the historical `distance`/`elevation_deg`/`azimuth_deg` aliases —
+  now raise an error naming them instead of being silently ignored; the
+  optional `cam_fov` key is supported by the MuJoCo offline renderer and
+  Genesis. `DebugPrimitive`, `DebugOverlayGetter`, `CameraCfg`, and
+  `validate_debug_overlays` are exported from `unisim` and
+  `unisim.contract` (unilabsim/wuji_unilab#21).
+
 - Add a local-source SuperDex `SceneBatchExecutor` integration: a persistent
   C++ CPU barrier batches independent-scene generalized force writes, stepping,
   and articulated state reads. `superdex_num_workers=0` resolves an

--- a/src/unisim/__init__.py
+++ b/src/unisim/__init__.py
@@ -7,7 +7,16 @@ The distribution is named ``unisim-core`` while the public Python namespace is
 from .adapters import ADAPTER_SPECS, AdapterSpec, adapter_spec
 from .benchmark import BenchmarkCase, BenchmarkResult
 from .conformance import assert_backend_conformance
-from .contract import BackendCapability, BackendError, SimBackend, UnsupportedCapabilityError
+from .contract import (
+    BackendCapability,
+    BackendError,
+    CameraCfg,
+    DebugOverlayGetter,
+    DebugPrimitive,
+    SimBackend,
+    UnsupportedCapabilityError,
+    validate_debug_overlays,
+)
 from .factory import create_backend
 from .fake import FakeBackend
 from .optional import OptionalDependencyError
@@ -19,6 +28,9 @@ __all__ = [
     "BenchmarkResult",
     "ADAPTER_SPECS",
     "AdapterSpec",
+    "CameraCfg",
+    "DebugOverlayGetter",
+    "DebugPrimitive",
     "FakeBackend",
     "DrakeBackend",
     "MJWarpBackend",
@@ -43,6 +55,7 @@ __all__ = [
     "assert_backend_conformance",
     "adapter_spec",
     "create_backend",
+    "validate_debug_overlays",
 ]
 
 

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -1,8 +1,9 @@
 import abc
-from collections.abc import Callable, Sequence
+import math
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from os import PathLike
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
@@ -17,6 +18,241 @@ from unisim.dr.types import (
 PreStepControlFn = Callable[[Any, np.ndarray], np.ndarray]
 TerrainHeightSampleFn = Callable[[np.ndarray], np.ndarray]
 SensorReadFn = Callable[[], np.ndarray]
+
+
+DebugPrimitiveKind = Literal["sphere", "box", "frame", "arrow", "ghost_geom", "text"]
+DEBUG_PRIMITIVE_KINDS = frozenset(
+    {"sphere", "box", "frame", "arrow", "ghost_geom", "text"}
+)
+DEFAULT_DEBUG_RGBA = (1.0, 0.2, 0.2, 0.5)
+
+# Expected ``size`` arity per primitive kind; ``ghost_geom`` also accepts an
+# empty size (uniform scale defaults to 1.0) and ``text`` carries no size.
+_DEBUG_PRIMITIVE_SIZE_ARITY: dict[str, frozenset[int]] = {
+    "sphere": frozenset({1}),
+    "box": frozenset({3}),
+    "frame": frozenset({1}),
+    "arrow": frozenset({1}),
+    "ghost_geom": frozenset({0, 1}),
+    "text": frozenset({0}),
+}
+
+
+@dataclass(frozen=True)
+class DebugPrimitive:
+    """One task-owned debug primitive overlaid on playback rendering.
+
+    ``pos`` (and the orientation implied by ``quat``) is expressed in the
+    environment-local frame; grid offsets are applied by the renderer when
+    multiple envs are composed into one frame.  ``size`` semantics depend on
+    ``kind``: sphere=(radius,), box=(half_x, half_y, half_z), frame=(axis_length,)
+    drawing RGB xyz triads, arrow=(length,) pointing along the local +z axis,
+    ghost_geom=(uniform_scale,) defaulting to 1.0, text=().  ``mesh_asset``
+    (ghost_geom only) names either a mesh registered in the playback model or
+    a mesh asset file (``.obj``/``.stl``) injected into the render model.
+    ``text`` (text kind only) is the label anchored at ``pos``; the MuJoCo
+    off-screen scene has no text channel, so text primitives are currently
+    skipped by the offline renderer (documented no-op, not an error).
+    """
+
+    kind: DebugPrimitiveKind
+    pos: tuple[float, float, float]
+    quat: tuple[float, float, float, float] | None = None
+    size: tuple[float, ...] = ()
+    rgba: tuple[float, float, float, float] = DEFAULT_DEBUG_RGBA
+    mesh_asset: str | None = None
+    text: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in DEBUG_PRIMITIVE_KINDS:
+            allowed = ", ".join(sorted(DEBUG_PRIMITIVE_KINDS))
+            raise ValueError(f"DebugPrimitive kind must be one of: {allowed}; got {self.kind!r}")
+        object.__setattr__(self, "pos", _as_float_tuple(self.pos, 3, "DebugPrimitive pos"))
+        if self.quat is not None:
+            quat = _as_float_tuple(self.quat, 4, "DebugPrimitive quat")
+            norm = math.sqrt(sum(component * component for component in quat))
+            if not math.isfinite(norm) or norm < 1e-6:
+                raise ValueError("DebugPrimitive quat must be a non-zero wxyz quaternion")
+            if abs(norm - 1.0) > 1e-3:
+                raise ValueError(
+                    f"DebugPrimitive quat must be unit-length wxyz (norm {norm:.6f})"
+                )
+            object.__setattr__(self, "quat", quat)
+        size = _as_float_tuple(self.size, None, "DebugPrimitive size")
+        if len(size) not in _DEBUG_PRIMITIVE_SIZE_ARITY[self.kind]:
+            raise ValueError(
+                f"DebugPrimitive kind {self.kind!r} expects size arity "
+                f"{sorted(_DEBUG_PRIMITIVE_SIZE_ARITY[self.kind])}; got {len(size)}"
+            )
+        if any(component <= 0 for component in size):
+            raise ValueError("DebugPrimitive size components must be positive")
+        object.__setattr__(self, "size", size)
+        rgba = _as_float_tuple(self.rgba, 4, "DebugPrimitive rgba")
+        if any(component < 0.0 or component > 1.0 for component in rgba):
+            raise ValueError("DebugPrimitive rgba components must lie in [0, 1]")
+        object.__setattr__(self, "rgba", rgba)
+        if self.kind == "ghost_geom":
+            if not isinstance(self.mesh_asset, str) or not self.mesh_asset:
+                raise ValueError("DebugPrimitive ghost_geom requires a non-empty mesh_asset")
+        elif self.mesh_asset is not None:
+            raise ValueError("DebugPrimitive mesh_asset is only valid for kind 'ghost_geom'")
+        if self.kind == "text":
+            if not isinstance(self.text, str):
+                raise ValueError("DebugPrimitive text kind requires a text string")
+        elif self.text is not None:
+            raise ValueError("DebugPrimitive text is only valid for kind 'text'")
+
+
+def _as_float_tuple(values: Any, arity: int | None, label: str) -> tuple[float, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{label} must be a numeric sequence")
+    if arity is not None and len(values) != arity:
+        raise ValueError(f"{label} must have {arity} components; got {len(values)}")
+    out = tuple(float(value) for value in values)
+    if not all(math.isfinite(value) for value in out):
+        raise ValueError(f"{label} components must be finite")
+    return out
+
+
+DebugOverlayGetter = Callable[[], "Sequence[Sequence[DebugPrimitive] | None] | None"]
+
+
+def validate_debug_overlays(
+    overlays: Sequence[Sequence[DebugPrimitive] | None] | None,
+    num_envs: int,
+) -> Sequence[Sequence[DebugPrimitive] | None] | None:
+    """Validate one frame of debug overlay primitives against the env batch.
+
+    The outer sequence is indexed by environment and must have length
+    ``num_envs``; each entry is the env's primitive sequence (``None`` or
+    empty marks an env without overlay).  ``None`` disables overlays for the
+    whole frame.  Returns the input unchanged so callers can chain it.
+    """
+    if overlays is None:
+        return None
+    if isinstance(overlays, (str, bytes)) or not isinstance(overlays, Sequence):
+        raise TypeError(
+            "debug overlays must be a per-env sequence of DebugPrimitive sequences or None"
+        )
+    if len(overlays) != num_envs:
+        raise ValueError(
+            f"debug overlays must have one entry per env (len == {num_envs}); "
+            f"got {len(overlays)}"
+        )
+    for env_idx, env_primitives in enumerate(overlays):
+        if env_primitives is None:
+            continue
+        if isinstance(env_primitives, (str, bytes)) or not isinstance(env_primitives, Sequence):
+            raise TypeError(f"debug overlays[{env_idx}] must be a sequence of DebugPrimitive")
+        for primitive in env_primitives:
+            if not isinstance(primitive, DebugPrimitive):
+                raise TypeError(
+                    f"debug overlays[{env_idx}] entries must be DebugPrimitive; "
+                    f"got {type(primitive).__name__}"
+                )
+    return overlays
+
+
+_CAMERA_CFG_FIELDS = frozenset(
+    {
+        "cam_distance",
+        "cam_elevation",
+        "cam_azimuth",
+        "cam_lookat",
+        "cam_tracking",
+        "cam_tracking_env_idx",
+        "cam_tracking_extra_envs",
+        "cam_fov",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CameraCfg:
+    """Typed playback/renderer camera configuration.
+
+    Angles are degrees in MuJoCo's free-camera convention (negative elevation
+    looks down from above).  ``cam_lookat`` pins the free-camera target;
+    ``cam_tracking`` follows one env's root body, showing up to
+    ``cam_tracking_extra_envs`` nearest neighbours.  ``cam_fov`` is the
+    vertical field of view in degrees where the renderer supports it.
+    """
+
+    cam_distance: float = 2.0
+    cam_elevation: float = -20.0
+    cam_azimuth: float = 90.0
+    cam_lookat: tuple[float, float, float] | None = None
+    cam_tracking: bool = False
+    cam_tracking_env_idx: int = 0
+    cam_tracking_extra_envs: int = 2
+    cam_fov: float | None = None
+
+    def __post_init__(self) -> None:
+        distance = float(self.cam_distance)
+        if not math.isfinite(distance) or distance <= 0:
+            raise ValueError(f"cam_distance must be positive and finite; got {self.cam_distance!r}")
+        object.__setattr__(self, "cam_distance", distance)
+        elevation = float(self.cam_elevation)
+        if not math.isfinite(elevation) or not -90.0 <= elevation <= 90.0:
+            raise ValueError(
+                f"cam_elevation must lie in [-90, 90] degrees; got {self.cam_elevation!r}"
+            )
+        object.__setattr__(self, "cam_elevation", elevation)
+        azimuth = float(self.cam_azimuth)
+        if not math.isfinite(azimuth):
+            raise ValueError(f"cam_azimuth must be finite; got {self.cam_azimuth!r}")
+        object.__setattr__(self, "cam_azimuth", azimuth)
+        if self.cam_lookat is not None:
+            lookat = _as_float_tuple(self.cam_lookat, 3, "CameraCfg cam_lookat")
+            object.__setattr__(self, "cam_lookat", lookat)
+        object.__setattr__(self, "cam_tracking", bool(self.cam_tracking))
+        for name in ("cam_tracking_env_idx", "cam_tracking_extra_envs"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+                raise TypeError(f"{name} must be an integer; got {value!r}")
+            if int(value) < 0:
+                raise ValueError(f"{name} must be non-negative; got {value}")
+            object.__setattr__(self, name, int(value))
+        if self.cam_fov is not None:
+            fov = float(self.cam_fov)
+            if not math.isfinite(fov) or not 0.0 < fov < 180.0:
+                raise ValueError(f"cam_fov must lie in (0, 180) degrees; got {self.cam_fov!r}")
+            object.__setattr__(self, "cam_fov", fov)
+
+    @classmethod
+    def from_kwargs(cls, kwargs: "CameraCfg | Mapping[str, Any] | None") -> "CameraCfg":
+        """Normalize boundary ``camera_kwargs`` input into a ``CameraCfg``.
+
+        ``None`` yields defaults and an existing ``CameraCfg`` passes through.
+        Mapping keys must be a subset of the declared fields; unknown keys
+        (including the historical ``distance``/``elevation_deg`` aliases) fail
+        closed with an error naming them instead of being silently ignored.
+        """
+        if kwargs is None:
+            return cls()
+        if isinstance(kwargs, cls):
+            return kwargs
+        if not isinstance(kwargs, Mapping):
+            raise TypeError(
+                f"camera_kwargs must be a CameraCfg, a mapping, or None; "
+                f"got {type(kwargs).__name__}"
+            )
+        unknown = sorted(set(kwargs) - _CAMERA_CFG_FIELDS)
+        if unknown:
+            allowed = ", ".join(sorted(_CAMERA_CFG_FIELDS))
+            raise ValueError(
+                f"unknown camera_kwargs key(s): {unknown}; supported keys: {allowed}"
+            )
+        return cls(**dict(kwargs))
+
+
+def unsupported_debug_overlay_error(owner: str) -> NotImplementedError:
+    """Build the fail-closed error for backends without debug overlay support."""
+    return NotImplementedError(
+        f"{owner} does not support debug overlay primitives "
+        "(get_play_capabilities().supports_debug_overlay is False); omit "
+        "debug_overlay_getter or use a backend on the MuJoCo offline snapshot pipeline"
+    )
 
 
 @dataclass(frozen=True)
@@ -246,6 +482,7 @@ class BackendPlayCapabilities:
     supports_native_interactive_renderer: bool = False
     supports_physics_state_playback: bool = False
     supports_native_video_capture: bool = False
+    supports_debug_overlay: bool = False
 
 
 class BackendHeightScanner(abc.ABC):
@@ -786,10 +1023,22 @@ class SimBackend(abc.ABC):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter: Callable[[], np.ndarray] | None = None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: DebugOverlayGetter | None = None,
     ) -> str | None:
         """Execute backend-owned playback for an env wrapper.
+
+        ``camera_kwargs`` is normalized into :class:`CameraCfg` at this
+        boundary; unknown mapping keys fail closed with an error naming them.
+
+        ``debug_overlay_getter`` is an optional per-frame callback returning a
+        sequence with one entry per environment (``len == num_envs``); each
+        entry is that env's sequence of :class:`DebugPrimitive` (``None`` or
+        empty marks an env without overlay) and returning ``None`` disables
+        overlays for the frame.  Primitive poses are env-local; the renderer
+        applies grid offsets when composing multiple envs.  Backends whose
+        ``get_play_capabilities().supports_debug_overlay`` is False fail
+        closed with :class:`NotImplementedError` when this is not ``None``.
 
         Known boundary: ``env`` is the owning env wrapper, not a physics-layer
         concept. Current playback implementations read env-level configuration
@@ -811,12 +1060,14 @@ class SimBackend(abc.ABC):
         capture: bool = False,
         width: int = 1280,
         height: int = 720,
-        camera_kwargs: dict[str, Any] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize a backend-native renderer.
 
         ``headless`` controls whether a native window is opened. ``capture``
         controls whether ``capture_video_frame`` is valid for the renderer.
+        ``camera_kwargs`` is normalized into :class:`CameraCfg` at this
+        boundary; unknown mapping keys fail closed with an error naming them.
         """
         raise NotImplementedError(f"{self.__class__.__name__} does not support native rendering")
 

--- a/src/unisim/backend/drake/backend.py
+++ b/src/unisim/backend/drake/backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import sys
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from importlib.util import find_spec
 from multiprocessing import cpu_count
@@ -23,6 +23,8 @@ import numpy as np
 from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    CameraCfg,
+    DebugOverlayGetter,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -551,6 +553,7 @@ class DrakeBackend(SimBackend):
             supports_native_interactive_renderer=False,
             supports_physics_state_playback=True,
             supports_native_video_capture=False,
+            supports_debug_overlay=True,
         )
 
     def resolve_play_render_plan(
@@ -598,8 +601,8 @@ class DrakeBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter: Callable[[], np.ndarray] | None = None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: DebugOverlayGetter | None = None,
     ) -> str | None:
         # Playback keeps Drake as the physics backend. The helper owns rendering
         # and video capture so training code can use one playback contract.
@@ -614,8 +617,8 @@ class DrakeBackend(SimBackend):
             headless=bool(headless),
             record_video=bool(record_video),
             frame_state_getter=frame_state_getter,
-            camera_kwargs=camera_kwargs,
-            extra_data_getter=extra_data_getter,
+            camera_kwargs=CameraCfg.from_kwargs(camera_kwargs),
+            debug_overlay_getter=debug_overlay_getter,
         )
 
     def init_renderer(

--- a/src/unisim/backend/drake/playback.py
+++ b/src/unisim/backend/drake/playback.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from os import PathLike
 from typing import Any, Callable, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import CameraCfg, DebugOverlayGetter
 from unisim.backend.mujoco.playback import run_mujoco_playback
 
 ObsT = TypeVar("ObsT")
@@ -24,8 +26,8 @@ def run_drake_playback(
     headless: bool,
     record_video: bool,
     frame_state_getter: Callable[[], np.ndarray] | None,
-    camera_kwargs: dict[str, Any] | None,
-    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
+    debug_overlay_getter: DebugOverlayGetter | None = None,
 ) -> str | None:
     """Run Drake physics playback and optionally render it with MuJoCo.
 
@@ -46,7 +48,7 @@ def run_drake_playback(
             record_video=True,
             frame_state_getter=frame_state_getter,
             camera_kwargs=camera_kwargs,
-            extra_data_getter=extra_data_getter,
+            debug_overlay_getter=debug_overlay_getter,
         )
     if not headless:
         raise NotImplementedError("Drake playback does not support interactive rendering yet.")

--- a/src/unisim/backend/genesis/backend.py
+++ b/src/unisim/backend/genesis/backend.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import importlib
 import logging
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from os import PathLike
 from typing import Any
 
@@ -27,9 +27,11 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    CameraCfg,
     RenderClosedError,
     SimBackend,
     normalize_play_render_mode,
+    unsupported_debug_overlay_error,
 )
 from unisim.dr.types import (
     INTERVAL_TERM_BODY_FORCE,
@@ -194,7 +196,7 @@ class GenesisBackend(SimBackend):
         self._render_config: tuple[bool, bool] | None = None
         self._viewer: Any | None = None
         self._render_camera: Any | None = None
-        self._camera_kwargs: dict[str, Any] = {}
+        self._camera_cfg: CameraCfg = CameraCfg()
         self._camera_tracking_env_idx: int | None = None
 
     # ------------------------------------------------------------------ #
@@ -889,7 +891,7 @@ class GenesisBackend(SimBackend):
         capture: bool = False,
         width: int = 1280,
         height: int = 720,
-        camera_kwargs: dict[str, Any] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
     ) -> None:
         """Lazily attach the Genesis viewer and/or an offscreen camera.
 
@@ -912,10 +914,9 @@ class GenesisBackend(SimBackend):
             return
         self._require_state("init_renderer")
         self._render_config = config
-        self._camera_kwargs = dict(camera_kwargs or {})
-        tracking = self._camera_kwargs.get("cam_tracking", False)
+        self._camera_cfg = CameraCfg.from_kwargs(camera_kwargs)
         self._camera_tracking_env_idx = (
-            int(self._camera_kwargs.get("cam_tracking_env_idx", 0)) if tracking else None
+            self._camera_cfg.cam_tracking_env_idx if self._camera_cfg.cam_tracking else None
         )
         visualizer = self._scene.visualizer
         if not headless:
@@ -941,7 +942,7 @@ class GenesisBackend(SimBackend):
             visualizer._viewer = viewer
             visualizer.viewer_lock = viewer.lock
             pos, lookat = playback.camera_pose_from_kwargs(
-                self._camera_kwargs, self._camera_lookat()
+                self._camera_cfg, self._camera_lookat()
             )
             # #1396: the viewer's pos/lookat branch reuses its polluted
             # default _camera_up; pass the full Z-up pose matrix instead.
@@ -951,7 +952,7 @@ class GenesisBackend(SimBackend):
             self._viewer = viewer
         if capture:
             pos, lookat = playback.camera_pose_from_kwargs(
-                self._camera_kwargs, self._camera_lookat()
+                self._camera_cfg, self._camera_lookat()
             )
             camera = visualizer.add_camera(
                 res=(int(width), int(height)),
@@ -959,7 +960,7 @@ class GenesisBackend(SimBackend):
                 lookat=tuple(lookat),
                 up=(0.0, 0.0, 1.0),
                 model="pinhole",
-                fov=float(self._camera_kwargs.get("cam_fov", 30.0)),
+                fov=self._camera_cfg.cam_fov if self._camera_cfg.cam_fov is not None else 30.0,
                 aperture=2.0,
                 focus_dist=None,
                 spp=256,
@@ -982,7 +983,7 @@ class GenesisBackend(SimBackend):
     def render(self) -> None:
         """Draw one interactive viewer frame (self-initializes interactive)."""
         if self._viewer is None:
-            self.init_renderer(headless=False, camera_kwargs=self._camera_kwargs)
+            self.init_renderer(headless=False, camera_kwargs=self._camera_cfg)
         assert self._viewer is not None
         try:
             self._scene.visualizer.update(force=False)
@@ -996,14 +997,14 @@ class GenesisBackend(SimBackend):
     def capture_video_frame(self) -> np.ndarray:
         """Capture one offscreen RGB frame (self-initializes headless+capture)."""
         if self._render_camera is None:
-            self.init_renderer(headless=True, capture=True, camera_kwargs=self._camera_kwargs)
+            self.init_renderer(headless=True, capture=True, camera_kwargs=self._camera_cfg)
         assert self._render_camera is not None
         if self._camera_tracking_env_idx is not None and self._base_link_idx is not None:
             lookat = np.asarray(
                 self._links_pos_cache[1][self._camera_tracking_env_idx, self._base_link_idx],
                 dtype=np.float64,
             )
-            pos, lookat = playback.camera_pose_from_kwargs(self._camera_kwargs, lookat)
+            pos, lookat = playback.camera_pose_from_kwargs(self._camera_cfg, lookat)
             self._render_camera.set_pose(pos=tuple(pos), lookat=tuple(lookat))
         frame = self._render_camera.render()[0]
         if frame.ndim == 4:
@@ -1030,11 +1031,14 @@ class GenesisBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter: Any = None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter: Any = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: Any = None,
     ) -> str | None:
         # Native live-scene playback: no state snapshots are needed.
-        del render_spacing, render_offset_mode, frame_state_getter, extra_data_getter
+        del render_spacing, render_offset_mode, frame_state_getter
+        if debug_overlay_getter is not None:
+            raise unsupported_debug_overlay_error(self.__class__.__name__)
+        camera_cfg = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None
         )
@@ -1049,7 +1053,7 @@ class GenesisBackend(SimBackend):
                 output_video=output_video,
                 headless=should_run_headless,
                 record_video=should_record_video,
-                camera_kwargs=camera_kwargs,
+                camera_kwargs=camera_cfg,
             )
         except RenderClosedError:
             if not should_run_headless and not should_record_video:

--- a/src/unisim/backend/genesis/playback.py
+++ b/src/unisim/backend/genesis/playback.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Mapping
 from os import PathLike
 from typing import Any, Callable, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import CameraCfg
 from unisim.backend.playback_common import env_cfg_value, write_playback_video
 
 ObsT = TypeVar("ObsT")
@@ -27,27 +29,23 @@ def display_available() -> bool:
 
 
 def camera_pose_from_kwargs(
-    camera_kwargs: dict[str, Any] | None, lookat: np.ndarray
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None, lookat: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Map repo-wide MuJoCo-style spherical camera kwargs onto (pos, lookat).
+    """Map the repo-wide MuJoCo-style camera configuration onto (pos, lookat).
 
     MuJoCo's negative-elevation convention is kept: ``cam_elevation=-20``
     places the camera above the horizon looking down. ``cam_lookat`` pins the
     lookat point when set.
     """
-    kwargs = dict(camera_kwargs or {})
-    distance = float(kwargs.get("cam_distance", kwargs.get("distance", 2.0)))
-    elevation_deg = float(kwargs.get("cam_elevation", -20.0))
-    azimuth_deg = float(kwargs.get("cam_azimuth", 90.0))
-    lookat_override = kwargs.get("cam_lookat")
+    camera = CameraCfg.from_kwargs(camera_kwargs)
     target = (
-        np.asarray(lookat_override, dtype=np.float64)
-        if lookat_override is not None
+        np.asarray(camera.cam_lookat, dtype=np.float64)
+        if camera.cam_lookat is not None
         else np.asarray(lookat, dtype=np.float64)
     )
-    elevation = np.deg2rad(elevation_deg)
-    azimuth = np.deg2rad(azimuth_deg)
-    offset = distance * np.array(
+    elevation = np.deg2rad(camera.cam_elevation)
+    azimuth = np.deg2rad(camera.cam_azimuth)
+    offset = camera.cam_distance * np.array(
         [
             np.cos(elevation) * np.cos(azimuth),
             np.cos(elevation) * np.sin(azimuth),
@@ -90,7 +88,7 @@ def run_genesis_playback(
     output_video: str | PathLike[str] | None,
     headless: bool,
     record_video: bool,
-    camera_kwargs: dict[str, Any] | None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
 ) -> str | None:
     if record_video and not headless:
         raise ValueError("genesis video recording requires headless=true.")
@@ -106,7 +104,7 @@ def run_genesis_playback(
             capture=True,
             width=1280,
             height=720,
-            camera_kwargs=dict(camera_kwargs or {}),
+            camera_kwargs=camera_kwargs,
         )
 
         obs = initialize()
@@ -126,7 +124,7 @@ def run_genesis_playback(
         write_playback_video(str(output_video), frames, fps=int(1.0 / ctrl_dt))
         return str(output_video)
 
-    backend.init_renderer(headless=False, camera_kwargs=dict(camera_kwargs or {}))
+    backend.init_renderer(headless=False, camera_kwargs=camera_kwargs)
     obs = initialize()
     last_render_time = time.perf_counter()
     render_dt = 1.0 / 60.0

--- a/src/unisim/backend/isaacsim/backend.py
+++ b/src/unisim/backend/isaacsim/backend.py
@@ -11,6 +11,7 @@ Kit/viewer/camera capability boundary.
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ import numpy as np
 from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
+    CameraCfg,
     normalize_play_render_mode,
 )
 from unisim.backend.isaacgym.backend import IsaacGymWorkerError
@@ -318,7 +320,7 @@ class IsaacSimBackend(MjcfSubprocessBackend):
         capture: bool = False,
         width: int = 1280,
         height: int = 720,
-        camera_kwargs: dict[str, Any] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
     ) -> None:
         mode = self._resolved_render_mode
         if mode is None:

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import gc
 import time
 import warnings
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from functools import partial
 from os import PathLike
@@ -25,6 +25,8 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    CameraCfg,
+    DebugOverlayGetter,
     PreStepControlFn,
     SimBackend,
     normalize_play_render_mode,
@@ -1691,7 +1693,10 @@ class MjwarpBackend(SimBackend):
         """Resources are fully materialized during the constructor cold path."""
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
-        return BackendPlayCapabilities(supports_physics_state_playback=True)
+        return BackendPlayCapabilities(
+            supports_physics_state_playback=True,
+            supports_debug_overlay=True,
+        )
 
     def resolve_play_render_plan(
         self,
@@ -1752,10 +1757,11 @@ class MjwarpBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter: Any = None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter: Any = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: DebugOverlayGetter | None = None,
     ) -> str | None:
         del render_offset_mode
+        camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record = bool(record_video) if record_video is not None else output_video is not None
         should_run_headless = bool(headless) if headless is not None else should_record
         return run_mjwarp_playback(
@@ -1770,8 +1776,8 @@ class MjwarpBackend(SimBackend):
             record_video=should_record,
             snapshot_shape=(self._num_envs, 1 + self._nq + self._nv),
             frame_state_getter=frame_state_getter,
-            camera_kwargs=camera_kwargs,
-            extra_data_getter=extra_data_getter,
+            camera_kwargs=camera,
+            debug_overlay_getter=debug_overlay_getter,
         )
 
     def get_physics_state(self) -> np.ndarray:

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 import os
 import sys
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from os import PathLike
 from typing import Any, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import CameraCfg, DebugOverlayGetter
 from unisim.backend.playback_common import (
     run_offline_snapshot_playback,
     validate_offline_visual_model,
@@ -52,13 +53,18 @@ def run_mjwarp_playback(
     record_video: bool,
     snapshot_shape: tuple[int, int],
     frame_state_getter: Callable[[], np.ndarray] | None,
-    camera_kwargs: dict[str, Any] | None,
-    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
+    debug_overlay_getter: DebugOverlayGetter | None = None,
 ) -> str | None:
     """Render detached mjwarp host snapshots with the existing MuJoCo pipeline."""
     if not headless:
         if record_video:
             raise ValueError("mjwarp interactive playback cannot record video simultaneously.")
+        if debug_overlay_getter is not None:
+            raise NotImplementedError(
+                "mjwarp interactive playback does not support debug overlay primitives; "
+                "use play_render_mode=record (offline MuJoCo snapshot renderer)"
+            )
         return _run_interactive(
             backend=backend, env=env, initialize=initialize, step=step,
             num_steps=num_steps, snapshot_shape=snapshot_shape,
@@ -78,7 +84,7 @@ def run_mjwarp_playback(
         frame_state_getter=frame_state_getter,
         camera_kwargs=camera_kwargs,
         backend_label="mjwarp",
-        extra_data_getter=extra_data_getter,
+        debug_overlay_getter=debug_overlay_getter,
     )
 
 
@@ -86,7 +92,7 @@ def _run_interactive(
     *, backend: Any, env: Any, initialize: Callable[[], ObsT],
     step: Callable[[ObsT], ObsT], num_steps: int | None,
     snapshot_shape: tuple[int, int], frame_state_getter: Callable[[], np.ndarray] | None,
-    camera_kwargs: dict[str, Any] | None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
 ) -> None:
     """Display one selected Warp world; MuJoCo only computes visual kinematics.
 
@@ -102,8 +108,8 @@ def _run_interactive(
     import mujoco
     import mujoco.viewer
 
-    camera = dict(camera_kwargs or {})
-    world = int(camera.get("cam_tracking_env_idx", 0))
+    camera = CameraCfg.from_kwargs(camera_kwargs)
+    world = camera.cam_tracking_env_idx
     if not 0 <= world < snapshot_shape[0]:
         raise ValueError("mjwarp interactive camera environment index is out of range.")
     model = mujoco.MjModel.from_xml_path(backend.get_playback_model(world))
@@ -138,11 +144,9 @@ def _run_interactive(
         ) from exc
     with viewer:
         with viewer.lock():
-            for key, attribute in (("cam_distance", "distance"),
-                                   ("cam_elevation", "elevation"),
-                                   ("cam_azimuth", "azimuth")):
-                if key in camera:
-                    setattr(viewer.cam, attribute, float(camera[key]))
+            viewer.cam.distance = camera.cam_distance
+            viewer.cam.elevation = camera.cam_elevation
+            viewer.cam.azimuth = camera.cam_azimuth
         viewer.sync()
         count = 0
         while viewer.is_running() and (num_steps is None or count < num_steps):

--- a/src/unisim/backend/motrix/backend.py
+++ b/src/unisim/backend/motrix/backend.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 
@@ -45,9 +45,11 @@ from ..base import (
     BackendPlayRenderPlan,
     BackendRootStateLayout,
     BackendTerrainSpawnData,
+    CameraCfg,
     RenderClosedError,
     SimBackend,
     normalize_play_render_mode,
+    unsupported_debug_overlay_error,
 )
 from ..motrix_camera import (
     MotrixTrackingCamera,
@@ -1015,10 +1017,13 @@ class MotrixBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter=None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter=None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter=None,
     ) -> str | None:
-        del frame_state_getter, extra_data_getter
+        del frame_state_getter
+        if debug_overlay_getter is not None:
+            raise unsupported_debug_overlay_error(self.__class__.__name__)
+        camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None
         )
@@ -1035,7 +1040,7 @@ class MotrixBackend(SimBackend):
                 render_offset_mode=render_offset_mode,
                 headless=should_run_headless,
                 record_video=should_record_video,
-                camera_kwargs=camera_kwargs,
+                camera_kwargs=camera,
             )
         except RenderClosedError:
             if not should_run_headless and not should_record_video:
@@ -1571,7 +1576,7 @@ class MotrixBackend(SimBackend):
         capture: bool = False,
         width: int = 1280,
         height: int = 720,
-        camera_kwargs: dict[str, Any] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize a Motrix renderer, optionally enabling system-camera capture."""
         headless = bool(headless)
@@ -1580,6 +1585,7 @@ class MotrixBackend(SimBackend):
         if self._render_app is not None:
             return
 
+        camera = CameraCfg.from_kwargs(camera_kwargs)
         settings = RenderSettings.performance()
         settings.enable_shadow = True
         offsets = render_offsets(
@@ -1591,16 +1597,12 @@ class MotrixBackend(SimBackend):
         self._render_offsets_np = offsets_np
         use_configured_camera = capture or camera_kwargs is not None
         if use_configured_camera:
-            base_positions = (
-                self.get_base_pos()
-                if bool(dict(camera_kwargs or {}).get("cam_tracking", False))
-                else None
-            )
+            base_positions = self.get_base_pos() if camera.cam_tracking else None
             camera_view = resolve_system_camera_view(
                 self._num_envs,
                 base_positions,
                 offsets,
-                camera_kwargs,
+                camera,
             )
             tracking_camera = camera_view.tracking
         else:

--- a/src/unisim/backend/motrix/playback.py
+++ b/src/unisim/backend/motrix/playback.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 from os import PathLike
 from typing import Any, Callable, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import CameraCfg
 from unisim.backend.playback_common import env_cfg_value, write_playback_video
 
 ObsT = TypeVar("ObsT")
@@ -25,10 +27,8 @@ def run_motrix_playback(
     render_offset_mode: str | None,
     headless: bool,
     record_video: bool,
-    camera_kwargs: dict[str, Any] | None,
-    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
 ) -> str | None:
-    del extra_data_getter
     if record_video and not headless:
         raise ValueError("Motrix video recording requires headless=true.")
 
@@ -50,7 +50,7 @@ def run_motrix_playback(
             capture=True,
             width=1280,
             height=720,
-            camera_kwargs=dict(camera_kwargs or {}),
+            camera_kwargs=camera_kwargs,
         )
 
         obs = initialize()

--- a/src/unisim/backend/motrix_camera.py
+++ b/src/unisim/backend/motrix_camera.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
+
+from unisim.backend.base import CameraCfg
 
 
 @dataclass(frozen=True)
@@ -53,19 +55,18 @@ def resolve_system_camera_view(
     num_envs: int,
     base_positions: np.ndarray | None,
     offsets: Sequence[Sequence[float]],
-    camera_kwargs: dict[str, Any] | None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
 ) -> MotrixCameraView:
-    cam_kw = dict(camera_kwargs or {})
-    if bool(cam_kw.get("cam_tracking", False)):
+    camera = CameraCfg.from_kwargs(camera_kwargs)
+    if camera.cam_tracking:
         if base_positions is None:
             raise ValueError("base_positions is required when cam_tracking=true")
-        env_idx = int(cam_kw.get("cam_tracking_env_idx", 0))
-        env_idx = max(0, min(env_idx, num_envs - 1))
+        env_idx = max(0, min(camera.cam_tracking_env_idx, num_envs - 1))
         tracking_camera = MotrixTrackingCamera(
             env_idx=env_idx,
-            distance=float(cam_kw.get("cam_distance", 2.0)),
-            elevation=float(cam_kw.get("cam_elevation", -20.0)),
-            azimuth=float(cam_kw.get("cam_azimuth", 90.0)),
+            distance=camera.cam_distance,
+            elevation=camera.cam_elevation,
+            azimuth=camera.cam_azimuth,
         )
         lookat = tracking_camera_lookat(
             base_positions,
@@ -80,8 +81,7 @@ def resolve_system_camera_view(
             tracking=tracking_camera,
         )
 
-    lookat_raw = cam_kw.get("cam_lookat")
-    if lookat_raw is None:
+    if camera.cam_lookat is None:
         offsets_np = np.asarray(offsets, dtype=np.float64)
         lookat = [
             float(np.mean(offsets_np[:, 0])),
@@ -89,14 +89,11 @@ def resolve_system_camera_view(
             0.75,
         ]
     else:
-        lookat_arr = np.asarray(lookat_raw, dtype=np.float64).reshape(-1)
-        if lookat_arr.shape != (3,):
-            raise ValueError(f"cam_lookat must contain 3 values, got {lookat_raw!r}")
-        lookat = [float(lookat_arr[0]), float(lookat_arr[1]), float(lookat_arr[2])]
+        lookat = [float(v) for v in camera.cam_lookat]
 
     return MotrixCameraView(
         lookat=lookat,
-        distance=float(cam_kw.get("cam_distance", 2.0)),
-        elevation=float(cam_kw.get("cam_elevation", -20.0)),
-        azimuth=float(cam_kw.get("cam_azimuth", 90.0)),
+        distance=camera.cam_distance,
+        elevation=camera.cam_elevation,
+        azimuth=camera.cam_azimuth,
     )

--- a/src/unisim/backend/mujoco/backend.py
+++ b/src/unisim/backend/mujoco/backend.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import time
 import weakref
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from multiprocessing import cpu_count, current_process, get_context
@@ -46,6 +46,8 @@ from ..base import (
     BackendPlayRenderPlan,
     BackendRootStateLayout,
     BackendTerrainSpawnData,
+    CameraCfg,
+    DebugOverlayGetter,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -1434,7 +1436,10 @@ class MuJoCoBackend(SimBackend):
                 ] += torque_np[:, body_offset, :]
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
-        return BackendPlayCapabilities(supports_physics_state_playback=True)
+        return BackendPlayCapabilities(
+            supports_physics_state_playback=True,
+            supports_debug_overlay=True,
+        )
 
     def resolve_play_render_plan(
         self,
@@ -1481,10 +1486,11 @@ class MuJoCoBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter=None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter=None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: DebugOverlayGetter | None = None,
     ) -> str | None:
         del render_offset_mode
+        camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None
         )
@@ -1499,8 +1505,8 @@ class MuJoCoBackend(SimBackend):
             headless=should_run_headless,
             record_video=should_record_video,
             frame_state_getter=frame_state_getter,
-            camera_kwargs=camera_kwargs,
-            extra_data_getter=extra_data_getter,
+            camera_kwargs=camera,
+            debug_overlay_getter=debug_overlay_getter,
         )
 
     # ------------------------------------------------------------------ #

--- a/src/unisim/backend/mujoco/playback.py
+++ b/src/unisim/backend/mujoco/playback.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import tempfile
+from collections.abc import Mapping, Sequence
 from os import PathLike
 from pathlib import Path
 from typing import Any, Callable, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import (
+    CameraCfg,
+    DebugOverlayGetter,
+    DebugPrimitive,
+    validate_debug_overlays,
+)
 from unisim.backend.playback_common import env_cfg_value, write_playback_video
 from unisim.scene import SceneCfg
 
@@ -26,8 +33,8 @@ def run_mujoco_playback(
     headless: bool,
     record_video: bool,
     frame_state_getter: Callable[[], np.ndarray] | None,
-    camera_kwargs: dict[str, Any] | None,
-    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
+    debug_overlay_getter: DebugOverlayGetter | None = None,
 ) -> str | None:
     if not headless:
         raise NotImplementedError("MuJoCo play mode does not support interactive rendering here.")
@@ -37,34 +44,29 @@ def run_mujoco_playback(
         raise ValueError("MuJoCo play rendering requires a finite num_steps value.")
     if output_video is None:
         raise ValueError("MuJoCo play rendering requires an output_video path.")
+    camera = CameraCfg.from_kwargs(camera_kwargs)
     if frame_state_getter is None:
         frame_state_getter = env.get_physics_state_snapshot
     assert frame_state_getter is not None
 
     obs = initialize()
     state_list = []
-    marker_list: list[np.ndarray | None] = []
+    overlay_list: list[Sequence[Sequence[DebugPrimitive] | None] | None] = []
     for _ in range(num_steps):
         obs = step(obs)
         state_list.append(np.asarray(frame_state_getter(), dtype=np.float32).copy())
-        if extra_data_getter is not None:
-            marker = extra_data_getter()
-            marker_list.append(
-                np.asarray(marker, dtype=np.float32).copy() if marker is not None else None
-            )
-        else:
-            marker_list.append(None)
+        overlay_list.append(debug_overlay_getter() if debug_overlay_getter is not None else None)
 
-    marker_positions_list = (
-        marker_list if any(marker is not None for marker in marker_list) else None
+    num_envs = int(state_list[0].shape[0])
+    validated_overlays = [
+        validate_debug_overlays(overlays, num_envs) for overlays in overlay_list
+    ]
+    debug_overlays_list = (
+        validated_overlays if any(overlays is not None for overlays in validated_overlays) else None
     )
 
     from unisim.visualization import render_many
 
-    cam_kw = dict(camera_kwargs or {})
-    use_tracking = bool(cam_kw.pop("cam_tracking", False))
-    tracking_env_idx = int(cam_kw.pop("cam_tracking_env_idx", 0))
-    tracking_extra_envs = int(cam_kw.pop("cam_tracking_extra_envs", 2))
     effective_spacing = (
         float(render_spacing)
         if render_spacing is not None
@@ -73,23 +75,24 @@ def run_mujoco_playback(
     with tempfile.TemporaryDirectory(prefix="unilab-playback-models-") as tmp_dir:
         model_files = resolve_render_play_model_files(
             env,
-            num_envs=state_list[0].shape[0],
+            num_envs=num_envs,
             tmp_dir=tmp_dir,
         )
 
-        if use_tracking:
+        if camera.cam_tracking:
             frames = render_many.render_states_get_frames_tracking(
                 state_list,
                 model_files,
                 width=1280,
                 height=720,
-                tracking_env_idx=tracking_env_idx,
-                max_extra_envs=tracking_extra_envs,
-                cam_distance=cam_kw.get("cam_distance", 2.0),
-                cam_elevation=cam_kw.get("cam_elevation", -20),
-                cam_azimuth=cam_kw.get("cam_azimuth", 90),
+                tracking_env_idx=camera.cam_tracking_env_idx,
+                max_extra_envs=camera.cam_tracking_extra_envs,
+                cam_distance=camera.cam_distance,
+                cam_elevation=camera.cam_elevation,
+                cam_azimuth=camera.cam_azimuth,
+                cam_fov=camera.cam_fov,
                 render_spacing=effective_spacing,
-                marker_positions_list=marker_positions_list,
+                debug_overlays_list=debug_overlays_list,
             )
         else:
             frames = render_many.render_states_get_frames(
@@ -98,9 +101,13 @@ def run_mujoco_playback(
                 width=1280,
                 height=720,
                 camera_id=-1,
+                cam_distance=camera.cam_distance,
+                cam_elevation=camera.cam_elevation,
+                cam_azimuth=camera.cam_azimuth,
+                cam_lookat=camera.cam_lookat,
+                cam_fov=camera.cam_fov,
                 render_spacing=effective_spacing,
-                marker_positions_list=marker_positions_list,
-                **cam_kw,
+                debug_overlays_list=debug_overlays_list,
             )
 
     if not frames:

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from os import PathLike
 from typing import Any
 
@@ -20,6 +20,8 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    CameraCfg,
+    DebugOverlayGetter,
     RenderClosedError,
     SimBackend,
     normalize_play_render_mode,
@@ -700,6 +702,7 @@ class NewtonBackend(SimBackend):
             supports_native_interactive_renderer=native,
             supports_physics_state_playback=True,
             supports_native_video_capture=native,
+            supports_debug_overlay=True,
         )
 
     @staticmethod
@@ -787,13 +790,19 @@ class NewtonBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter: Any = None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter: Any = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: DebugOverlayGetter | None = None,
     ) -> str | None:
         del render_offset_mode
+        camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record = bool(record_video) if record_video is not None else output_video is not None
         should_run_headless = bool(headless) if headless is not None else should_record
         if not should_run_headless and not should_record:
+            if debug_overlay_getter is not None:
+                raise NotImplementedError(
+                    "newton interactive playback does not support debug overlay primitives; "
+                    "use play_render_mode=record"
+                )
             try:
                 return run_newton_native_playback(
                     backend=self,
@@ -805,11 +814,31 @@ class NewtonBackend(SimBackend):
                     render_spacing=render_spacing,
                     headless=False,
                     record_video=False,
-                    camera_kwargs=camera_kwargs,
+                    camera_kwargs=camera,
                 )
             except RenderClosedError:
                 logger.info("Render window closed.")
                 return None
+        if debug_overlay_getter is not None:
+            # The native ViewerGL renderer cannot inject user geoms; overlays
+            # route to the offline MuJoCo snapshot pipeline even when the
+            # native viewer dependencies are installed.
+            return run_offline_snapshot_playback(
+                backend=self,
+                env=env,
+                initialize=initialize,
+                step=step,
+                num_steps=num_steps,
+                output_video=output_video,
+                render_spacing=render_spacing,
+                headless=should_run_headless,
+                record_video=should_record,
+                snapshot_shape=(self._num_envs, 1 + self._metadata.nq + self._metadata.nv),
+                frame_state_getter=frame_state_getter,
+                camera_kwargs=camera,
+                backend_label="newton",
+                debug_overlay_getter=debug_overlay_getter,
+            )
         if newton_render_dependencies_available():
             return run_newton_native_playback(
                 backend=self,
@@ -821,7 +850,7 @@ class NewtonBackend(SimBackend):
                 render_spacing=render_spacing,
                 headless=should_run_headless,
                 record_video=should_record,
-                camera_kwargs=camera_kwargs,
+                camera_kwargs=camera,
             )
         return run_offline_snapshot_playback(
             backend=self,
@@ -835,9 +864,8 @@ class NewtonBackend(SimBackend):
             record_video=should_record,
             snapshot_shape=(self._num_envs, 1 + self._metadata.nq + self._metadata.nv),
             frame_state_getter=frame_state_getter,
-            camera_kwargs=camera_kwargs,
+            camera_kwargs=camera,
             backend_label="newton",
-            extra_data_getter=extra_data_getter,
         )
 
     def init_renderer(
@@ -849,17 +877,18 @@ class NewtonBackend(SimBackend):
         capture: bool = False,
         width: int = 1280,
         height: int = 720,
-        camera_kwargs: dict[str, Any] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
     ) -> None:
         """Attach a native ViewerGL renderer on the cold playback path.
 
         ``offset_mode`` is accepted for contract parity and ignored: envs are
         laid out with ViewerGL's grid world offsets.  ``camera_kwargs`` is
-        likewise accepted for parity; the native viewer keeps its default
-        camera (the offline MuJoCo snapshot path honors camera kwargs).  The
-        first (headless, capture) pair is pinned.
+        validated (normalized to :class:`CameraCfg`) but the native viewer
+        keeps its default camera (the offline MuJoCo snapshot path honors the
+        camera configuration).  The first (headless, capture) pair is pinned.
         """
-        del offset_mode, camera_kwargs
+        del offset_mode
+        CameraCfg.from_kwargs(camera_kwargs)
         config = (bool(headless), bool(capture))
         if self._viewer is not None:
             if self._render_config != config:

--- a/src/unisim/backend/newton/playback.py
+++ b/src/unisim/backend/newton/playback.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from os import PathLike
 from typing import Any, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import CameraCfg
 from unisim.backend.playback_common import env_cfg_value, write_playback_video
 
 ObsT = TypeVar("ObsT")
@@ -44,9 +45,10 @@ def run_newton_native_playback(
     render_spacing: float | None,
     headless: bool,
     record_video: bool,
-    camera_kwargs: dict[str, Any] | None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
 ) -> str | None:
     """Drive native ViewerGL playback for an env wrapper (genesis semantics)."""
+    camera = CameraCfg.from_kwargs(camera_kwargs)
     if record_video and not headless:
         raise ValueError("newton native video recording requires headless=true.")
 
@@ -62,7 +64,7 @@ def run_newton_native_playback(
             capture=True,
             width=1280,
             height=720,
-            camera_kwargs=dict(camera_kwargs or {}),
+            camera_kwargs=camera,
         )
 
         obs = initialize()
@@ -85,7 +87,7 @@ def run_newton_native_playback(
     backend.init_renderer(
         spacing=float(render_spacing) if render_spacing is not None else 1.0,
         headless=False,
-        camera_kwargs=dict(camera_kwargs or {}),
+        camera_kwargs=camera,
     )
     obs = initialize()
     last_render_time = time.perf_counter()

--- a/src/unisim/backend/playback_common.py
+++ b/src/unisim/backend/playback_common.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from os import PathLike
 from pathlib import Path
 from typing import Any, TypeVar
 
 import numpy as np
+
+from unisim.backend.base import CameraCfg, DebugOverlayGetter
 
 ObsT = TypeVar("ObsT")
 
@@ -102,9 +104,9 @@ def run_offline_snapshot_playback(
     record_video: bool,
     snapshot_shape: tuple[int, int],
     frame_state_getter: Callable[[], np.ndarray] | None,
-    camera_kwargs: dict[str, Any] | None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
     backend_label: str,
-    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
+    debug_overlay_getter: DebugOverlayGetter | None = None,
 ) -> str:
     """Render detached host snapshots with the offline MuJoCo pipeline."""
     if not headless:
@@ -164,7 +166,7 @@ def run_offline_snapshot_playback(
         record_video=True,
         frame_state_getter=_validated_state_getter,
         camera_kwargs=camera_kwargs,
-        extra_data_getter=extra_data_getter,
+        debug_overlay_getter=debug_overlay_getter,
     )
     if result is None:
         raise RuntimeError(

--- a/src/unisim/backend/subprocess_ipc/backend.py
+++ b/src/unisim/backend/subprocess_ipc/backend.py
@@ -21,7 +21,7 @@ import select
 import subprocess
 import tempfile
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from multiprocessing import shared_memory
 from pathlib import Path
@@ -33,9 +33,11 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    CameraCfg,
     RenderClosedError,
     SimBackend,
     normalize_play_render_mode,
+    unsupported_debug_overlay_error,
 )
 from unisim.dr.types import (
     DomainRandomizationCapabilities,
@@ -86,22 +88,15 @@ def _display_available() -> bool:
     return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
 
 
-def _normalize_camera_kwargs(camera_kwargs: dict[str, Any] | None) -> dict[str, float]:
-    """Map repository camera kwargs onto the worker's spherical camera offset."""
-    kwargs = dict(camera_kwargs or {})
-    distance = float(kwargs.get("cam_distance", kwargs.get("distance", 2.0)))
-    elevation = kwargs.get("cam_elevation")
-    elevation_deg = (
-        float(-float(elevation))
-        if elevation is not None
-        else float(kwargs.get("elevation_deg", 20.0))
-    )
-    azimuth = kwargs.get("cam_azimuth")
-    azimuth_deg = float(azimuth) if azimuth is not None else float(kwargs.get("azimuth_deg", 90.0))
+def _normalize_camera_kwargs(
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
+) -> dict[str, float]:
+    """Map the repository camera configuration onto the worker's spherical offset."""
+    camera = CameraCfg.from_kwargs(camera_kwargs)
     return {
-        "distance": distance,
-        "elevation_deg": elevation_deg,
-        "azimuth_deg": azimuth_deg,
+        "distance": camera.cam_distance,
+        "elevation_deg": -camera.cam_elevation,
+        "azimuth_deg": camera.cam_azimuth,
     }
 
 
@@ -1174,7 +1169,7 @@ class MjcfSubprocessBackend(SimBackend):
         capture: bool = False,
         width: int = 1280,
         height: int = 720,
-        camera_kwargs: dict[str, Any] | None = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize the worker-side viewer and/or capture camera.
 
@@ -1252,10 +1247,13 @@ class MjcfSubprocessBackend(SimBackend):
         headless: bool | None = None,
         record_video: bool | None = None,
         frame_state_getter: Any = None,
-        camera_kwargs: dict[str, Any] | None = None,
-        extra_data_getter: Any = None,
+        camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
+        debug_overlay_getter: Any = None,
     ) -> str | None:
-        del frame_state_getter, extra_data_getter
+        del frame_state_getter
+        if debug_overlay_getter is not None:
+            raise unsupported_debug_overlay_error(self.__class__.__name__)
+        camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None
         )
@@ -1272,7 +1270,7 @@ class MjcfSubprocessBackend(SimBackend):
                 render_offset_mode=render_offset_mode,
                 headless=should_run_headless,
                 record_video=should_record_video,
-                camera_kwargs=camera_kwargs,
+                camera_kwargs=camera,
                 width=self._render_width,
                 height=self._render_height,
             )

--- a/src/unisim/backend/subprocess_ipc/playback.py
+++ b/src/unisim/backend/subprocess_ipc/playback.py
@@ -8,11 +8,13 @@ headlessly and writes them through the shared ``write_playback_video``.
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 from os import PathLike
 from typing import Any, Callable, TypeVar
 
 import numpy as np
 
+from unisim.backend.base import CameraCfg
 from unisim.backend.playback_common import env_cfg_value, write_playback_video
 
 ObsT = TypeVar("ObsT")
@@ -30,12 +32,10 @@ def run_subprocess_playback(
     render_offset_mode: str | None,
     headless: bool,
     record_video: bool,
-    camera_kwargs: dict[str, Any] | None,
+    camera_kwargs: CameraCfg | Mapping[str, Any] | None,
     width: int = 1280,
     height: int = 720,
-    extra_data_getter: Callable[[], np.ndarray | None] | None = None,
 ) -> str | None:
-    del extra_data_getter
     label = str(backend.backend_type)
     if record_video and not headless:
         raise ValueError(f"{label} video recording requires headless=true.")
@@ -51,7 +51,7 @@ def run_subprocess_playback(
             capture=True,
             width=int(width),
             height=int(height),
-            camera_kwargs=dict(camera_kwargs or {}),
+            camera_kwargs=camera_kwargs,
         )
 
         obs = initialize()
@@ -76,7 +76,7 @@ def run_subprocess_playback(
         headless=False,
         width=int(width),
         height=int(height),
-        camera_kwargs=dict(camera_kwargs or {}),
+        camera_kwargs=camera_kwargs,
     )
     obs = initialize()
     last_render_time = time.perf_counter()

--- a/src/unisim/backend/superdex/backend.py
+++ b/src/unisim/backend/superdex/backend.py
@@ -12,6 +12,7 @@ from unisim.backend.base import (
     BackendPlayCapabilities,
     BackendPlayRenderPlan,
     BackendRootStateLayout,
+    CameraCfg,
     SimBackend,
     normalize_play_render_mode,
 )
@@ -681,7 +682,10 @@ class SuperDexBackend(SimBackend):
         return DomainRandomizationCapabilities()
 
     def get_play_capabilities(self) -> BackendPlayCapabilities:
-        return BackendPlayCapabilities(supports_physics_state_playback=True)
+        return BackendPlayCapabilities(
+            supports_physics_state_playback=True,
+            supports_debug_overlay=True,
+        )
 
     @staticmethod
     def resolve_play_render_plan(
@@ -716,7 +720,7 @@ class SuperDexBackend(SimBackend):
     def run_playback(self, *, env, initialize, step, num_steps, output_video=None,
                      render_spacing=None, render_offset_mode=None, headless=None,
                      record_video=None, frame_state_getter=None, camera_kwargs=None,
-                     extra_data_getter=None):
+                     debug_overlay_getter=None):
         from unisim.backend.playback_common import run_offline_snapshot_playback
 
         if self.scene_visual_model_file is None:
@@ -736,9 +740,9 @@ class SuperDexBackend(SimBackend):
             record_video=should_record,
             snapshot_shape=(self.num_envs, 1 + self.model.nq + self.model.nv),
             frame_state_getter=frame_state_getter,
-            camera_kwargs=camera_kwargs,
+            camera_kwargs=CameraCfg.from_kwargs(camera_kwargs),
             backend_label="superdex",
-            extra_data_getter=extra_data_getter,
+            debug_overlay_getter=debug_overlay_getter,
         )
 
     def get_physics_state(self) -> np.ndarray:

--- a/src/unisim/contract.py
+++ b/src/unisim/contract.py
@@ -5,12 +5,22 @@ the original public import path while benchmark metadata keeps its coarse
 capability labels.
 """
 
-from .backend.base import SimBackend
+from .backend.base import (
+    CameraCfg,
+    DebugOverlayGetter,
+    DebugPrimitive,
+    SimBackend,
+    validate_debug_overlays,
+)
 from .errors import BackendCapability, BackendError, UnsupportedCapabilityError
 
 __all__ = [
     "BackendCapability",
     "BackendError",
+    "CameraCfg",
+    "DebugOverlayGetter",
+    "DebugPrimitive",
     "SimBackend",
     "UnsupportedCapabilityError",
+    "validate_debug_overlays",
 ]

--- a/src/unisim/visualization/render_many.py
+++ b/src/unisim/visualization/render_many.py
@@ -9,8 +9,10 @@ import math
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 _USER_MUJOCO_GL = os.environ.get("MUJOCO_GL")
@@ -122,6 +124,8 @@ os.environ["MUJOCO_GL"] = _resolve_gl_backend()
 import mujoco  # noqa: E402
 import numpy as np  # noqa: E402
 
+from unisim.backend.base import DebugPrimitive  # noqa: E402
+
 
 def render_backend_usable() -> bool:
     """Whether the resolved MUJOCO_GL backend can actually render on this host.
@@ -220,8 +224,181 @@ def _replicable_terrain_geom_indices(model) -> np.ndarray:
     return np.asarray(indices, dtype=np.int64)
 
 
-def init_worker(model_path, shape):
-    """Initialize MuJoCo-only rendering context for a worker process."""
+def _collect_ghost_mesh_assets(debug_overlays_list) -> list[str]:
+    """Collect unique ``ghost_geom`` mesh asset keys across all frames."""
+    assets: set[str] = set()
+    for overlays in debug_overlays_list or []:
+        for env_primitives in overlays or []:
+            for primitive in env_primitives or []:
+                if primitive.kind == "ghost_geom":
+                    assert primitive.mesh_asset is not None
+                    assets.add(primitive.mesh_asset)
+    return sorted(assets)
+
+
+def _inject_ghost_mesh_assets(model_path, ghost_assets, tmp_dir):
+    """Bake external ghost meshes into the primary render model.
+
+    Returns ``(model_path, ghost_mesh_map)`` where the map resolves each
+    ``DebugPrimitive.mesh_asset`` key to a mesh name in the primary model.
+    Assets already registered as mesh names pass through unchanged; file
+    assets (``.obj``/``.stl``/...) are appended to a recompiled copy saved
+    under ``tmp_dir``.  Compiled ``.mjb`` playback models cannot be extended
+    and fail closed.
+    """
+    is_sequence = isinstance(model_path, Sequence) and not isinstance(
+        model_path, (str, bytes, os.PathLike)
+    )
+    paths = [str(path) for path in model_path] if is_sequence else [str(model_path)]
+    primary = paths[0]
+    loader = (
+        mujoco.MjModel.from_binary_path
+        if primary.endswith(".mjb")
+        else mujoco.MjModel.from_xml_path
+    )
+    model = loader(primary)
+    mesh_object = mujoco.mjtObj.mjOBJ_MESH
+    name_map: dict[str, str] = {}
+    missing: list[str] = []
+    for asset in ghost_assets:
+        if mujoco.mj_name2id(model, mesh_object, asset) >= 0:
+            name_map[asset] = asset
+        else:
+            missing.append(asset)
+    if missing:
+        if primary.endswith(".mjb"):
+            raise ValueError(
+                "ghost_geom mesh assets not registered in the playback model require an "
+                f"XML playback model so they can be injected; {primary} is a compiled .mjb"
+            )
+        spec = mujoco.MjSpec.from_file(primary)
+        for index, asset in enumerate(missing):
+            asset_path = Path(asset).expanduser()
+            if not asset_path.is_file():
+                raise ValueError(
+                    f"ghost_geom mesh asset {asset!r} is neither a mesh name registered in "
+                    "the playback model nor an existing mesh file"
+                )
+            name = f"unisim_ghost_{index}"
+            while mujoco.mj_name2id(model, mesh_object, name) >= 0:
+                name = f"{name}_"
+            mesh = spec.add_mesh(name=name)
+            mesh.file = str(asset_path.resolve())
+            name_map[asset] = name
+        augmented_path = Path(tmp_dir) / "ghost_augmented_model.mjb"
+        mujoco.mj_saveModel(spec.compile(), str(augmented_path))
+        paths[0] = str(augmented_path)
+    result = paths if is_sequence else paths[0]
+    return result, name_map
+
+
+def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_ids) -> None:
+    """Convert one :class:`DebugPrimitive` into user-scene geoms (env-local pos)."""
+    pos = np.array(primitive.pos, dtype=np.float64)
+    if offset_xy is not None:
+        pos[0] += float(offset_xy[0])
+        pos[1] += float(offset_xy[1])
+    if primitive.quat is not None:
+        quat = np.array(primitive.quat, dtype=np.float64)
+        quat /= np.linalg.norm(quat)
+        mat = np.empty(9, dtype=np.float64)
+        mujoco.mju_quat2Mat(mat, quat)
+    else:
+        mat = np.eye(3, dtype=np.float64).flatten()
+    rgba = np.array(primitive.rgba, dtype=np.float64)
+
+    kind = primitive.kind
+    if kind == "sphere":
+        mujoco.mjv_initGeom(
+            scene.geoms[scene.ngeom],
+            type=mujoco.mjtGeom.mjGEOM_SPHERE,
+            size=np.array([primitive.size[0], 0.0, 0.0]),
+            pos=pos,
+            mat=mat,
+            rgba=rgba,
+        )
+        scene.ngeom += 1
+    elif kind == "box":
+        mujoco.mjv_initGeom(
+            scene.geoms[scene.ngeom],
+            type=mujoco.mjtGeom.mjGEOM_BOX,
+            size=np.array(primitive.size),
+            pos=pos,
+            mat=mat,
+            rgba=rgba,
+        )
+        scene.ngeom += 1
+    elif kind == "ghost_geom":
+        assert primitive.mesh_asset is not None
+        mesh_id = ghost_mesh_ids.get(primitive.mesh_asset, -1)
+        if mesh_id < 0:
+            raise ValueError(
+                f"ghost_geom mesh asset {primitive.mesh_asset!r} was not resolved in the "
+                "render worker; it must be a mesh name in the playback model or a mesh file"
+            )
+        scale = primitive.size[0] if primitive.size else 1.0
+        geom = scene.geoms[scene.ngeom]
+        mujoco.mjv_initGeom(
+            geom,
+            type=mujoco.mjtGeom.mjGEOM_MESH,
+            size=np.array([scale, scale, scale]),
+            pos=pos,
+            mat=mat,
+            rgba=rgba,
+        )
+        geom.dataid = mesh_id
+        scene.ngeom += 1
+    elif kind in ("frame", "arrow"):
+        length = float(primitive.size[0])
+        width = max(1e-3, 0.02 * length)
+        rotation = np.asarray(mat, dtype=np.float64).reshape(3, 3)
+        if kind == "arrow":
+            axes = ((rotation[:, 2], tuple(rgba)),)
+        else:
+            alpha = rgba[3]
+            axes = tuple(
+                (rotation[:, axis], (*color, alpha))
+                for axis, color in enumerate(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)))
+            )
+        for direction, color in axes:
+            if scene.ngeom >= scene.maxgeom:
+                return
+            geom = scene.geoms[scene.ngeom]
+            mujoco.mjv_connector(
+                geom,
+                mujoco.mjtGeom.mjGEOM_ARROW,
+                width,
+                pos,
+                pos + direction * length,
+            )
+            geom.rgba[:] = color
+            scene.ngeom += 1
+    elif kind == "text":
+        # mjvScene has no text channel on the off-screen path; text primitives
+        # are a documented no-op here (see DebugPrimitive).
+        return
+
+
+def _append_debug_primitives(scene, overlays, offsets, env_indices, ghost_mesh_ids) -> None:
+    """Inject per-env debug primitives into ``scene`` with grid offsets applied."""
+    for env_idx in env_indices:
+        env_primitives = overlays[env_idx] if env_idx < len(overlays) else None
+        if not env_primitives:
+            continue
+        offset_xy = offsets[env_idx] if offsets is not None else None
+        for primitive in env_primitives:
+            if scene.ngeom >= scene.maxgeom:
+                return
+            _append_primitive(scene, primitive, offset_xy, ghost_mesh_ids)
+
+
+def init_worker(model_path, shape, cam_fov=None, ghost_mesh_map=None):
+    """Initialize MuJoCo-only rendering context for a worker process.
+
+    ``ghost_mesh_map`` maps ``DebugPrimitive.mesh_asset`` keys to mesh names
+    resolvable in the primary model (already augmented by
+    :func:`_inject_ghost_mesh_assets` on the caller side when needed).
+    """
     import atexit
 
     def _load_model(path_like):
@@ -241,10 +418,23 @@ def init_worker(model_path, shape):
     for model in models:
         model.vis.global_.offwidth = 3840
         model.vis.global_.offheight = 2160
+        if cam_fov is not None:
+            model.vis.global_.fovy = float(cam_fov)
+
+    ghost_mesh_ids: dict[str, int] = {}
+    for asset, mesh_name in (ghost_mesh_map or {}).items():
+        mesh_id = mujoco.mj_name2id(models[0], mujoco.mjtObj.mjOBJ_MESH, mesh_name)
+        if mesh_id < 0:
+            raise ValueError(
+                f"ghost_geom mesh {mesh_name!r} (asset {asset!r}) is not registered in "
+                "the primary playback model"
+            )
+        ghost_mesh_ids[asset] = int(mesh_id)
 
     _worker_ctx["models"] = models
     _worker_ctx["data_list"] = [mujoco.MjData(model) for model in models]
     _worker_ctx["terrain_geom_indices"] = [_replicable_terrain_geom_indices(m) for m in models]
+    _worker_ctx["ghost_mesh_ids"] = ghost_mesh_ids
     _worker_ctx["renderer"] = mujoco.Renderer(models[0], height=shape[1], width=shape[0])
     atexit.register(_close_worker)
 
@@ -253,8 +443,8 @@ def render_frame_job(args):
     """
     Worker function to render a single frame.
     args: (state_batch, offsets, transparent, cam_distance, cam_elevation, cam_azimuth,
-           cam_lookat, marker_positions)
-    marker_positions: optional (num_envs, 3) world-frame positions for overlay spheres.
+           cam_lookat, debug_overlays)
+    debug_overlays: optional per-env sequences of DebugPrimitive (env-local poses).
     """
     (
         state_batch,
@@ -264,7 +454,7 @@ def render_frame_job(args):
         cam_elevation,
         cam_azimuth,
         cam_lookat,
-        marker_positions,
+        debug_overlays,
     ) = args
 
     models = _worker_ctx["models"]
@@ -410,28 +600,15 @@ def render_frame_job(args):
             mujoco.mjv_addGeoms(model, data, vopt, pert, catmask_static, renderer.scene)
             vopt.geomgroup[0] = geomgroup0
 
-    # 3. Overlay marker spheres (e.g. EE goal positions)
-    if marker_positions is not None:
-        scene = renderer.scene
-        sphere_rgba = np.array([1.0, 0.2, 0.2, 0.8], dtype=np.float32)
-        sphere_size = np.array([0.025, 0.0, 0.0], dtype=np.float32)
-        eye3 = np.eye(3, dtype=np.float32).flatten()
-        for env_idx in range(num_envs):
-            if scene.ngeom >= scene.maxgeom:
-                break
-            pos = marker_positions[env_idx].astype(np.float32).copy()
-            if offsets is not None:
-                pos[0] += float(offsets[env_idx, 0])
-                pos[1] += float(offsets[env_idx, 1])
-            mujoco.mjv_initGeom(
-                scene.geoms[scene.ngeom],
-                type=mujoco.mjtGeom.mjGEOM_SPHERE,
-                size=sphere_size,
-                pos=pos,
-                mat=eye3,
-                rgba=sphere_rgba,
-            )
-            scene.ngeom += 1
+    # 3. Overlay debug primitives (e.g. goal poses, frames, ghost geoms)
+    if debug_overlays is not None:
+        _append_debug_primitives(
+            renderer.scene,
+            debug_overlays,
+            offsets,
+            range(num_envs),
+            _worker_ctx.get("ghost_mesh_ids", {}),
+        )
 
     return renderer.render()
 
@@ -447,8 +624,9 @@ def render_states_get_frames(
     cam_elevation=-20,
     cam_azimuth=90,
     cam_lookat=None,
+    cam_fov=None,
     render_spacing=1.0,
-    marker_positions_list=None,
+    debug_overlays_list=None,
 ):
     """
     Render a list of physics states and return the list of frames.
@@ -464,8 +642,10 @@ def render_states_get_frames(
         cam_elevation: Camera elevation angle in degrees.
         cam_azimuth: Camera azimuth angle in degrees.
         cam_lookat: Optional [x, y, z] lookat override for the free camera.
+        cam_fov: Optional vertical field of view in degrees.
         render_spacing: Grid spacing used to offset each env in composed video frames.
-        marker_positions_list: Optional list of (num_envs, 3) arrays for overlay spheres.
+        debug_overlays_list: Optional list (one entry per state) of per-env
+            DebugPrimitive sequences with env-local poses.
     Returns:
         List of numpy arrays (H, W, 3) (RGB)
     """
@@ -485,59 +665,67 @@ def render_states_get_frames(
         f"Rendering {len(state_list)} frames for {num_envs} envs with {num_processes} processes..."
     )
 
-    # Prepare arguments for each frame
-    tasks = [
-        (s, offsets, False, cam_distance, cam_elevation, cam_azimuth, cam_lookat, m)
-        for s, m in zip(
-            state_list,
-            marker_positions_list
-            if marker_positions_list is not None
-            else [None] * len(state_list),
-        )
-    ]
-
-    frames: list[Any] = []
-
-    if num_processes <= 1:
-        # Serial execution
-        # Initialize context manually
-        init_worker(model_path, shape)
-        try:
-            for task in tasks:
-                res = render_frame_job(task)
-                frames.append(res)
-        finally:
-            _close_worker()
-    else:
-        # Use a process pool. ProcessPoolExecutor (unlike multiprocessing.Pool)
-        # fails fast with BrokenProcessPool when a worker dies during init or a
-        # task, instead of silently respawning the dead worker forever — which
-        # would turn a single render failure into an unbounded error-log flood
-        # (see issue #605). spawn avoids forking OpenGL/MuJoCo contexts.
-        import multiprocessing
-        from concurrent.futures import BrokenExecutor, ProcessPoolExecutor
-
-        ctx = multiprocessing.get_context("spawn")
-        chunksize = max(1, len(tasks) // (num_processes * 4))
-        try:
-            with ProcessPoolExecutor(
-                max_workers=num_processes,
-                mp_context=ctx,
-                initializer=init_worker,
-                initargs=(model_path, shape),
-            ) as pool:
-                frames = list(pool.map(render_frame_job, tasks, chunksize=chunksize))
-        except BrokenExecutor as exc:
-            # A worker died during init or a task (bad model, OOM, or an
-            # unusable GL backend). Fail fast instead of respawning forever.
-            print(
-                f"[render] A render worker terminated before completing "
-                f"({type(exc).__name__}: {exc}); skipping video recording. "
-                "If this host is headless, ensure a usable MUJOCO_GL backend "
-                "(egl on a GPU, or install OSMesa for software rendering).",
-                file=sys.stderr,
+    ghost_assets = _collect_ghost_mesh_assets(debug_overlays_list)
+    with tempfile.TemporaryDirectory(prefix="unisim-ghost-models-") as tmp_dir:
+        ghost_mesh_map: dict[str, str] = {}
+        if ghost_assets:
+            model_path, ghost_mesh_map = _inject_ghost_mesh_assets(
+                model_path, ghost_assets, tmp_dir
             )
-            return []
+
+        # Prepare arguments for each frame
+        tasks = [
+            (s, offsets, False, cam_distance, cam_elevation, cam_azimuth, cam_lookat, o)
+            for s, o in zip(
+                state_list,
+                debug_overlays_list
+                if debug_overlays_list is not None
+                else [None] * len(state_list),
+            )
+        ]
+
+        frames: list[Any] = []
+
+        if num_processes <= 1:
+            # Serial execution
+            # Initialize context manually
+            init_worker(model_path, shape, cam_fov, ghost_mesh_map)
+            try:
+                for task in tasks:
+                    res = render_frame_job(task)
+                    frames.append(res)
+            finally:
+                _close_worker()
+        else:
+            # Use a process pool. ProcessPoolExecutor (unlike multiprocessing.Pool)
+            # fails fast with BrokenProcessPool when a worker dies during init or a
+            # task, instead of silently respawning the dead worker forever — which
+            # would turn a single render failure into an unbounded error-log flood
+            # (see issue #605). spawn avoids forking OpenGL/MuJoCo contexts.
+            import multiprocessing
+            from concurrent.futures import BrokenExecutor, ProcessPoolExecutor
+
+            ctx = multiprocessing.get_context("spawn")
+            chunksize = max(1, len(tasks) // (num_processes * 4))
+            try:
+                with ProcessPoolExecutor(
+                    max_workers=num_processes,
+                    mp_context=ctx,
+                    initializer=init_worker,
+                    initargs=(model_path, shape, cam_fov, ghost_mesh_map),
+                ) as pool:
+                    frames = list(pool.map(render_frame_job, tasks, chunksize=chunksize))
+            except BrokenExecutor as exc:
+                # A worker died during init or a task (bad model, OOM, or an
+                # unusable GL backend). Fail fast instead of respawning forever.
+                print(
+                    f"[render] A render worker terminated before completing "
+                    f"({type(exc).__name__}: {exc}); skipping video recording. "
+                    "If this host is headless, ensure a usable MUJOCO_GL backend "
+                    "(egl on a GPU, or install OSMesa for software rendering).",
+                    file=sys.stderr,
+                )
+                return []
 
     return frames
 
@@ -566,7 +754,7 @@ def render_frame_tracking_job(args):
         cam_distance,
         cam_elevation,
         cam_azimuth,
-        marker_positions,
+        debug_overlays,
     ) = args
 
     models = _worker_ctx["models"]
@@ -680,28 +868,15 @@ def render_frame_tracking_job(args):
             mujoco.mjv_addGeoms(model, data, vopt, pert, catmask_static, renderer.scene)
             vopt.geomgroup[0] = geomgroup0
 
-    # Overlay marker spheres for rendered envs
-    if marker_positions is not None:
-        scene = renderer.scene
-        sphere_rgba = np.array([1.0, 0.2, 0.2, 0.8], dtype=np.float32)
-        sphere_size = np.array([0.025, 0.0, 0.0], dtype=np.float32)
-        eye3 = np.eye(3, dtype=np.float32).flatten()
-        for global_i in env_indices:
-            if scene.ngeom >= scene.maxgeom:
-                break
-            pos = marker_positions[global_i].astype(np.float32).copy()
-            if offsets is not None:
-                pos[0] += float(offsets[global_i, 0])
-                pos[1] += float(offsets[global_i, 1])
-            mujoco.mjv_initGeom(
-                scene.geoms[scene.ngeom],
-                type=mujoco.mjtGeom.mjGEOM_SPHERE,
-                size=sphere_size,
-                pos=pos,
-                mat=eye3,
-                rgba=sphere_rgba,
-            )
-            scene.ngeom += 1
+    # Overlay debug primitives for rendered envs
+    if debug_overlays is not None:
+        _append_debug_primitives(
+            renderer.scene,
+            debug_overlays,
+            offsets,
+            env_indices,
+            _worker_ctx.get("ghost_mesh_ids", {}),
+        )
 
     return renderer.render()
 
@@ -716,8 +891,9 @@ def render_states_get_frames_tracking(
     cam_distance=2.0,
     cam_elevation=-20,
     cam_azimuth=90,
+    cam_fov=None,
     render_spacing=1.0,
-    marker_positions_list=None,
+    debug_overlays_list=None,
 ):
     """Render with camera tracking on a single primary environment.
 
@@ -732,7 +908,10 @@ def render_states_get_frames_tracking(
         cam_distance: Camera distance from the tracked body.
         cam_elevation: Camera elevation angle in degrees.
         cam_azimuth: Camera azimuth angle in degrees.
+        cam_fov: Optional vertical field of view in degrees.
         render_spacing: Grid spacing for env layout.
+        debug_overlays_list: Optional list (one entry per state) of per-env
+            DebugPrimitive sequences with env-local poses.
     """
     if not state_list:
         print("No states to render.")
@@ -757,24 +936,41 @@ def render_states_get_frames_tracking(
         f"+ {total_shown - 1} neighbours) ..."
     )
 
-    tasks = [
-        (s, offsets, env_indices, primary_local_idx, cam_distance, cam_elevation, cam_azimuth, m)
-        for s, m in zip(
-            state_list,
-            marker_positions_list
-            if marker_positions_list is not None
-            else [None] * len(state_list),
-        )
-    ]
-
-    # Camera tracking changes each frame so multiprocessing gives inconsistent
-    # results when workers don't share state. Default to serial.
+    ghost_assets = _collect_ghost_mesh_assets(debug_overlays_list)
     frames = []
-    init_worker(model_path, shape)
-    try:
-        for task in tasks:
-            frames.append(render_frame_tracking_job(task))
-    finally:
-        _close_worker()
+    with tempfile.TemporaryDirectory(prefix="unisim-ghost-models-") as tmp_dir:
+        ghost_mesh_map: dict[str, str] = {}
+        if ghost_assets:
+            model_path, ghost_mesh_map = _inject_ghost_mesh_assets(
+                model_path, ghost_assets, tmp_dir
+            )
+
+        tasks = [
+            (
+                s,
+                offsets,
+                env_indices,
+                primary_local_idx,
+                cam_distance,
+                cam_elevation,
+                cam_azimuth,
+                o,
+            )
+            for s, o in zip(
+                state_list,
+                debug_overlays_list
+                if debug_overlays_list is not None
+                else [None] * len(state_list),
+            )
+        ]
+
+        # Camera tracking changes each frame so multiprocessing gives inconsistent
+        # results when workers don't share state. Default to serial.
+        init_worker(model_path, shape, cam_fov, ghost_mesh_map)
+        try:
+            for task in tasks:
+                frames.append(render_frame_tracking_job(task))
+        finally:
+            _close_worker()
 
     return frames

--- a/src/unisim/visualization/render_many.py
+++ b/src/unisim/visualization/render_many.py
@@ -178,9 +178,10 @@ _worker_ctx: dict[str, Any] = {}
 
 
 def _close_worker():
-    """Explicitly close the renderer in the worker context."""
-    if "renderer" in _worker_ctx:
-        _worker_ctx["renderer"].close()
+    """Explicitly close the renderer in the worker context (idempotent)."""
+    renderer = _worker_ctx.pop("renderer", None)
+    if renderer is not None:
+        renderer.close()
 
 
 def _offset_freejoint_object_qpos(model, data, offset) -> set[int]:

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -1,0 +1,526 @@
+"""Contract tests for debug overlay primitives and the typed camera config."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from unisim.backend.base import (
+    BackendPlayCapabilities,
+    CameraCfg,
+    DebugPrimitive,
+    validate_debug_overlays,
+)
+from unisim.fake import FakeBackend
+
+
+class TestDebugPrimitive:
+    def test_sphere_defaults(self) -> None:
+        primitive = DebugPrimitive(kind="sphere", pos=(0.0, 0.0, 0.5), size=(0.025,))
+        assert primitive.rgba == (1.0, 0.2, 0.2, 0.5)
+        assert primitive.quat is None
+        assert primitive.mesh_asset is None
+        assert primitive.text is None
+
+    def test_frozen(self) -> None:
+        primitive = DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(0.1,))
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            primitive.pos = (1, 1, 1)  # type: ignore[misc]
+
+    def test_unknown_kind_fails(self) -> None:
+        with pytest.raises(ValueError, match="kind must be one of"):
+            DebugPrimitive(kind="cone", pos=(0, 0, 0))  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ("kind", "size"),
+        [
+            ("sphere", (0.1, 0.2)),
+            ("box", (0.1,)),
+            ("frame", ()),
+            ("arrow", (0.1, 0.2)),
+            ("ghost_geom", (1.0, 2.0)),
+            ("text", (1.0,)),
+        ],
+    )
+    def test_size_arity_enforced(self, kind: str, size: tuple[float, ...]) -> None:
+        kwargs: dict = {"kind": kind, "pos": (0, 0, 0), "size": size}
+        if kind == "ghost_geom":
+            kwargs["mesh_asset"] = "asset.stl"
+        if kind == "text":
+            kwargs["text"] = "label"
+        with pytest.raises(ValueError, match="size arity"):
+            DebugPrimitive(**kwargs)
+
+    def test_non_positive_size_fails(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(-0.1,))
+
+    def test_non_finite_pos_fails(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DebugPrimitive(kind="sphere", pos=(0, float("nan"), 0), size=(0.1,))
+
+    def test_quat_must_be_unit_wxyz(self) -> None:
+        with pytest.raises(ValueError, match="unit-length"):
+            DebugPrimitive(
+                kind="box", pos=(0, 0, 0), size=(0.1, 0.1, 0.1), quat=(2.0, 0.0, 0.0, 0.0)
+            )
+        with pytest.raises(ValueError, match="non-zero"):
+            DebugPrimitive(
+                kind="box", pos=(0, 0, 0), size=(0.1, 0.1, 0.1), quat=(0.0, 0.0, 0.0, 0.0)
+            )
+
+    def test_rgba_range_enforced(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(0.1,), rgba=(1.0, 0, 0, 1.5))
+
+    def test_ghost_geom_requires_mesh_asset(self) -> None:
+        with pytest.raises(ValueError, match="mesh_asset"):
+            DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0))
+        primitive = DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0), mesh_asset="goal.stl")
+        assert primitive.size == ()
+
+    def test_mesh_asset_rejected_for_other_kinds(self) -> None:
+        with pytest.raises(ValueError, match="only valid for kind 'ghost_geom'"):
+            DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(0.1,), mesh_asset="x.stl")
+
+    def test_text_rules(self) -> None:
+        with pytest.raises(ValueError, match="requires a text string"):
+            DebugPrimitive(kind="text", pos=(0, 0, 0))
+        with pytest.raises(ValueError, match="only valid for kind 'text'"):
+            DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(0.1,), text="hi")
+        primitive = DebugPrimitive(kind="text", pos=(0, 0, 0), text="goal")
+        assert primitive.text == "goal"
+
+
+class TestValidateDebugOverlays:
+    def test_none_passes_through(self) -> None:
+        assert validate_debug_overlays(None, 2) is None
+
+    def test_valid_overlay_shape(self) -> None:
+        overlays = [
+            [DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(0.1,))],
+            None,
+        ]
+        assert validate_debug_overlays(overlays, 2) is overlays
+
+    def test_outer_length_must_match_num_envs(self) -> None:
+        with pytest.raises(ValueError, match=r"len == 3"):
+            validate_debug_overlays([[]], 3)
+
+    def test_non_sequence_outer_fails(self) -> None:
+        with pytest.raises(TypeError, match="per-env sequence"):
+            validate_debug_overlays("nope", 1)  # type: ignore[arg-type]
+
+    def test_non_primitive_entry_fails(self) -> None:
+        with pytest.raises(TypeError, match="DebugPrimitive"):
+            validate_debug_overlays([[{"kind": "sphere"}]], 1)
+
+
+class TestCameraCfg:
+    def test_defaults(self) -> None:
+        cfg = CameraCfg.from_kwargs(None)
+        assert cfg.cam_distance == 2.0
+        assert cfg.cam_elevation == -20.0
+        assert cfg.cam_azimuth == 90.0
+        assert cfg.cam_lookat is None
+        assert not cfg.cam_tracking
+        assert cfg.cam_fov is None
+
+    def test_passthrough(self) -> None:
+        cfg = CameraCfg(cam_distance=3.0, cam_tracking=True, cam_tracking_env_idx=2)
+        assert CameraCfg.from_kwargs(cfg) is cfg
+
+    def test_mapping_subset(self) -> None:
+        cfg = CameraCfg.from_kwargs(
+            {"cam_distance": 1.5, "cam_lookat": [0, 0, 0.5], "cam_fov": 45.0}
+        )
+        assert cfg.cam_distance == 1.5
+        assert cfg.cam_lookat == (0.0, 0.0, 0.5)
+        assert cfg.cam_fov == 45.0
+
+    def test_unknown_keys_fail_closed_with_names(self) -> None:
+        with pytest.raises(ValueError, match="unknown camera_kwargs key.*'cam_zoom'"):
+            CameraCfg.from_kwargs({"cam_distance": 2.0, "cam_zoom": 3})
+
+    @pytest.mark.parametrize("legacy_key", ["distance", "elevation_deg", "azimuth_deg"])
+    def test_legacy_alias_keys_fail_closed(self, legacy_key: str) -> None:
+        with pytest.raises(ValueError, match=f"'{legacy_key}'"):
+            CameraCfg.from_kwargs({legacy_key: 1.0})
+
+    def test_bad_lookat_fails(self) -> None:
+        with pytest.raises(ValueError, match="cam_lookat must have 3 components"):
+            CameraCfg.from_kwargs({"cam_lookat": [0, 0]})
+
+    def test_bad_values_fail(self) -> None:
+        with pytest.raises(ValueError, match="cam_distance"):
+            CameraCfg(cam_distance=0.0)
+        with pytest.raises(ValueError, match="cam_elevation"):
+            CameraCfg(cam_elevation=-120.0)
+        with pytest.raises(ValueError, match="cam_fov"):
+            CameraCfg(cam_fov=200.0)
+        with pytest.raises(ValueError, match="cam_tracking_env_idx"):
+            CameraCfg(cam_tracking_env_idx=-1)
+
+    def test_non_mapping_fails(self) -> None:
+        with pytest.raises(TypeError, match="CameraCfg, a mapping, or None"):
+            CameraCfg.from_kwargs([("cam_distance", 2.0)])  # type: ignore[arg-type]
+
+
+class TestPlayCapabilities:
+    def test_default_is_false(self) -> None:
+        assert not BackendPlayCapabilities().supports_debug_overlay
+
+    def test_fake_backend_default(self) -> None:
+        assert not FakeBackend().get_play_capabilities().supports_debug_overlay
+
+    @pytest.mark.parametrize(
+        "backend_path",
+        [
+            "unisim.backend.drake.backend.DrakeBackend",
+            "unisim.backend.mjwarp.backend.MjwarpBackend",
+            "unisim.backend.newton.backend.NewtonBackend",
+            "unisim.backend.superdex.backend.SuperDexBackend",
+        ],
+    )
+    def test_mujoco_snapshot_pipeline_backends_support_overlay(self, backend_path: str) -> None:
+        module_path, _, class_name = backend_path.rpartition(".")
+        import importlib
+
+        backend_cls = getattr(importlib.import_module(module_path), class_name)
+        backend = backend_cls.__new__(backend_cls)
+        assert backend.get_play_capabilities().supports_debug_overlay
+
+    def test_motrix_genesis_subprocess_do_not_support_overlay(self) -> None:
+        import importlib
+
+        for module_path, class_name in (
+            ("unisim.backend.motrix.backend", "MotrixBackend"),
+            ("unisim.backend.genesis.backend", "GenesisBackend"),
+            ("unisim.backend.subprocess_ipc.backend", "MjcfSubprocessBackend"),
+        ):
+            backend_cls = getattr(importlib.import_module(module_path), class_name)
+            backend = backend_cls.__new__(backend_cls)
+            assert not backend.get_play_capabilities().supports_debug_overlay
+
+
+class TestRunPlaybackContract:
+    def test_base_run_playback_fails_closed(self) -> None:
+        with pytest.raises(NotImplementedError, match="does not support playback execution"):
+            FakeBackend().run_playback(env=None, initialize=lambda: None, step=lambda o: o,
+                                       num_steps=1)
+
+    @pytest.mark.parametrize(
+        ("module_path", "class_name"),
+        [
+            ("unisim.backend.motrix.backend", "MotrixBackend"),
+            ("unisim.backend.genesis.backend", "GenesisBackend"),
+            ("unisim.backend.subprocess_ipc.backend", "MjcfSubprocessBackend"),
+        ],
+    )
+    def test_unsupported_backends_fail_closed_on_overlay(
+        self, module_path: str, class_name: str
+    ) -> None:
+        import importlib
+
+        backend_cls = getattr(importlib.import_module(module_path), class_name)
+        backend = backend_cls.__new__(backend_cls)
+        with pytest.raises(NotImplementedError, match="debug overlay primitives"):
+            backend.run_playback(
+                env=None,
+                initialize=lambda: None,
+                step=lambda o: o,
+                num_steps=1,
+                debug_overlay_getter=lambda: None,
+            )
+
+    def test_mjwarp_interactive_fails_closed_on_overlay(self) -> None:
+        from unisim.backend.mjwarp.playback import run_mjwarp_playback
+
+        with pytest.raises(NotImplementedError, match="interactive playback"):
+            run_mjwarp_playback(
+                backend=None,
+                env=None,
+                initialize=lambda: None,
+                step=lambda o: o,
+                num_steps=1,
+                output_video=None,
+                render_spacing=None,
+                headless=False,
+                record_video=False,
+                snapshot_shape=(1, 2),
+                frame_state_getter=None,
+                camera_kwargs=None,
+                debug_overlay_getter=lambda: None,
+            )
+
+
+class TestPrimitiveToGeomConversion:
+    """Primitive -> mjvGeom conversion without a GL context (MjvScene only)."""
+
+    @pytest.fixture(autouse=True)
+    def _mujoco(self):
+        self.mujoco = pytest.importorskip("mujoco")
+        from unisim.visualization import render_many
+
+        self.render_many = render_many
+        self.model = self.mujoco.MjModel.from_xml_string(
+            "<mujoco><worldbody><geom type='box' size='0.05 0.05 0.05'/></worldbody></mujoco>"
+        )
+
+    def _scene(self, maxgeom: int = 32):
+        return self.mujoco.MjvScene(self.model, maxgeom=maxgeom)
+
+    def test_sphere_box_arrow_conversion(self) -> None:
+        scene = self._scene()
+        overlays = [
+            [
+                DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,)),
+                DebugPrimitive(
+                    kind="box",
+                    pos=(0.1, 0, 0.5),
+                    size=(0.02, 0.03, 0.04),
+                    quat=(1.0, 0.0, 0.0, 0.0),
+                    rgba=(0.0, 1.0, 0.0, 0.4),
+                ),
+                DebugPrimitive(kind="arrow", pos=(0, 0, 0.5), size=(0.2,)),
+            ]
+        ]
+        self.render_many._append_debug_primitives(
+            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+        )
+        assert scene.ngeom == 3
+        sphere, box, arrow = scene.geoms[0], scene.geoms[1], scene.geoms[2]
+        assert int(sphere.type) == int(self.mujoco.mjtGeom.mjGEOM_SPHERE)
+        np.testing.assert_allclose(sphere.pos, [0, 0, 0.5])
+        assert sphere.size[0] == pytest.approx(0.05)
+        assert int(box.type) == int(self.mujoco.mjtGeom.mjGEOM_BOX)
+        np.testing.assert_allclose(box.size, [0.02, 0.03, 0.04], atol=1e-7)
+        np.testing.assert_allclose(box.rgba, [0.0, 1.0, 0.0, 0.4], atol=1e-7)
+        assert int(arrow.type) == int(self.mujoco.mjtGeom.mjGEOM_ARROW)
+        # mjv_connector: pos = start, z axis = direction, size[2] = length
+        np.testing.assert_allclose(arrow.pos, [0, 0, 0.5], atol=1e-6)
+        np.testing.assert_allclose(arrow.mat.reshape(3, 3)[:, 2], [0, 0, 1], atol=1e-6)
+        assert arrow.size[2] == pytest.approx(0.2, abs=1e-6)
+
+    def test_frame_draws_rgb_triad(self) -> None:
+        scene = self._scene()
+        overlays = [[DebugPrimitive(kind="frame", pos=(0, 0, 0), size=(0.1,))]]
+        self.render_many._append_debug_primitives(
+            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+        )
+        assert scene.ngeom == 3
+        for geom, expected_rgb in zip(
+            scene.geoms[:3], ([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0])
+        ):
+            assert int(geom.type) == int(self.mujoco.mjtGeom.mjGEOM_ARROW)
+            np.testing.assert_allclose(geom.rgba[:3], expected_rgb, atol=1e-7)
+
+    def test_grid_offset_applied(self) -> None:
+        scene = self._scene()
+        overlays = [
+            None,
+            [DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,))],
+        ]
+        offsets = np.array([[0.0, 0.0], [1.0, 2.0]])
+        self.render_many._append_debug_primitives(
+            scene, overlays, offsets=offsets, env_indices=range(2), ghost_mesh_ids={}
+        )
+        assert scene.ngeom == 1
+        np.testing.assert_allclose(scene.geoms[0].pos, [1.0, 2.0, 0.5], atol=1e-7)
+
+    def test_text_is_documented_noop(self) -> None:
+        scene = self._scene()
+        overlays = [[DebugPrimitive(kind="text", pos=(0, 0, 0), text="label")]]
+        self.render_many._append_debug_primitives(
+            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+        )
+        assert scene.ngeom == 0
+
+    def test_ghost_geom_uses_mesh_dataid(self, tmp_path: Path) -> None:
+        scene = self._scene()
+        overlays = [
+            [
+                DebugPrimitive(
+                    kind="ghost_geom", pos=(0, 0, 0.3), size=(2.0,), mesh_asset="goal.stl",
+                    rgba=(0.2, 0.6, 1.0, 0.3),
+                )
+            ]
+        ]
+        self.render_many._append_debug_primitives(
+            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={"goal.stl": 5}
+        )
+        assert scene.ngeom == 1
+        geom = scene.geoms[0]
+        assert int(geom.type) == int(self.mujoco.mjtGeom.mjGEOM_MESH)
+        assert geom.dataid == 5
+        np.testing.assert_allclose(geom.size, [2.0, 2.0, 2.0], atol=1e-7)
+
+    def test_ghost_geom_unresolved_asset_fails(self) -> None:
+        scene = self._scene()
+        overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0), mesh_asset="missing.stl")]]
+        with pytest.raises(ValueError, match="missing.stl"):
+            self.render_many._append_debug_primitives(
+                scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+            )
+
+    def test_ghost_mesh_injection_into_xml_model(self, tmp_path: Path) -> None:
+        obj_path = tmp_path / "goal.obj"
+        obj_path.write_text(
+            "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\n"
+            "f 1 3 2\nf 1 2 4\nf 2 3 4\nf 3 1 4\n"
+        )
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(
+            "<mujoco><worldbody><geom type='box' size='0.05 0.05 0.05'/></worldbody></mujoco>"
+        )
+        new_path, name_map = self.render_many._inject_ghost_mesh_assets(
+            str(model_path), [str(obj_path)], tmp_path
+        )
+        assert new_path != str(model_path)
+        model = self.mujoco.MjModel.from_binary_path(new_path)
+        mesh_name = name_map[str(obj_path)]
+        assert (
+            self.mujoco.mj_name2id(model, self.mujoco.mjtObj.mjOBJ_MESH, mesh_name) >= 0
+        )
+
+    def test_ghost_mesh_registered_name_passes_through(self, tmp_path: Path) -> None:
+        obj_path = tmp_path / "goal.obj"
+        obj_path.write_text(
+            "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\n"
+            "f 1 3 2\nf 1 2 4\nf 2 3 4\nf 3 1 4\n"
+        )
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(
+            f"<mujoco><asset><mesh name='goal' file='{obj_path}'/></asset>"
+            "<worldbody><geom type='mesh' mesh='goal'/></worldbody></mujoco>"
+        )
+        new_path, name_map = self.render_many._inject_ghost_mesh_assets(
+            str(model_path), ["goal"], tmp_path
+        )
+        assert new_path == str(model_path)
+        assert name_map == {"goal": "goal"}
+
+    def test_ghost_mesh_missing_file_fails(self, tmp_path: Path) -> None:
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(
+            "<mujoco><worldbody><geom type='box' size='0.05 0.05 0.05'/></worldbody></mujoco>"
+        )
+        with pytest.raises(ValueError, match="neither a mesh name"):
+            self.render_many._inject_ghost_mesh_assets(
+                str(model_path), [str(tmp_path / "absent.obj")], tmp_path
+            )
+
+    def test_ghost_mesh_mjb_model_fails_closed(self, tmp_path: Path) -> None:
+        mjb_path = tmp_path / "scene.mjb"
+        self.mujoco.mj_saveModel(self.model, str(mjb_path))
+        with pytest.raises(ValueError, match="compiled .mjb"):
+            self.render_many._inject_ghost_mesh_assets(
+                str(mjb_path), ["not_registered"], tmp_path
+            )
+
+
+class TestHeadlessPrimitiveRendering:
+    """Offline snapshot rendering with overlays (skipped without a GL backend)."""
+
+    @pytest.fixture(autouse=True)
+    def _render(self):
+        pytest.importorskip("mujoco")
+        from unisim.visualization import render_many
+
+        if not render_many.render_backend_usable():
+            pytest.skip("no usable MuJoCo off-screen GL backend on this host")
+        self.render_many = render_many
+
+    MODEL = """<mujoco>
+      <worldbody>
+        <light pos='0 0 3' dir='0 0 -1'/>
+        <geom type='plane' size='5 5 0.1'/>
+        <body name='base' pos='0 0 0.5'>
+          <joint name='slide' type='slide' axis='1 0 0'/>
+          <geom type='box' size='0.05 0.05 0.05'/>
+        </body>
+      </worldbody>
+    </mujoco>"""
+
+    def _states(self, num_frames: int = 2) -> list[np.ndarray]:
+        # [time, qpos(1), qvel(1)] for the single slide joint.
+        return [
+            np.array([[0.0, 0.0, 0.0], [0.0, 0.1, 0.0]], dtype=np.float32)
+            for _ in range(num_frames)
+        ]
+
+    def test_primitives_change_rendered_frames(self, tmp_path: Path) -> None:
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(self.MODEL)
+        overlays = [
+            [DebugPrimitive(kind="sphere", pos=(0.2, 0.0, 0.6), size=(0.05,))],
+            [DebugPrimitive(kind="frame", pos=(0.0, 0.2, 0.5), size=(0.15,))],
+        ]
+        states = self._states()
+        baseline = self.render_many.render_states_get_frames(
+            states, str(model_path), width=160, height=120, num_processes=1
+        )
+        with_overlay = self.render_many.render_states_get_frames(
+            states,
+            str(model_path),
+            width=160,
+            height=120,
+            num_processes=1,
+            debug_overlays_list=[overlays] * len(states),
+        )
+        assert len(with_overlay) == len(states)
+        assert with_overlay[0].shape == (120, 160, 3)
+        assert np.abs(with_overlay[0].astype(int) - baseline[0].astype(int)).sum() > 0
+
+    def test_ghost_geom_renders_headless(self, tmp_path: Path) -> None:
+        obj_path = tmp_path / "goal.obj"
+        obj_path.write_text(
+            "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\n"
+            "f 1 3 2\nf 1 2 4\nf 2 3 4\nf 3 1 4\n"
+        )
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(self.MODEL)
+        states = self._states(num_frames=1)
+        overlays = [
+            [
+                DebugPrimitive(
+                    kind="ghost_geom", pos=(0.3, 0.0, 0.6), size=(1.0,),
+                    mesh_asset=str(obj_path), rgba=(0.2, 0.6, 1.0, 0.5),
+                )
+            ],
+            None,
+        ]
+        frames = self.render_many.render_states_get_frames(
+            states,
+            str(model_path),
+            width=160,
+            height=120,
+            num_processes=1,
+            cam_fov=45.0,
+            debug_overlays_list=[overlays],
+        )
+        assert len(frames) == 1
+        assert frames[0].shape == (120, 160, 3)
+
+    def test_tracking_render_with_overlay(self, tmp_path: Path) -> None:
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(self.MODEL)
+        states = self._states(num_frames=1)
+        overlays = [
+            [DebugPrimitive(kind="arrow", pos=(0, 0, 0.8), size=(0.2,))],
+            None,
+        ]
+        frames = self.render_many.render_states_get_frames_tracking(
+            states,
+            str(model_path),
+            width=160,
+            height=120,
+            tracking_env_idx=0,
+            max_extra_envs=1,
+            debug_overlays_list=[overlays],
+        )
+        assert len(frames) == 1
+        assert frames[0].shape == (120, 160, 3)

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import textwrap
 from pathlib import Path
 
 import numpy as np
@@ -423,16 +424,11 @@ class TestPrimitiveToGeomConversion:
 
 
 class TestHeadlessPrimitiveRendering:
-    """Offline snapshot rendering with overlays (skipped without a GL backend)."""
+    """Offline snapshot rendering with overlays (skipped without a GL backend).
 
-    @pytest.fixture(autouse=True)
-    def _render(self):
-        pytest.importorskip("mujoco")
-        from unisim.visualization import render_many
-
-        if not render_many.render_backend_usable():
-            pytest.skip("no usable MuJoCo off-screen GL backend on this host")
-        self.render_many = render_many
+    Rendering runs in a clean subprocess (like the module's GL probe) so a
+    driver-level EGL crash cannot take down the pytest process.
+    """
 
     MODEL = """<mujoco>
       <worldbody>
@@ -445,82 +441,104 @@ class TestHeadlessPrimitiveRendering:
       </worldbody>
     </mujoco>"""
 
-    def _states(self, num_frames: int = 2) -> list[np.ndarray]:
-        # [time, qpos(1), qvel(1)] for the single slide joint.
-        return [
+    OBJ = (
+        "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\n"
+        "f 1 3 2\nf 1 2 4\nf 2 3 4\nf 3 1 4\n"
+    )
+
+    _SCRIPT = textwrap.dedent(
+        """
+        import sys
+        import numpy as np
+        from unisim.backend.base import DebugPrimitive
+        from unisim.visualization import render_many
+
+        model_path, obj_path, mode = sys.argv[1:4]
+        states = [
             np.array([[0.0, 0.0, 0.0], [0.0, 0.1, 0.0]], dtype=np.float32)
-            for _ in range(num_frames)
+            for _ in range(2)
         ]
 
-    def test_primitives_change_rendered_frames(self, tmp_path: Path) -> None:
-        model_path = tmp_path / "scene.xml"
-        model_path.write_text(self.MODEL)
-        overlays = [
-            [DebugPrimitive(kind="sphere", pos=(0.2, 0.0, 0.6), size=(0.05,))],
-            [DebugPrimitive(kind="frame", pos=(0.0, 0.2, 0.5), size=(0.15,))],
-        ]
-        states = self._states()
-        baseline = self.render_many.render_states_get_frames(
-            states, str(model_path), width=160, height=120, num_processes=1
-        )
-        with_overlay = self.render_many.render_states_get_frames(
-            states,
-            str(model_path),
-            width=160,
-            height=120,
-            num_processes=1,
-            debug_overlays_list=[overlays] * len(states),
-        )
-        assert len(with_overlay) == len(states)
-        assert with_overlay[0].shape == (120, 160, 3)
-        assert np.abs(with_overlay[0].astype(int) - baseline[0].astype(int)).sum() > 0
-
-    def test_ghost_geom_renders_headless(self, tmp_path: Path) -> None:
-        obj_path = tmp_path / "goal.obj"
-        obj_path.write_text(
-            "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\n"
-            "f 1 3 2\nf 1 2 4\nf 2 3 4\nf 3 1 4\n"
-        )
-        model_path = tmp_path / "scene.xml"
-        model_path.write_text(self.MODEL)
-        states = self._states(num_frames=1)
-        overlays = [
-            [
-                DebugPrimitive(
+        if mode == "overlay_diff":
+            overlays = [
+                [DebugPrimitive(kind="sphere", pos=(0.2, 0.0, 0.6), size=(0.05,))],
+                [DebugPrimitive(kind="frame", pos=(0.0, 0.2, 0.5), size=(0.15,))],
+            ]
+            baseline = render_many.render_states_get_frames(
+                states, model_path, width=160, height=120, num_processes=1
+            )
+            with_overlay = render_many.render_states_get_frames(
+                states, model_path, width=160, height=120, num_processes=1,
+                debug_overlays_list=[overlays] * len(states),
+            )
+            assert len(with_overlay) == len(states) == len(baseline)
+            assert with_overlay[0].shape == (120, 160, 3)
+            diff = np.abs(with_overlay[0].astype(int) - baseline[0].astype(int)).sum()
+            assert diff > 0
+        elif mode == "ghost":
+            overlays = [
+                [DebugPrimitive(
                     kind="ghost_geom", pos=(0.3, 0.0, 0.6), size=(1.0,),
-                    mesh_asset=str(obj_path), rgba=(0.2, 0.6, 1.0, 0.5),
-                )
-            ],
-            None,
-        ]
-        frames = self.render_many.render_states_get_frames(
-            states,
-            str(model_path),
-            width=160,
-            height=120,
-            num_processes=1,
-            cam_fov=45.0,
-            debug_overlays_list=[overlays],
-        )
-        assert len(frames) == 1
-        assert frames[0].shape == (120, 160, 3)
+                    mesh_asset=obj_path, rgba=(0.2, 0.6, 1.0, 0.5),
+                )],
+                None,
+            ]
+            frames = render_many.render_states_get_frames(
+                states[:1], model_path, width=160, height=120, num_processes=1,
+                cam_fov=45.0, debug_overlays_list=[overlays],
+            )
+            assert len(frames) == 1 and frames[0].shape == (120, 160, 3)
+        elif mode == "tracking":
+            overlays = [[DebugPrimitive(kind="arrow", pos=(0, 0, 0.8), size=(0.2,))], None]
+            frames = render_many.render_states_get_frames_tracking(
+                states[:1], model_path, width=160, height=120,
+                tracking_env_idx=0, max_extra_envs=1, debug_overlays_list=[overlays],
+            )
+            assert len(frames) == 1 and frames[0].shape == (120, 160, 3)
+        else:
+            raise AssertionError(f"unknown mode {mode!r}")
+        print("RENDER-OK")
+        """
+    )
 
-    def test_tracking_render_with_overlay(self, tmp_path: Path) -> None:
-        model_path = tmp_path / "scene.xml"
-        model_path.write_text(self.MODEL)
-        states = self._states(num_frames=1)
-        overlays = [
-            [DebugPrimitive(kind="arrow", pos=(0, 0, 0.8), size=(0.2,))],
-            None,
-        ]
-        frames = self.render_many.render_states_get_frames_tracking(
-            states,
-            str(model_path),
-            width=160,
-            height=120,
-            tracking_env_idx=0,
-            max_extra_envs=1,
-            debug_overlays_list=[overlays],
+    @pytest.fixture(autouse=True)
+    def _render(self, tmp_path: Path):
+        pytest.importorskip("mujoco")
+        from unisim.visualization import render_many
+
+        if not render_many.render_backend_usable():
+            pytest.skip("no usable MuJoCo off-screen GL backend on this host")
+        self._model_path = tmp_path / "scene.xml"
+        self._model_path.write_text(self.MODEL)
+        self._obj_path = tmp_path / "goal.obj"
+        self._obj_path.write_text(self.OBJ)
+
+    def _run_render_mode(self, mode: str) -> None:
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                self._SCRIPT,
+                str(self._model_path),
+                str(self._obj_path),
+                mode,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        assert len(frames) == 1
-        assert frames[0].shape == (120, 160, 3)
+        assert result.returncode == 0 and "RENDER-OK" in result.stdout, (
+            f"render subprocess failed:\n{result.stdout}\n{result.stderr}"
+        )
+
+    def test_primitives_change_rendered_frames(self) -> None:
+        self._run_render_mode("overlay_diff")
+
+    def test_ghost_geom_renders_headless(self) -> None:
+        self._run_render_mode("ghost")
+
+    def test_tracking_render_with_overlay(self) -> None:
+        self._run_render_mode("tracking")


### PR DESCRIPTION
## Summary

Roadmap child for unilabsim/wuji_unilab#21: replace the `extra_data_getter` marker channel with typed, task-owned debug overlay primitives on the playback contract, and type the playback camera configuration. Supersedes the reverted d4e79f7 (free-form dict overlays multiplexed onto the marker channel via `isinstance` sniffing, box-only, no validation) with a typed contract validated at the boundary.

**Breaking changes (approved by maintainer, no compatibility shim):**

- `SimBackend.run_playback(..., extra_data_getter=...)` is replaced by `debug_overlay_getter` on every adapter. The getter returns `Sequence[Sequence[DebugPrimitive] | None] | None` per frame: the outer sequence is indexed by env (`len == num_envs`), each entry is that env's primitive list; `None` disables overlays for the frame. Poses are env-local; the renderer applies grid offsets.
- `camera_kwargs` is normalized into the frozen `CameraCfg` at the `run_playback`/`init_renderer` boundary. Unknown keys — including the legacy `distance`/`elevation_deg`/`azimuth_deg` aliases — now raise an error naming them instead of being silently ignored.

## Changes

- `unisim.backend.base`: frozen `DebugPrimitive` (`sphere`/`box`/`frame`/`arrow`/`ghost_geom`/`text`; kind-checked `size` arity, unit wxyz `quat`, `[0,1]` `rgba`; `mesh_asset` only for `ghost_geom`, `text` only for `text`), `DebugOverlayGetter` alias, `validate_debug_overlays`, frozen `CameraCfg` with `from_kwargs` (+ optional `cam_fov`), `BackendPlayCapabilities.supports_debug_overlay` (default `False`), and a shared `unsupported_debug_overlay_error`. Re-exported via `unisim.contract` and top-level `unisim`.
- `unisim.visualization.render_many`: the `marker_positions_list` red-sphere special case becomes generic primitive injection into the user scene — sphere/box via `mjv_initGeom`, `frame` as an RGB triad and `arrow` via `mjv_connector` arrows (local +z direction), `ghost_geom` as translucent mesh geoms (`dataid = mesh id`). Ghost mesh assets resolve to playback-model mesh names or are injected from `.obj`/`.stl` files through `MjSpec` into a recompiled primary render model (compiled `.mjb` playback models fail closed). `text` is a documented no-op on the off-screen path (no text channel in `mjvScene`). Multiprocess rendering, grid offsets, and the tracking camera are unchanged; `cam_fov` maps to `model.vis.global_.fovy`.
- Backend adapters: mujoco/mjwarp/drake/newton/superdex advertise `supports_debug_overlay=True` and forward overlays through the shared offline snapshot pipeline. newton record playback with overlays routes to the MuJoCo snapshot renderer (native ViewerGL cannot inject user geoms); mjwarp interactive playback fails closed with overlays. motrix/genesis/subprocess IPC (isaacgym/isaacsim) accept the parameter and fail closed with `NotImplementedError` when a getter is supplied.
- `_close_worker` is now idempotent (the serial path's explicit close was re-run by the atexit hook).

## Backend/platform impact

- UniLab / uni_rl call sites using `extra_data_getter` must migrate to `debug_overlay_getter` (next roadmap child, owned separately); positional camera aliases in `camera_kwargs` configs must use the `cam_*` keys.
- Rendering behavior is unchanged when no overlay getter is supplied (verified by pixel-diff baseline test).
- No new dependencies; the base wheel remains NumPy-only and `import unisim` stays engine-free.

## Verification

- `make check` (`uv run ruff check .` + `uv run pytest -q`): **208 passed, 30 skipped** on the final head (a49d1c2), 6 consecutive full-suite runs green.
- New `tests/test_debug_overlay.py` (56 tests): contract validation, overlay shape convention, `CameraCfg.from_kwargs` legal/illegal input, capability defaults and MuJoCo-family opt-in, fail-closed unsupported backends, primitive→`mjvGeom` conversion on a GL-free `MjvScene`, and headless EGL render snapshots (sphere/box/frame/arrow/ghost/tracking; run in a clean subprocess like the module's GL probe, skipped when no GL backend is usable).
- Repo-wide grep: no residual `extra_data_getter`/`marker_positions` references outside the CHANGELOG entry documenting the break.
