### PR TITLE
feat(playback): public append_debug_primitives entry and run_playback on_frame hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@
   `validate_debug_overlays` are exported from `unisim` and
   `unisim.contract` (unilabsim/wuji_unilab#21).
 
+- Add `unisim.visualization.render_many.append_debug_primitives`, the public
+  primitive-injection entry shared by the offline render workers and
+  interactive viewers (single-env `viewer.user_scn` callers pass
+  `overlays=[primitives]`, `offsets=None`); it returns the injected geom
+  count. Interactive `ghost_geom` meshes must already be registered in the
+  loaded model (resolved via `mesh_ids`), failing closed otherwise — the
+  interactive path cannot recompile the model (unilabsim/wuji_unilab#21).
+
+- Add `run_playback(..., on_frame=...)`: the offline MuJoCo pipeline calls
+  `on_frame(frame_index, frame)` with each `(H, W, 3)` uint8 frame before
+  video encoding; returning a replacement array (same shape/dtype, validated
+  fail-closed) substitutes it and `None` keeps the original. Backends on
+  native renderers (motrix, genesis, subprocess IPC; newton/mjwarp
+  interactive paths) fail closed with `NotImplementedError`; newton record
+  playback with `on_frame` routes to the offline snapshot renderer
+  (unilabsim/wuji_unilab#21).
+
 - Add a local-source SuperDex `SceneBatchExecutor` integration: a persistent
   C++ CPU barrier batches independent-scene generalized force writes, stepping,
   and articulated state reads. `superdex_num_workers=0` resolves an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@
   injected into the render model; `text` primitives are a documented no-op on
   the MuJoCo off-screen path. Newton record playback with overlays routes to
   the offline MuJoCo snapshot renderer (the native ViewerGL path cannot
-  inject user geoms); mjwarp interactive playback fails closed with overlays.
+  inject user geoms).
+- mjwarp interactive playback now consumes `debug_overlay_getter`: each frame
+  injects the tracked world's primitives into the passive viewer's
+  `user_scn` before `sync()`, resolving `ghost_geom` meshes against the
+  playback model (fail-closed when unregistered). `BackendPlayCapabilities`
+  gains `supports_interactive_debug_overlay` (default False; mjwarp reports
+  True) so callers can tell whether the interactive path consumes the getter.
+  The interactive `on_frame` hook remains fail-closed
+  (unilabsim/wuji_unilab#21).
 - **Breaking:** `camera_kwargs` is normalized into the typed frozen
   `CameraCfg` at the `run_playback`/`init_renderer` boundary. Unknown keys —
   including the historical `distance`/`elevation_deg`/`azimuth_deg` aliases —

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -1025,6 +1025,7 @@ class SimBackend(abc.ABC):
         frame_state_getter: Callable[[], np.ndarray] | None = None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: DebugOverlayGetter | None = None,
+        on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None = None,
     ) -> str | None:
         """Execute backend-owned playback for an env wrapper.
 
@@ -1039,6 +1040,13 @@ class SimBackend(abc.ABC):
         applies grid offsets when composing multiple envs.  Backends whose
         ``get_play_capabilities().supports_debug_overlay`` is False fail
         closed with :class:`NotImplementedError` when this is not ``None``.
+
+        ``on_frame`` is an optional per-frame video hook called by offline
+        render pipelines before encoding: it receives ``(frame_index, frame)``
+        with the frame an ``(H, W, 3)`` uint8 array, and returns a replacement
+        frame of the same shape/dtype or ``None`` to keep the original.
+        Backends rendering through a native (non-offline) renderer fail closed
+        with :class:`NotImplementedError` when this is not ``None``.
 
         Known boundary: ``env`` is the owning env wrapper, not a physics-layer
         concept. Current playback implementations read env-level configuration

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -477,12 +477,18 @@ class BackendSensorView:
 
 @dataclass(frozen=True)
 class BackendPlayCapabilities:
-    """Backend-native play/render capabilities surfaced through env contracts."""
+    """Backend-native play/render capabilities surfaced through env contracts.
+
+    ``supports_debug_overlay`` covers the offline/record rendering path;
+    ``supports_interactive_debug_overlay`` reports whether the interactive
+    rendering path can additionally consume ``debug_overlay_getter``.
+    """
 
     supports_native_interactive_renderer: bool = False
     supports_physics_state_playback: bool = False
     supports_native_video_capture: bool = False
     supports_debug_overlay: bool = False
+    supports_interactive_debug_overlay: bool = False
 
 
 class BackendHeightScanner(abc.ABC):
@@ -1040,6 +1046,9 @@ class SimBackend(abc.ABC):
         applies grid offsets when composing multiple envs.  Backends whose
         ``get_play_capabilities().supports_debug_overlay`` is False fail
         closed with :class:`NotImplementedError` when this is not ``None``.
+        On the interactive rendering path only backends whose
+        ``supports_interactive_debug_overlay`` is True consume it; the others
+        fail closed with :class:`NotImplementedError`.
 
         ``on_frame`` is an optional per-frame video hook called by offline
         render pipelines before encoding: it receives ``(frame_index, frame)``

--- a/src/unisim/backend/drake/backend.py
+++ b/src/unisim/backend/drake/backend.py
@@ -603,6 +603,7 @@ class DrakeBackend(SimBackend):
         frame_state_getter: Callable[[], np.ndarray] | None = None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: DebugOverlayGetter | None = None,
+        on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None = None,
     ) -> str | None:
         # Playback keeps Drake as the physics backend. The helper owns rendering
         # and video capture so training code can use one playback contract.
@@ -619,6 +620,7 @@ class DrakeBackend(SimBackend):
             frame_state_getter=frame_state_getter,
             camera_kwargs=CameraCfg.from_kwargs(camera_kwargs),
             debug_overlay_getter=debug_overlay_getter,
+            on_frame=on_frame,
         )
 
     def init_renderer(

--- a/src/unisim/backend/drake/playback.py
+++ b/src/unisim/backend/drake/playback.py
@@ -28,6 +28,7 @@ def run_drake_playback(
     frame_state_getter: Callable[[], np.ndarray] | None,
     camera_kwargs: CameraCfg | Mapping[str, Any] | None,
     debug_overlay_getter: DebugOverlayGetter | None = None,
+    on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None = None,
 ) -> str | None:
     """Run Drake physics playback and optionally render it with MuJoCo.
 
@@ -49,6 +50,7 @@ def run_drake_playback(
             frame_state_getter=frame_state_getter,
             camera_kwargs=camera_kwargs,
             debug_overlay_getter=debug_overlay_getter,
+            on_frame=on_frame,
         )
     if not headless:
         raise NotImplementedError("Drake playback does not support interactive rendering yet.")

--- a/src/unisim/backend/genesis/backend.py
+++ b/src/unisim/backend/genesis/backend.py
@@ -1033,11 +1033,17 @@ class GenesisBackend(SimBackend):
         frame_state_getter: Any = None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: Any = None,
+        on_frame: Any = None,
     ) -> str | None:
         # Native live-scene playback: no state snapshots are needed.
         del render_spacing, render_offset_mode, frame_state_getter
         if debug_overlay_getter is not None:
             raise unsupported_debug_overlay_error(self.__class__.__name__)
+        if on_frame is not None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} renders through a native renderer and "
+                "does not support on_frame callbacks"
+            )
         camera_cfg = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -1696,6 +1696,7 @@ class MjwarpBackend(SimBackend):
         return BackendPlayCapabilities(
             supports_physics_state_playback=True,
             supports_debug_overlay=True,
+            supports_interactive_debug_overlay=True,
         )
 
     def resolve_play_render_plan(

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -1759,6 +1759,7 @@ class MjwarpBackend(SimBackend):
         frame_state_getter: Any = None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: DebugOverlayGetter | None = None,
+        on_frame: Any = None,
     ) -> str | None:
         del render_offset_mode
         camera = CameraCfg.from_kwargs(camera_kwargs)
@@ -1778,6 +1779,7 @@ class MjwarpBackend(SimBackend):
             frame_state_getter=frame_state_getter,
             camera_kwargs=camera,
             debug_overlay_getter=debug_overlay_getter,
+            on_frame=on_frame,
         )
 
     def get_physics_state(self) -> np.ndarray:

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -55,15 +55,17 @@ def run_mjwarp_playback(
     frame_state_getter: Callable[[], np.ndarray] | None,
     camera_kwargs: CameraCfg | Mapping[str, Any] | None,
     debug_overlay_getter: DebugOverlayGetter | None = None,
+    on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None = None,
 ) -> str | None:
     """Render detached mjwarp host snapshots with the existing MuJoCo pipeline."""
     if not headless:
         if record_video:
             raise ValueError("mjwarp interactive playback cannot record video simultaneously.")
-        if debug_overlay_getter is not None:
+        if debug_overlay_getter is not None or on_frame is not None:
             raise NotImplementedError(
-                "mjwarp interactive playback does not support debug overlay primitives; "
-                "use play_render_mode=record (offline MuJoCo snapshot renderer)"
+                "mjwarp interactive playback supports neither debug overlay primitives "
+                "nor on_frame callbacks; use play_render_mode=record (offline MuJoCo "
+                "snapshot renderer)"
             )
         return _run_interactive(
             backend=backend, env=env, initialize=initialize, step=step,
@@ -85,6 +87,7 @@ def run_mjwarp_playback(
         camera_kwargs=camera_kwargs,
         backend_label="mjwarp",
         debug_overlay_getter=debug_overlay_getter,
+        on_frame=on_frame,
     )
 
 

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -16,7 +16,7 @@ from typing import Any, TypeVar
 
 import numpy as np
 
-from unisim.backend.base import CameraCfg, DebugOverlayGetter
+from unisim.backend.base import CameraCfg, DebugOverlayGetter, validate_debug_overlays
 from unisim.backend.playback_common import (
     run_offline_snapshot_playback,
     validate_offline_visual_model,
@@ -61,16 +61,16 @@ def run_mjwarp_playback(
     if not headless:
         if record_video:
             raise ValueError("mjwarp interactive playback cannot record video simultaneously.")
-        if debug_overlay_getter is not None or on_frame is not None:
+        if on_frame is not None:
             raise NotImplementedError(
-                "mjwarp interactive playback supports neither debug overlay primitives "
-                "nor on_frame callbacks; use play_render_mode=record (offline MuJoCo "
-                "snapshot renderer)"
+                "mjwarp interactive playback does not support on_frame callbacks; "
+                "use play_render_mode=record (offline MuJoCo snapshot renderer)"
             )
         return _run_interactive(
             backend=backend, env=env, initialize=initialize, step=step,
             num_steps=num_steps, snapshot_shape=snapshot_shape,
             frame_state_getter=frame_state_getter, camera_kwargs=camera_kwargs,
+            debug_overlay_getter=debug_overlay_getter,
         )
     return run_offline_snapshot_playback(
         backend=backend,
@@ -91,16 +91,61 @@ def run_mjwarp_playback(
     )
 
 
+def _inject_interactive_debug_overlays(
+    *,
+    user_scn: Any,
+    overlays: Any,
+    world: int,
+    num_envs: int,
+    model: Any,
+    mesh_id_cache: dict[str, int],
+) -> int:
+    """Inject this frame's debug primitives into the passive viewer scene.
+
+    Returns the number of scene geoms written.  The caller owns
+    ``viewer.lock()``; the scene is reset (``ngeom = 0``) before injection
+    because ``viewer.sync()`` does not clear user geoms.
+    """
+    import mujoco
+
+    from unisim.visualization.render_many import append_debug_primitives
+
+    validated = validate_debug_overlays(overlays, num_envs)
+    user_scn.ngeom = 0
+    if validated is None:
+        return 0
+    env_primitives = validated[world]
+    if not env_primitives:
+        return 0
+    for primitive in env_primitives:
+        if primitive.kind == "ghost_geom" and primitive.mesh_asset not in mesh_id_cache:
+            mesh_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_MESH, primitive.mesh_asset)
+            if mesh_id < 0:
+                raise ValueError(
+                    f"mjwarp interactive ghost_geom mesh {primitive.mesh_asset!r} is not "
+                    "registered in the playback model; interactive overlay meshes cannot "
+                    "be injected from files (see append_debug_primitives)"
+                )
+            mesh_id_cache[primitive.mesh_asset] = int(mesh_id)
+    return append_debug_primitives(
+        user_scn, [env_primitives], offsets=None, mesh_ids=mesh_id_cache
+    )
+
+
 def _run_interactive(
     *, backend: Any, env: Any, initialize: Callable[[], ObsT],
     step: Callable[[ObsT], ObsT], num_steps: int | None,
     snapshot_shape: tuple[int, int], frame_state_getter: Callable[[], np.ndarray] | None,
     camera_kwargs: CameraCfg | Mapping[str, Any] | None,
+    debug_overlay_getter: DebugOverlayGetter | None = None,
 ) -> None:
     """Display one selected Warp world; MuJoCo only computes visual kinematics.
 
     The passive viewer owns detached model/data, so mouse perturbations cannot
-    mutate the physics state. Closing its window ends playback.
+    mutate the physics state. Closing its window ends playback.  When
+    ``debug_overlay_getter`` is provided, the current frame's primitives for
+    the displayed world are injected into ``viewer.user_scn`` before each
+    ``viewer.sync()``.
     """
     if num_steps is not None and (isinstance(num_steps, bool) or num_steps <= 0):
         raise ValueError("mjwarp interactive playback requires positive num_steps or None.")
@@ -146,6 +191,11 @@ def _run_interactive(
             "(on macOS use mjpython)."
         ) from exc
     with viewer:
+        mesh_id_cache: dict[str, int] = {}
+        if debug_overlay_getter is not None and viewer.user_scn is None:
+            raise RuntimeError(
+                "mjwarp interactive debug overlays require viewer.user_scn support."
+            )
         with viewer.lock():
             viewer.cam.distance = camera.cam_distance
             viewer.cam.elevation = camera.cam_elevation
@@ -157,6 +207,15 @@ def _run_interactive(
             obs = step(obs)
             with viewer.lock():
                 update()
+                if debug_overlay_getter is not None:
+                    _inject_interactive_debug_overlays(
+                        user_scn=viewer.user_scn,
+                        overlays=debug_overlay_getter(),
+                        world=world,
+                        num_envs=snapshot_shape[0],
+                        model=model,
+                        mesh_id_cache=mesh_id_cache,
+                    )
             viewer.sync()
             count += 1
             time.sleep(max(0, ctrl_dt - (time.monotonic() - start)))

--- a/src/unisim/backend/motrix/backend.py
+++ b/src/unisim/backend/motrix/backend.py
@@ -1019,10 +1019,16 @@ class MotrixBackend(SimBackend):
         frame_state_getter=None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter=None,
+        on_frame=None,
     ) -> str | None:
         del frame_state_getter
         if debug_overlay_getter is not None:
             raise unsupported_debug_overlay_error(self.__class__.__name__)
+        if on_frame is not None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} renders through a native renderer and "
+                "does not support on_frame callbacks"
+            )
         camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None

--- a/src/unisim/backend/mujoco/backend.py
+++ b/src/unisim/backend/mujoco/backend.py
@@ -1488,6 +1488,7 @@ class MuJoCoBackend(SimBackend):
         frame_state_getter=None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: DebugOverlayGetter | None = None,
+        on_frame=None,
     ) -> str | None:
         del render_offset_mode
         camera = CameraCfg.from_kwargs(camera_kwargs)
@@ -1507,6 +1508,7 @@ class MuJoCoBackend(SimBackend):
             frame_state_getter=frame_state_getter,
             camera_kwargs=camera,
             debug_overlay_getter=debug_overlay_getter,
+            on_frame=on_frame,
         )
 
     # ------------------------------------------------------------------ #

--- a/src/unisim/backend/mujoco/playback.py
+++ b/src/unisim/backend/mujoco/playback.py
@@ -16,7 +16,11 @@ from unisim.backend.base import (
     DebugPrimitive,
     validate_debug_overlays,
 )
-from unisim.backend.playback_common import env_cfg_value, write_playback_video
+from unisim.backend.playback_common import (
+    apply_on_frame_callback,
+    env_cfg_value,
+    write_playback_video,
+)
 from unisim.scene import SceneCfg
 
 ObsT = TypeVar("ObsT")
@@ -35,6 +39,7 @@ def run_mujoco_playback(
     frame_state_getter: Callable[[], np.ndarray] | None,
     camera_kwargs: CameraCfg | Mapping[str, Any] | None,
     debug_overlay_getter: DebugOverlayGetter | None = None,
+    on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None = None,
 ) -> str | None:
     if not headless:
         raise NotImplementedError("MuJoCo play mode does not support interactive rendering here.")
@@ -117,6 +122,7 @@ def run_mujoco_playback(
         print(f"[playback] No frames rendered; skipping video export to {output_video}.")
         return None
 
+    frames = apply_on_frame_callback(frames, on_frame, backend_label="mujoco")
     ctrl_dt = float(env_cfg_value(env, "ctrl_dt", 1.0 / 60.0))
     write_playback_video(str(output_video), frames, fps=int(1.0 / ctrl_dt))
     return str(output_video)

--- a/src/unisim/backend/newton/backend.py
+++ b/src/unisim/backend/newton/backend.py
@@ -792,16 +792,17 @@ class NewtonBackend(SimBackend):
         frame_state_getter: Any = None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: DebugOverlayGetter | None = None,
+        on_frame: Any = None,
     ) -> str | None:
         del render_offset_mode
         camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record = bool(record_video) if record_video is not None else output_video is not None
         should_run_headless = bool(headless) if headless is not None else should_record
         if not should_run_headless and not should_record:
-            if debug_overlay_getter is not None:
+            if debug_overlay_getter is not None or on_frame is not None:
                 raise NotImplementedError(
-                    "newton interactive playback does not support debug overlay primitives; "
-                    "use play_render_mode=record"
+                    "newton interactive playback supports neither debug overlay primitives "
+                    "nor on_frame callbacks; use play_render_mode=record"
                 )
             try:
                 return run_newton_native_playback(
@@ -819,10 +820,11 @@ class NewtonBackend(SimBackend):
             except RenderClosedError:
                 logger.info("Render window closed.")
                 return None
-        if debug_overlay_getter is not None:
-            # The native ViewerGL renderer cannot inject user geoms; overlays
-            # route to the offline MuJoCo snapshot pipeline even when the
-            # native viewer dependencies are installed.
+        if debug_overlay_getter is not None or on_frame is not None:
+            # The native ViewerGL renderer can neither inject user geoms nor
+            # post-process frames; overlays and on_frame route to the offline
+            # MuJoCo snapshot pipeline even when the native viewer
+            # dependencies are installed.
             return run_offline_snapshot_playback(
                 backend=self,
                 env=env,
@@ -838,6 +840,7 @@ class NewtonBackend(SimBackend):
                 camera_kwargs=camera,
                 backend_label="newton",
                 debug_overlay_getter=debug_overlay_getter,
+                on_frame=on_frame,
             )
         if newton_render_dependencies_available():
             return run_newton_native_playback(
@@ -866,6 +869,7 @@ class NewtonBackend(SimBackend):
             frame_state_getter=frame_state_getter,
             camera_kwargs=camera,
             backend_label="newton",
+            on_frame=on_frame,
         )
 
     def init_renderer(

--- a/src/unisim/backend/playback_common.py
+++ b/src/unisim/backend/playback_common.py
@@ -38,6 +38,37 @@ def write_playback_video(path: str, frames: list[np.ndarray], *, fps: int) -> No
     imageio.mimsave(path, frames, fps=fps)
 
 
+def apply_on_frame_callback(
+    frames: list[np.ndarray],
+    on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None,
+    *,
+    backend_label: str,
+) -> list[np.ndarray]:
+    """Apply the ``run_playback`` per-frame hook before video encoding.
+
+    ``on_frame(frame_index, frame)`` receives ``(H, W, 3)`` uint8 frames and
+    returns a replacement frame of identical shape/dtype or ``None`` to keep
+    the original.  Replacement frames with a mismatched contract fail closed.
+    """
+    if on_frame is None:
+        return frames
+    out: list[np.ndarray] = []
+    for index, frame in enumerate(frames):
+        replacement = on_frame(index, frame)
+        if replacement is None:
+            out.append(frame)
+            continue
+        replacement = np.asarray(replacement)
+        if replacement.shape != frame.shape or replacement.dtype != frame.dtype:
+            raise ValueError(
+                f"{backend_label} on_frame must return None or an array with the frame's "
+                f"shape {frame.shape} and dtype {frame.dtype}; got shape "
+                f"{replacement.shape} and dtype {replacement.dtype} at frame {index}"
+            )
+        out.append(replacement)
+    return out
+
+
 def validate_offline_visual_model(
     *,
     mujoco: Any,
@@ -107,6 +138,7 @@ def run_offline_snapshot_playback(
     camera_kwargs: CameraCfg | Mapping[str, Any] | None,
     backend_label: str,
     debug_overlay_getter: DebugOverlayGetter | None = None,
+    on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None = None,
 ) -> str:
     """Render detached host snapshots with the offline MuJoCo pipeline."""
     if not headless:
@@ -167,6 +199,7 @@ def run_offline_snapshot_playback(
         frame_state_getter=_validated_state_getter,
         camera_kwargs=camera_kwargs,
         debug_overlay_getter=debug_overlay_getter,
+        on_frame=on_frame,
     )
     if result is None:
         raise RuntimeError(

--- a/src/unisim/backend/subprocess_ipc/backend.py
+++ b/src/unisim/backend/subprocess_ipc/backend.py
@@ -1249,10 +1249,16 @@ class MjcfSubprocessBackend(SimBackend):
         frame_state_getter: Any = None,
         camera_kwargs: CameraCfg | Mapping[str, Any] | None = None,
         debug_overlay_getter: Any = None,
+        on_frame: Any = None,
     ) -> str | None:
         del frame_state_getter
         if debug_overlay_getter is not None:
             raise unsupported_debug_overlay_error(self.__class__.__name__)
+        if on_frame is not None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} renders through a native renderer and "
+                "does not support on_frame callbacks"
+            )
         camera = CameraCfg.from_kwargs(camera_kwargs)
         should_record_video = (
             bool(record_video) if record_video is not None else output_video is not None

--- a/src/unisim/backend/superdex/backend.py
+++ b/src/unisim/backend/superdex/backend.py
@@ -720,7 +720,7 @@ class SuperDexBackend(SimBackend):
     def run_playback(self, *, env, initialize, step, num_steps, output_video=None,
                      render_spacing=None, render_offset_mode=None, headless=None,
                      record_video=None, frame_state_getter=None, camera_kwargs=None,
-                     debug_overlay_getter=None):
+                     debug_overlay_getter=None, on_frame=None):
         from unisim.backend.playback_common import run_offline_snapshot_playback
 
         if self.scene_visual_model_file is None:
@@ -743,6 +743,7 @@ class SuperDexBackend(SimBackend):
             camera_kwargs=CameraCfg.from_kwargs(camera_kwargs),
             backend_label="superdex",
             debug_overlay_getter=debug_overlay_getter,
+            on_frame=on_frame,
         )
 
     def get_physics_state(self) -> np.ndarray:

--- a/src/unisim/visualization/render_many.py
+++ b/src/unisim/visualization/render_many.py
@@ -293,8 +293,12 @@ def _inject_ghost_mesh_assets(model_path, ghost_assets, tmp_dir):
     return result, name_map
 
 
-def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_ids) -> None:
-    """Convert one :class:`DebugPrimitive` into user-scene geoms (env-local pos)."""
+def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, mesh_ids) -> int:
+    """Convert one :class:`DebugPrimitive` into user-scene geoms (env-local pos).
+
+    Returns the number of geoms injected (0 for the documented text no-op or
+    when ``scene.maxgeom`` is exhausted mid-frame).
+    """
     pos = np.array(primitive.pos, dtype=np.float64)
     if offset_xy is not None:
         pos[0] += float(offset_xy[0])
@@ -319,7 +323,8 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_id
             rgba=rgba,
         )
         scene.ngeom += 1
-    elif kind == "box":
+        return 1
+    if kind == "box":
         mujoco.mjv_initGeom(
             scene.geoms[scene.ngeom],
             type=mujoco.mjtGeom.mjGEOM_BOX,
@@ -329,13 +334,15 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_id
             rgba=rgba,
         )
         scene.ngeom += 1
-    elif kind == "ghost_geom":
+        return 1
+    if kind == "ghost_geom":
         assert primitive.mesh_asset is not None
-        mesh_id = ghost_mesh_ids.get(primitive.mesh_asset, -1)
+        mesh_id = mesh_ids.get(primitive.mesh_asset, -1)
         if mesh_id < 0:
             raise ValueError(
-                f"ghost_geom mesh asset {primitive.mesh_asset!r} was not resolved in the "
-                "render worker; it must be a mesh name in the playback model or a mesh file"
+                f"ghost_geom mesh asset {primitive.mesh_asset!r} is not resolved; the mesh "
+                "must be registered in the model that owns this scene (resolve it with "
+                "mj_name2id and pass the id via mesh_ids)"
             )
         scale = primitive.size[0] if primitive.size else 1.0
         geom = scene.geoms[scene.ngeom]
@@ -349,7 +356,8 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_id
         )
         geom.dataid = mesh_id
         scene.ngeom += 1
-    elif kind in ("frame", "arrow"):
+        return 1
+    if kind in ("frame", "arrow"):
         length = float(primitive.size[0])
         width = max(1e-3, 0.02 * length)
         rotation = np.asarray(mat, dtype=np.float64).reshape(3, 3)
@@ -361,9 +369,10 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_id
                 (rotation[:, axis], (*color, alpha))
                 for axis, color in enumerate(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)))
             )
+        added = 0
         for direction, color in axes:
             if scene.ngeom >= scene.maxgeom:
-                return
+                return added
             geom = scene.geoms[scene.ngeom]
             mujoco.mjv_connector(
                 geom,
@@ -374,23 +383,49 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, ghost_mesh_id
             )
             geom.rgba[:] = color
             scene.ngeom += 1
-    elif kind == "text":
-        # mjvScene has no text channel on the off-screen path; text primitives
-        # are a documented no-op here (see DebugPrimitive).
-        return
+            added += 1
+        return added
+    # kind == "text": mjvScene has no text channel; text primitives are a
+    # documented no-op here (see DebugPrimitive).
+    return 0
 
 
-def _append_debug_primitives(scene, overlays, offsets, env_indices, ghost_mesh_ids) -> None:
-    """Inject per-env debug primitives into ``scene`` with grid offsets applied."""
-    for env_idx in env_indices:
-        env_primitives = overlays[env_idx] if env_idx < len(overlays) else None
+def append_debug_primitives(scene, overlays, *, offsets=None, mesh_ids=None) -> int:
+    """Inject per-env :class:`DebugPrimitive` overlays into a caller-owned scene.
+
+    This is the single conversion implementation shared by the offline render
+    workers and interactive viewers (e.g. ``mujoco.viewer.launch_passive`` with
+    ``viewer.user_scn``).  ``overlays`` follows the ``debug_overlay_getter``
+    shape convention: one entry per environment, each a sequence of
+    :class:`DebugPrimitive` (``None``/empty marks an env without overlay);
+    a single-env caller passes ``[primitives]``.  Primitive poses are
+    env-local; ``offsets`` (optional ``(num_envs, 2)`` grid XY offsets, same
+    indexing as ``overlays``) shifts them into world space — pass ``None`` for
+    a single already-placed env.
+
+    ``mesh_ids`` maps ``ghost_geom`` ``mesh_asset`` keys to mesh ids in the
+    model that owns this scene's render context.  Unlike the offline pipeline
+    (which can inject mesh files into a recompiled render model), an
+    interactive viewer cannot be recompiled, so ghost meshes must already be
+    registered in the loaded model; unresolved assets fail closed with
+    ``ValueError``.
+
+    The caller owns the scene's capacity (``maxgeom``) and must reset
+    ``scene.ngeom`` between frames.  Returns the number of geoms injected.
+    """
+    if overlays is None:
+        return 0
+    resolved_mesh_ids = mesh_ids or {}
+    added = 0
+    for env_idx, env_primitives in enumerate(overlays):
         if not env_primitives:
             continue
         offset_xy = offsets[env_idx] if offsets is not None else None
         for primitive in env_primitives:
             if scene.ngeom >= scene.maxgeom:
-                return
-            _append_primitive(scene, primitive, offset_xy, ghost_mesh_ids)
+                return added
+            added += _append_primitive(scene, primitive, offset_xy, resolved_mesh_ids)
+    return added
 
 
 def init_worker(model_path, shape, cam_fov=None, ghost_mesh_map=None):
@@ -603,12 +638,11 @@ def render_frame_job(args):
 
     # 3. Overlay debug primitives (e.g. goal poses, frames, ghost geoms)
     if debug_overlays is not None:
-        _append_debug_primitives(
+        append_debug_primitives(
             renderer.scene,
             debug_overlays,
-            offsets,
-            range(num_envs),
-            _worker_ctx.get("ghost_mesh_ids", {}),
+            offsets=offsets,
+            mesh_ids=_worker_ctx.get("ghost_mesh_ids"),
         )
 
     return renderer.render()
@@ -869,14 +903,16 @@ def render_frame_tracking_job(args):
             mujoco.mjv_addGeoms(model, data, vopt, pert, catmask_static, renderer.scene)
             vopt.geomgroup[0] = geomgroup0
 
-    # Overlay debug primitives for rendered envs
+    # Overlay debug primitives for rendered envs (slice to the shown subset)
     if debug_overlays is not None:
-        _append_debug_primitives(
+        append_debug_primitives(
             renderer.scene,
-            debug_overlays,
-            offsets,
-            env_indices,
-            _worker_ctx.get("ghost_mesh_ids", {}),
+            [
+                debug_overlays[global_i] if global_i < len(debug_overlays) else None
+                for global_i in env_indices
+            ],
+            offsets=offsets[env_indices] if offsets is not None else None,
+            mesh_ids=_worker_ctx.get("ghost_mesh_ids"),
         )
 
     return renderer.render()

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -259,14 +259,19 @@ class TestRunPlaybackContract:
             )
 
     def test_mjwarp_interactive_accepts_overlay_getter(self, monkeypatch) -> None:
-        """An overlay getter no longer fails closed; without a desktop the run
-        reaches the DISPLAY guard instead of the removed NotImplementedError."""
+        """An overlay getter no longer fails closed; the run now reaches the
+        platform guards/model loading instead of the removed NotImplementedError."""
         from unisim.backend.mjwarp.playback import run_mjwarp_playback
 
+        class _SentinelBackend:
+            def get_playback_model(self, world: int) -> str:
+                raise RuntimeError("SENTINEL reached model loading")
+
         monkeypatch.delenv("DISPLAY", raising=False)
-        with pytest.raises(RuntimeError, match="DISPLAY"):
+        monkeypatch.delenv("MUJOCO_GL", raising=False)
+        with pytest.raises(RuntimeError, match="DISPLAY|SENTINEL"):
             run_mjwarp_playback(
-                backend=None,
+                backend=_SentinelBackend(),
                 env=None,
                 initialize=lambda: None,
                 step=lambda o: o,

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -173,9 +173,12 @@ class TestCameraCfg:
 class TestPlayCapabilities:
     def test_default_is_false(self) -> None:
         assert not BackendPlayCapabilities().supports_debug_overlay
+        assert not BackendPlayCapabilities().supports_interactive_debug_overlay
 
     def test_fake_backend_default(self) -> None:
-        assert not FakeBackend().get_play_capabilities().supports_debug_overlay
+        capabilities = FakeBackend().get_play_capabilities()
+        assert not capabilities.supports_debug_overlay
+        assert not capabilities.supports_interactive_debug_overlay
 
     @pytest.mark.parametrize(
         "backend_path",
@@ -193,6 +196,24 @@ class TestPlayCapabilities:
         backend_cls = getattr(importlib.import_module(module_path), class_name)
         backend = backend_cls.__new__(backend_cls)
         assert backend.get_play_capabilities().supports_debug_overlay
+
+    def test_only_mjwarp_supports_interactive_overlay(self) -> None:
+        import importlib
+
+        for module_path, class_name, expected in (
+            ("unisim.backend.mjwarp.backend", "MjwarpBackend", True),
+            ("unisim.backend.drake.backend", "DrakeBackend", False),
+            ("unisim.backend.newton.backend", "NewtonBackend", False),
+            ("unisim.backend.superdex.backend", "SuperDexBackend", False),
+            ("unisim.backend.motrix.backend", "MotrixBackend", False),
+            ("unisim.backend.genesis.backend", "GenesisBackend", False),
+            ("unisim.backend.subprocess_ipc.backend", "MjcfSubprocessBackend", False),
+        ):
+            backend_cls = getattr(importlib.import_module(module_path), class_name)
+            backend = backend_cls.__new__(backend_cls)
+            assert (
+                backend.get_play_capabilities().supports_interactive_debug_overlay is expected
+            ), f"{class_name} interactive overlay capability mismatch"
 
     def test_motrix_genesis_subprocess_do_not_support_overlay(self) -> None:
         import importlib
@@ -237,10 +258,13 @@ class TestRunPlaybackContract:
                 debug_overlay_getter=lambda: None,
             )
 
-    def test_mjwarp_interactive_fails_closed_on_overlay(self) -> None:
+    def test_mjwarp_interactive_accepts_overlay_getter(self, monkeypatch) -> None:
+        """An overlay getter no longer fails closed; without a desktop the run
+        reaches the DISPLAY guard instead of the removed NotImplementedError."""
         from unisim.backend.mjwarp.playback import run_mjwarp_playback
 
-        with pytest.raises(NotImplementedError, match="interactive playback"):
+        monkeypatch.delenv("DISPLAY", raising=False)
+        with pytest.raises(RuntimeError, match="DISPLAY"):
             run_mjwarp_playback(
                 backend=None,
                 env=None,
@@ -592,6 +616,99 @@ class TestAppendDebugPrimitivesPublic:
         overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0), mesh_asset="goal.stl")]]
         with pytest.raises(ValueError, match="registered in the model"):
             self.render_many.append_debug_primitives(scene, overlays, mesh_ids={})
+
+
+class TestInteractiveOverlayInjection:
+    """mjwarp passive-viewer scene injection (no GL context required)."""
+
+    OBJ = (
+        "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\n"
+        "f 1 3 2\nf 1 2 4\nf 2 3 4\nf 3 1 4\n"
+    )
+
+    @pytest.fixture(autouse=True)
+    def _mujoco(self, tmp_path: Path):
+        self.mujoco = pytest.importorskip("mujoco")
+        from unisim.backend.mjwarp.playback import _inject_interactive_debug_overlays
+
+        self.inject = _inject_interactive_debug_overlays
+        obj_path = tmp_path / "goal.obj"
+        obj_path.write_text(self.OBJ)
+        self.model = self.mujoco.MjModel.from_xml_string(
+            f"<mujoco><asset><mesh name='goal' file='{obj_path}'/></asset>"
+            "<worldbody><geom type='mesh' mesh='goal'/></worldbody></mujoco>"
+        )
+
+    def _scene(self, maxgeom: int = 16):
+        return self.mujoco.MjvScene(self.model, maxgeom=maxgeom)
+
+    def test_none_overlays_clears_scene(self) -> None:
+        scene = self._scene()
+        overlays = [[DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,))]]
+        added = self.inject(
+            user_scn=scene, overlays=overlays, world=0, num_envs=1,
+            model=self.model, mesh_id_cache={},
+        )
+        assert added == 1 and scene.ngeom == 1
+        # A frame without overlays resets ngeom (sync() does not clear user geoms).
+        assert self.inject(
+            user_scn=scene, overlays=None, world=0, num_envs=1,
+            model=self.model, mesh_id_cache={},
+        ) == 0
+        assert scene.ngeom == 0
+
+    def test_only_tracked_world_is_injected(self) -> None:
+        scene = self._scene()
+        overlays = [
+            [DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,))],
+            [DebugPrimitive(kind="frame", pos=(0, 0, 0.2), size=(0.1,))],
+        ]
+        added = self.inject(
+            user_scn=scene, overlays=overlays, world=1, num_envs=2,
+            model=self.model, mesh_id_cache={},
+        )
+        assert added == 3  # the frame triad of env 1 only
+        assert scene.ngeom == 3
+        np.testing.assert_allclose(scene.geoms[0].pos, [0, 0, 0.2], atol=1e-7)
+
+    def test_empty_tracked_world_injects_nothing(self) -> None:
+        scene = self._scene()
+        overlays = [[DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,))], None]
+        assert self.inject(
+            user_scn=scene, overlays=overlays, world=1, num_envs=2,
+            model=self.model, mesh_id_cache={},
+        ) == 0
+        assert scene.ngeom == 0
+
+    def test_ghost_geom_resolves_registered_mesh_and_caches_id(self) -> None:
+        scene = self._scene()
+        cache: dict[str, int] = {}
+        overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0.3), mesh_asset="goal")]]
+        added = self.inject(
+            user_scn=scene, overlays=overlays, world=0, num_envs=1,
+            model=self.model, mesh_id_cache=cache,
+        )
+        mesh_id = self.mujoco.mj_name2id(self.model, self.mujoco.mjtObj.mjOBJ_MESH, "goal")
+        assert added == 1
+        assert cache == {"goal": mesh_id}
+        assert scene.geoms[0].dataid == mesh_id
+
+    def test_ghost_geom_unregistered_mesh_fails_closed(self) -> None:
+        scene = self._scene()
+        overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0), mesh_asset="absent")]]
+        with pytest.raises(ValueError, match="not registered in the playback model"):
+            self.inject(
+                user_scn=scene, overlays=overlays, world=0, num_envs=1,
+                model=self.model, mesh_id_cache={},
+            )
+
+    def test_wrong_outer_length_fails(self) -> None:
+        scene = self._scene()
+        with pytest.raises(ValueError, match=r"len == 2"):
+            self.inject(
+                user_scn=scene, overlays=[[]], world=0, num_envs=2,
+                model=self.model, mesh_id_cache={},
+            )
 
 
 class TestOnFrameCallback:

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -289,8 +289,8 @@ class TestPrimitiveToGeomConversion:
                 DebugPrimitive(kind="arrow", pos=(0, 0, 0.5), size=(0.2,)),
             ]
         ]
-        self.render_many._append_debug_primitives(
-            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+        self.render_many.append_debug_primitives(
+            scene, overlays, offsets=None, mesh_ids={}
         )
         assert scene.ngeom == 3
         sphere, box, arrow = scene.geoms[0], scene.geoms[1], scene.geoms[2]
@@ -309,8 +309,8 @@ class TestPrimitiveToGeomConversion:
     def test_frame_draws_rgb_triad(self) -> None:
         scene = self._scene()
         overlays = [[DebugPrimitive(kind="frame", pos=(0, 0, 0), size=(0.1,))]]
-        self.render_many._append_debug_primitives(
-            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+        self.render_many.append_debug_primitives(
+            scene, overlays, offsets=None, mesh_ids={}
         )
         assert scene.ngeom == 3
         for geom, expected_rgb in zip(
@@ -326,8 +326,8 @@ class TestPrimitiveToGeomConversion:
             [DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,))],
         ]
         offsets = np.array([[0.0, 0.0], [1.0, 2.0]])
-        self.render_many._append_debug_primitives(
-            scene, overlays, offsets=offsets, env_indices=range(2), ghost_mesh_ids={}
+        self.render_many.append_debug_primitives(
+            scene, overlays, offsets=offsets, mesh_ids={}
         )
         assert scene.ngeom == 1
         np.testing.assert_allclose(scene.geoms[0].pos, [1.0, 2.0, 0.5], atol=1e-7)
@@ -335,8 +335,8 @@ class TestPrimitiveToGeomConversion:
     def test_text_is_documented_noop(self) -> None:
         scene = self._scene()
         overlays = [[DebugPrimitive(kind="text", pos=(0, 0, 0), text="label")]]
-        self.render_many._append_debug_primitives(
-            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+        self.render_many.append_debug_primitives(
+            scene, overlays, offsets=None, mesh_ids={}
         )
         assert scene.ngeom == 0
 
@@ -350,8 +350,8 @@ class TestPrimitiveToGeomConversion:
                 )
             ]
         ]
-        self.render_many._append_debug_primitives(
-            scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={"goal.stl": 5}
+        self.render_many.append_debug_primitives(
+            scene, overlays, offsets=None, mesh_ids={"goal.stl": 5}
         )
         assert scene.ngeom == 1
         geom = scene.geoms[0]
@@ -363,8 +363,8 @@ class TestPrimitiveToGeomConversion:
         scene = self._scene()
         overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0), mesh_asset="missing.stl")]]
         with pytest.raises(ValueError, match="missing.stl"):
-            self.render_many._append_debug_primitives(
-                scene, overlays, offsets=None, env_indices=range(1), ghost_mesh_ids={}
+            self.render_many.append_debug_primitives(
+                scene, overlays, offsets=None, mesh_ids={}
             )
 
     def test_ghost_mesh_injection_into_xml_model(self, tmp_path: Path) -> None:
@@ -542,3 +542,222 @@ class TestHeadlessPrimitiveRendering:
 
     def test_tracking_render_with_overlay(self) -> None:
         self._run_render_mode("tracking")
+
+
+class TestAppendDebugPrimitivesPublic:
+    """Public single-callable entry shared by workers and interactive viewers."""
+
+    @pytest.fixture(autouse=True)
+    def _mujoco(self):
+        self.mujoco = pytest.importorskip("mujoco")
+        from unisim.visualization import render_many
+
+        self.render_many = render_many
+        self.model = self.mujoco.MjModel.from_xml_string(
+            "<mujoco><worldbody><geom type='box' size='0.05 0.05 0.05'/></worldbody></mujoco>"
+        )
+
+    def test_single_env_no_offsets_returns_count(self) -> None:
+        scene = self.mujoco.MjvScene(self.model, maxgeom=16)
+        overlays = [
+            [
+                DebugPrimitive(kind="sphere", pos=(0, 0, 0.5), size=(0.05,)),
+                DebugPrimitive(kind="frame", pos=(0, 0, 0), size=(0.1,)),
+                DebugPrimitive(kind="text", pos=(0, 0, 0), text="skip-me"),
+            ]
+        ]
+        added = self.render_many.append_debug_primitives(scene, overlays)
+        assert added == 4  # sphere + 3 frame axes; text is a documented no-op
+        assert scene.ngeom == 4
+
+    def test_none_overlays_injects_nothing(self) -> None:
+        scene = self.mujoco.MjvScene(self.model, maxgeom=16)
+        assert self.render_many.append_debug_primitives(scene, None) == 0
+        assert scene.ngeom == 0
+
+    def test_maxgeom_caps_injection(self) -> None:
+        scene = self.mujoco.MjvScene(self.model, maxgeom=2)
+        overlays = [
+            [
+                DebugPrimitive(kind="sphere", pos=(0, 0, 0), size=(0.05,)),
+                DebugPrimitive(kind="sphere", pos=(0.1, 0, 0), size=(0.05,)),
+                DebugPrimitive(kind="sphere", pos=(0.2, 0, 0), size=(0.05,)),
+            ]
+        ]
+        assert self.render_many.append_debug_primitives(scene, overlays) == 2
+        assert scene.ngeom == 2
+
+    def test_ghost_geom_unregistered_mesh_fails_closed(self) -> None:
+        scene = self.mujoco.MjvScene(self.model, maxgeom=16)
+        overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0), mesh_asset="goal.stl")]]
+        with pytest.raises(ValueError, match="registered in the model"):
+            self.render_many.append_debug_primitives(scene, overlays, mesh_ids={})
+
+
+class TestOnFrameCallback:
+    def test_none_passthrough(self) -> None:
+        from unisim.backend.playback_common import apply_on_frame_callback
+
+        frames = [np.zeros((4, 4, 3), dtype=np.uint8)]
+        assert apply_on_frame_callback(frames, None, backend_label="test") is frames
+
+    def test_replacement_and_keep(self) -> None:
+        from unisim.backend.playback_common import apply_on_frame_callback
+
+        frames = [np.zeros((4, 4, 3), dtype=np.uint8) for _ in range(3)]
+        calls: list[int] = []
+
+        def on_frame(index: int, frame: np.ndarray) -> np.ndarray | None:
+            calls.append(index)
+            if index == 1:
+                return np.full_like(frame, 255)
+            return None
+
+        out = apply_on_frame_callback(frames, on_frame, backend_label="test")
+        assert calls == [0, 1, 2]
+        assert out[0] is frames[0] and out[2] is frames[2]
+        assert out[1].min() == 255
+
+    def test_bad_replacement_fails_closed(self) -> None:
+        from unisim.backend.playback_common import apply_on_frame_callback
+
+        frames = [np.zeros((4, 4, 3), dtype=np.uint8)]
+        with pytest.raises(ValueError, match="on_frame must return None"):
+            apply_on_frame_callback(
+                frames, lambda i, f: np.zeros((2, 2, 3), dtype=np.uint8), backend_label="test"
+            )
+        with pytest.raises(ValueError, match="dtype"):
+            apply_on_frame_callback(
+                frames, lambda i, f: f.astype(np.float32), backend_label="test"
+            )
+
+    @pytest.mark.parametrize(
+        ("module_path", "class_name"),
+        [
+            ("unisim.backend.motrix.backend", "MotrixBackend"),
+            ("unisim.backend.genesis.backend", "GenesisBackend"),
+            ("unisim.backend.subprocess_ipc.backend", "MjcfSubprocessBackend"),
+        ],
+    )
+    def test_native_renderer_backends_fail_closed(
+        self, module_path: str, class_name: str
+    ) -> None:
+        import importlib
+
+        backend_cls = getattr(importlib.import_module(module_path), class_name)
+        backend = backend_cls.__new__(backend_cls)
+        with pytest.raises(NotImplementedError, match="on_frame"):
+            backend.run_playback(
+                env=None,
+                initialize=lambda: None,
+                step=lambda o: o,
+                num_steps=1,
+                on_frame=lambda i, frame: None,
+            )
+
+    def test_mjwarp_interactive_fails_closed_on_on_frame(self) -> None:
+        from unisim.backend.mjwarp.playback import run_mjwarp_playback
+
+        with pytest.raises(NotImplementedError, match="on_frame"):
+            run_mjwarp_playback(
+                backend=None,
+                env=None,
+                initialize=lambda: None,
+                step=lambda o: o,
+                num_steps=1,
+                output_video=None,
+                render_spacing=None,
+                headless=False,
+                record_video=False,
+                snapshot_shape=(1, 2),
+                frame_state_getter=None,
+                camera_kwargs=None,
+                on_frame=lambda i, frame: None,
+            )
+
+    def test_newton_interactive_fails_closed_on_on_frame(self) -> None:
+        from unisim.backend.newton.backend import NewtonBackend
+
+        backend = NewtonBackend.__new__(NewtonBackend)
+        with pytest.raises(NotImplementedError, match="on_frame"):
+            backend.run_playback(
+                env=None,
+                initialize=lambda: None,
+                step=lambda o: o,
+                num_steps=1,
+                headless=False,
+                record_video=False,
+                on_frame=lambda i, frame: None,
+            )
+
+
+class TestOnFrameEndToEnd:
+    """Offline MuJoCo playback applies on_frame before video encoding."""
+
+    _SCRIPT = textwrap.dedent(
+        """
+        import sys
+        from types import SimpleNamespace
+        import imageio.v2 as imageio
+        import numpy as np
+        from unisim.backend.mujoco.playback import run_mujoco_playback
+        from unisim.scene import SceneCfg
+
+        model_path, out_path = sys.argv[1:3]
+        env = SimpleNamespace(
+            cfg=SimpleNamespace(scene=SceneCfg(model_file=model_path), ctrl_dt=0.05)
+        )
+        state = np.array([[0.0, 0.0, 0.0], [0.0, 0.1, 0.0]], dtype=np.float32)
+        calls = []
+
+        def on_frame(index, frame):
+            calls.append(index)
+            assert frame.dtype == np.uint8 and frame.ndim == 3
+            painted = frame.copy()
+            painted[..., 0] = 255
+            return painted
+
+        result = run_mujoco_playback(
+            env=env,
+            initialize=lambda: None,
+            step=lambda obs: obs,
+            num_steps=2,
+            output_video=out_path,
+            render_spacing=1.0,
+            headless=True,
+            record_video=True,
+            frame_state_getter=lambda: state,
+            camera_kwargs=None,
+            on_frame=on_frame,
+        )
+        assert result == out_path
+        assert calls == [0, 1]
+        frames = list(imageio.mimread(out_path))
+        assert len(frames) == 2
+        assert frames[0][..., 0].min() == 255
+        print("ONFRAME-OK")
+        """
+    )
+
+    def test_on_frame_paints_video_frames(self, tmp_path: Path) -> None:
+        pytest.importorskip("mujoco")
+        pytest.importorskip("imageio")
+        from unisim.visualization import render_many
+
+        if not render_many.render_backend_usable():
+            pytest.skip("no usable MuJoCo off-screen GL backend on this host")
+        model_path = tmp_path / "scene.xml"
+        model_path.write_text(TestHeadlessPrimitiveRendering.MODEL)
+        out_path = tmp_path / "play.gif"
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-c", self._SCRIPT, str(model_path), str(out_path)],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        assert result.returncode == 0 and "ONFRAME-OK" in result.stdout, (
+            f"on_frame subprocess failed:\n{result.stdout}\n{result.stderr}"
+        )


### PR DESCRIPTION
## Summary

Follow-up to #53 (merged at a49d1c2) closing the upstream gaps found by the downstream UniLab child (Motphys/UniLab#1548). Roadmap: unilabsim/wuji_unilab#21.

1. **Public primitive-injection entry for interactive viewers** — `unisim.visualization.render_many.append_debug_primitives(scene, overlays, *, offsets=None, mesh_ids=None) -> int` is now the single conversion implementation shared by the offline render workers and interactive viewers. Single-env `mujoco.viewer.launch_passive` callers inject into `viewer.user_scn` with `overlays=[primitives]`, `offsets=None`; the return value is the injected geom count. Interactive `ghost_geom` meshes must already be registered in the loaded model (resolve with `mj_name2id`, pass via `mesh_ids`); unresolved assets fail closed with `ValueError` since the interactive path cannot recompile the model — documented in the docstring. The worker grid path and the tracking path (sliced env subset) call the same function, so the two paths cannot drift.

2. **`run_playback(..., on_frame=...)`** — `on_frame: Callable[[int, np.ndarray], np.ndarray | None] | None`. The offline MuJoCo snapshot pipeline (mujoco, mjwarp, drake, newton, superdex) calls it with each `(H, W, 3)` uint8 frame before video encoding; a returned replacement must match the frame's shape/dtype (validated fail-closed in `playback_common.apply_on_frame_callback`) and `None` keeps the original. Native-renderer backends (motrix, genesis, subprocess IPC / isaacgym / isaacsim) and the newton/mjwarp interactive paths fail closed with `NotImplementedError`; newton record playback with `on_frame` routes to the offline snapshot renderer, matching the existing debug-overlay routing.

3. **mjwarp interactive playback consumes `debug_overlay_getter`** (fixes the regression where #53 left the interactive path fail-closed) — the passive-viewer loop injects the tracked world's primitives into `viewer.user_scn` before each `sync()`, resetting `ngeom` first (sync does not clear user geoms) and resolving `ghost_geom` meshes against the playback model with a per-run `mesh_ids` cache (fail-closed `ValueError` when unregistered). `BackendPlayCapabilities` gains `supports_interactive_debug_overlay: bool = False`; mjwarp reports True, every other backend keeps False so callers can tell whether the interactive path consumes the getter. `render_many` stays a lazy import inside the injection helper so `MUJOCO_GL` probing cannot disturb the glfw interactive window. The interactive `on_frame` hook remains fail-closed.

## Backend/platform impact

- Additive on top of #53's contract: one new capability bit (default False), one previously-raising path now supported; no new breaking changes.
- UniLab's interactive overlay path can now call `append_debug_primitives` directly, or simply pass `debug_overlay_getter` to mjwarp interactive playback.
- No new dependencies; base wheel remains NumPy-only.

## Verification

- `make check` on head `0168a27`: **227 passed, 31 skipped** (`ruff check` clean).
- New/updated tests in `tests/test_debug_overlay.py`: public helper count/offsets/maxgeom-cap/ghost fail-closed, `apply_on_frame_callback` passthrough/replace/contract errors, fail-closed `run_playback` on motrix/genesis/subprocess + mjwarp/newton interactive `on_frame`, a subprocess E2E painting video frames via `on_frame` (skips without imageio/GL), capability-bit assertions (default False, mjwarp-only True), GL-free unit tests for `_inject_interactive_debug_overlays` (world slicing, `ngeom` reset semantics, ghost mesh resolution/caching, unregistered-mesh fail-closed), and a DISPLAY-guard regression proving the interactive overlay getter now passes through.
- CHANGELOG `Unreleased` updated for all three items.
