### PR TITLE
fix(render): offset mocap bodies with the multi-env render grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Fix:** multi-env grid rendering in `render_many.render_frame_job` now
+  translates mocap bodies with the environment. Worker `MjData` is reused
+  across frames, so `init_worker` caches cold-path `mocap_pos` defaults and
+  `set_state` resets from them before adding the grid offset; mocap bodies
+  are excluded from the legacy `geom_xpos`/`site_xpos` post-shift so the two
+  mechanisms cannot double the offset. Previously, models whose first body
+  has a free joint (e.g. the Wuji in-hand scene: free-joint cube plus mocap
+  palm) rendered every env's mocap-driven geometry stacked at env 0,
+  misaligned with both the free-joint objects and the debug overlay
+  primitives, which already receive the offset exactly once
+  (unilabsim/wuji_unilab#21).
+
 - **Breaking:** replace `run_playback(..., extra_data_getter=...)` with
   `debug_overlay_getter`. The new callback returns per-frame, per-env
   sequences of typed `DebugPrimitive` values (`sphere`, `box`, `frame`,

--- a/src/unisim/visualization/render_many.py
+++ b/src/unisim/visualization/render_many.py
@@ -469,6 +469,7 @@ def init_worker(model_path, shape, cam_fov=None, ghost_mesh_map=None):
 
     _worker_ctx["models"] = models
     _worker_ctx["data_list"] = [mujoco.MjData(model) for model in models]
+    _worker_ctx["mocap_defaults"] = [data.mocap_pos.copy() for data in _worker_ctx["data_list"]]
     _worker_ctx["terrain_geom_indices"] = [_replicable_terrain_geom_indices(m) for m in models]
     _worker_ctx["ghost_mesh_ids"] = ghost_mesh_ids
     _worker_ctx["renderer"] = mujoco.Renderer(models[0], height=shape[1], width=shape[0])
@@ -516,6 +517,15 @@ def render_frame_job(args):
         apply_root_offset = False
 
         if offset is not None:
+            # Mocap bodies are independent from qpos; translate them with
+            # the environment so mocap-driven geometry (e.g. a mocap palm)
+            # stays aligned in multi-env renders. Reset from the cold-path
+            # defaults first: worker MjData is reused for every frame.
+            if getattr(model, "nmocap", 0):
+                model_idx = next(i for i, item in enumerate(data_list) if item is d)
+                d.mocap_pos[:] = _worker_ctx["mocap_defaults"][model_idx]
+                d.mocap_pos[:, 0] += offset[0]
+                d.mocap_pos[:, 1] += offset[1]
             # Check if Root (Body 1) has a free joint or slide joints allowing X/Y movement
             # Body 0 is world. Body 1 is usually the robot base.
             robot_moved = False
@@ -568,6 +578,11 @@ def render_frame_job(args):
             qpos_shifted_bodies = set(shifted_body_ids)
             if target_body_id >= 0:
                 qpos_shifted_bodies.add(target_body_id)
+            # Mocap bodies already carry the grid offset via mocap_pos above;
+            # shifting their geom/site xpos again would double the offset.
+            qpos_shifted_bodies.update(
+                int(body_id) for body_id in np.flatnonzero(model.body_mocapid >= 0)
+            )
 
             for i in range(model.ngeom):
                 body_id = model.geom_bodyid[i]

--- a/tests/test_render_many.py
+++ b/tests/test_render_many.py
@@ -1,0 +1,163 @@
+"""Headless regression tests for multi-env grid offsets in render_many."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Free-joint object as body 1 (apply_root_offset=False) plus a mocap palm
+# with an articulated finger, mirroring the Wuji playback model.
+WUJI_LIKE_XML = """<mujoco>
+  <worldbody>
+    <geom name='floor' type='plane' size='5 5 0.1'/>
+    <body name='object/cube' pos='0.3 0.1 0.55'>
+      <joint name='cube_free' type='free'/>
+      <geom name='cube' type='box' size='0.04 0.04 0.04' rgba='0 0 1 1'/>
+    </body>
+    <body name='robot/palm' mocap='true' pos='0 0 0.5'>
+      <geom name='palm' type='box' size='0.05 0.05 0.02' rgba='1 0 0 1'/>
+      <body name='finger' pos='0 0 0.05'>
+        <joint name='hinge' type='hinge' axis='0 1 0'/>
+        <geom name='finger' type='box' size='0.02 0.02 0.02' rgba='0 1 0 1'/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# Fixed-root robot as body 1 (apply_root_offset=True) plus a mocap goal body;
+# the base geom uses group 1 so the no-terrain static pass still draws it.
+FIXED_ROOT_XML = """<mujoco>
+  <worldbody>
+    <geom name='floor' type='plane' size='5 5 0.1'/>
+    <body name='robot/base' pos='0.1 0.2 0.3'>
+      <geom name='base' type='box' size='0.03 0.03 0.03' rgba='0 0 1 1' group='1'/>
+      <body name='finger' pos='0 0 0.1'>
+        <joint name='hinge' type='hinge' axis='0 1 0'/>
+        <geom name='finger' type='box' size='0.02 0.02 0.02' rgba='0 1 0 1'/>
+      </body>
+    </body>
+    <body name='goal' mocap='true' pos='0.5 0.5 0.1'>
+      <geom name='goal' type='sphere' size='0.02' rgba='1 0 0 1'/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import numpy as np
+    import mujoco
+    from unisim.backend.base import DebugPrimitive
+    from unisim.visualization import render_many
+
+    model_path, mode = sys.argv[1:3]
+    model = mujoco.MjModel.from_xml_path(model_path)
+    data = mujoco.MjData(model)
+    mujoco.mj_resetData(model, data)
+    states = np.zeros((2, 1 + model.nq + model.nv))
+    for env in range(2):
+        states[env, 1 : 1 + model.nq] = data.qpos
+    offsets = np.array([[0.0, 0.0], [2.0, 3.0]])
+    overlays = None
+    if mode == "wuji":
+        overlays = [
+            None,
+            [DebugPrimitive(
+                kind="sphere", pos=(0, 0, 0.5), size=(0.05,), rgba=(1.0, 0.0, 1.0, 1.0)
+            )],
+        ]
+
+    render_many.init_worker(model_path, (160, 120))
+    try:
+        render_frame_job = render_many.render_frame_job
+        render_frame_job((states, offsets, False, 6.0, -30.0, 90.0, None, overlays))
+        scene = render_many._worker_ctx["renderer"].scene
+        for geom in list(scene.geoms)[: scene.ngeom]:
+            print(
+                "GEOM",
+                *(round(float(c), 4) for c in geom.rgba[:3]),
+                *(round(float(p), 4) for p in geom.pos),
+            )
+    finally:
+        render_many._close_worker()
+    """
+)
+
+
+def _parse_scene_geoms(stdout: str) -> dict[tuple[float, ...], list[np.ndarray]]:
+    geoms: dict[tuple[float, ...], list[np.ndarray]] = {}
+    for line in stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 7 and parts[0] == "GEOM":
+            rgba = tuple(float(v) for v in parts[1:4])
+            geoms.setdefault(rgba, []).append(np.array([float(v) for v in parts[4:7]]))
+    for positions in geoms.values():
+        positions.sort(key=lambda p: p[0] + p[1])
+    return geoms
+
+
+class TestMultiEnvGridOffsets:
+    """Multi-env grid rendering offsets env geometry exactly once."""
+
+    @pytest.fixture(autouse=True)
+    def _render(self, tmp_path: Path):
+        pytest.importorskip("mujoco")
+        from unisim.visualization import render_many
+
+        if not render_many.render_backend_usable():
+            pytest.skip("no usable MuJoCo off-screen GL backend on this host")
+        self._tmp_path = tmp_path
+
+    def _scene_geoms(
+        self, xml: str, mode: str
+    ) -> dict[tuple[float, ...], list[np.ndarray]]:
+        model_path = self._tmp_path / f"{mode}.xml"
+        model_path.write_text(xml)
+        result = subprocess.run(
+            [sys.executable, "-c", _SCRIPT, str(model_path), mode],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f"render subprocess failed:\n{result.stdout}\n{result.stderr}"
+        )
+        return _parse_scene_geoms(result.stdout)
+
+    def test_mocap_palm_follows_grid_with_freejoint_object(self) -> None:
+        geoms = self._scene_geoms(WUJI_LIKE_XML, "wuji")
+        # Free-joint cube moved via qpos; mocap palm and its articulated
+        # finger must follow the same grid cell exactly once.
+        np.testing.assert_allclose(
+            geoms[(0.0, 0.0, 1.0)], [[0.3, 0.1, 0.55], [2.3, 3.1, 0.55]], atol=1e-4
+        )
+        np.testing.assert_allclose(
+            geoms[(1.0, 0.0, 0.0)], [[0.0, 0.0, 0.5], [2.0, 3.0, 0.5]], atol=1e-4
+        )
+        np.testing.assert_allclose(
+            geoms[(0.0, 1.0, 0.0)], [[0.0, 0.0, 0.55], [2.0, 3.0, 0.55]], atol=1e-4
+        )
+        # Overlay primitives (env-local poses) land on the same grid offset
+        # as the env geometry: the env-1 marker coincides with the palm.
+        np.testing.assert_allclose(geoms[(1.0, 0.0, 1.0)], [[2.0, 3.0, 0.5]], atol=1e-4)
+
+    def test_fixed_root_robot_and_mocap_goal_offset_exactly_once(self) -> None:
+        geoms = self._scene_geoms(FIXED_ROOT_XML, "fixedroot")
+        np.testing.assert_allclose(
+            geoms[(0.0, 0.0, 1.0)], [[0.1, 0.2, 0.3], [2.1, 3.2, 0.3]], atol=1e-4
+        )
+        np.testing.assert_allclose(
+            geoms[(0.0, 1.0, 0.0)], [[0.1, 0.2, 0.4], [2.1, 3.2, 0.4]], atol=1e-4
+        )
+        # The mocap goal is translated via mocap_pos, not the geom_xpos
+        # post-shift; both mechanisms together would double the offset.
+        np.testing.assert_allclose(
+            geoms[(1.0, 0.0, 0.0)], [[0.5, 0.5, 0.1], [2.5, 3.5, 0.1]], atol=1e-4
+        )


### PR DESCRIPTION
## Summary

Ports the surviving multi-env off-screen rendering fix from `feat/mjwarp-interactive` (everything else on that branch was either merged via #50 or canceled by its own Revert). Roadmap: unilabsim/wuji_unilab#21.

**Bug:** in multi-env grid recording (`render_many.render_frame_job`), mocap bodies are driven by `mocap_pos`, not `qpos`. When the model's first body has a free joint (e.g. the Wuji in-hand scene: free-joint cube + mocap palm + articulated fingers), the legacy `geom_xpos` post-shift never runs, so every env's mocap-driven geometry rendered stacked at env 0 — misaligned with the free-joint objects and with debug overlay primitives (which receive the grid offset exactly once via `append_debug_primitives`).

**Fix** (adapted cherry-pick of `a159eff` + `64f4226`):

- `init_worker` caches cold-path `mocap_pos` defaults; `set_state` resets `mocap_pos` from those defaults before adding the grid offset, because worker `MjData` is reused across frames (source of the original per-frame drift).
- Mocap bodies are excluded from the legacy `geom_xpos`/`site_xpos` post-shift (`qpos_shifted_bodies`), so the new mocap mechanism and the legacy one cannot double the offset when both run (`apply_root_offset=True` path).

## Adaptation note — why 3d6c6f6 is not ported

The branch's third commit shifted `scene.geom.pos` directly after `mjv_addGeoms`, based on the premise that `mjv_addGeoms` derives geom poses from body transforms and ignores `data.geom_xpos`. On the pinned mujoco 3.11.0 (and 3.10.0) this premise does not hold — `mjv_addGeoms` honors `geom_xpos`/`mocap_pos` updates (verified empirically). Porting that post-pass verbatim makes **every** env geom land at 2× the grid offset (free-joint cube: qpos shift + scene shift; mocap palm: mocap offset + scene shift), which would also desync env geometry from overlay primitives. With the mocap fix alone, all geometry lands at exactly 1× the grid offset; the new regression tests assert exact scene-geom positions for both the free-joint-object (`apply_root_offset=False`) and fixed-root (`apply_root_offset=True`) scenarios, plus overlay/env-geometry offset consistency.

## Verification

- `make check` on head `fad2a58`: **228 passed, 13 skipped** (ruff clean; env synced to locked mujoco 3.11.0).
- New `tests/test_render_many.py` (headless subprocess pattern, skips without a GL backend): `test_mocap_palm_follows_grid_with_freejoint_object` **fails on main** (palm renders at env 0) and passes here; `test_fixed_root_robot_and_mocap_goal_offset_exactly_once` guards the double-shift regression.
- Empirical scene inspection of a Wuji-faithful model (free-joint cube, mocap palm, articulated finger): env 1 cube/palm/finger all land at base + offset exactly once; debug overlay marker at env-local palm pos coincides with the rendered palm.
- CHANGELOG `Unreleased` updated.

## Known boundaries (unchanged by this PR)

- `render_frame_tracking_job` has its own `set_state` copy with the same mocap limitation; the source branch did not touch it, so this PR doesn't either.
- In models with no replicable terrain, group-0 static worldbody geoms (e.g. a fixed-root robot's base geoms in the default group) are still skipped for envs ≥ 1 to avoid duplicate floor draws — pre-existing behavior on both main and the source branch.
