### PR TITLE
fix(playback): replay mocap state, texture ghost overlays, auto-fit grid camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+- **Breaking (snapshot layout):** `mjwarp` `get_physics_state` snapshots now
+  append `[mocap_pos(nmocap*3), mocap_quat(nmocap*4)]` after
+  `[time, qpos, qvel]` when the model has mocap bodies, and
+  `run_playback_mode` declares the extended `snapshot_shape`. The offline
+  render workers (`render_many`) replay the recorded mocap pose instead of
+  resetting mocap bodies to the model defaults, fixing record-mode videos
+  where mocap-driven geometry (e.g. the Wuji mocap palm, whose wrist pitch is
+  randomized at reset) rendered misaligned with — and interpenetrating — the
+  free-joint objects. Legacy `[time, qpos, qvel]` snapshots keep the previous
+  defaults-plus-grid-offset fallback. `validate_offline_visual_model` now also
+  requires `nmocap` parity between the physics and visual models.
+
+- **Fix:** `ghost_geom` debug overlays now inherit the material (with mesh UV
+  texturing) of the model geom that renders the same mesh, in both the
+  offline render workers and the mjwarp interactive viewer, matching the
+  source task's textured goal indicator. `append_debug_primitives` gains an
+  optional `mesh_materials` mapping; assets without a textured model geom
+  keep the flat primitive rgba.
+
+- **Fix:** multi-env grid recording without an explicit `cam_lookat` widens
+  `cam_distance` so every grid cell fits the frame (`render_many`
+  `_grid_fit_distance`, from the grid span, fovy, and frame aspect ratio).
+  An explicit `cam_lookat` still pins the camera to a single env.
+
 - **Fix:** multi-env grid rendering in `render_many.render_frame_job` now
   translates mocap bodies with the environment. Worker `MjData` is reused
   across frames, so `init_worker` caches cold-path `mocap_pos` defaults and

--- a/src/unisim/backend/base.py
+++ b/src/unisim/backend/base.py
@@ -1109,7 +1109,13 @@ class SimBackend(abc.ABC):
         )
 
     def get_physics_state(self) -> np.ndarray:
-        """Return a physics snapshot suitable for offline playback/video export."""
+        """Return a physics snapshot suitable for offline playback/video export.
+
+        Rows use the ``[time, qpos, qvel]`` layout; backends whose model has
+        mocap bodies append ``[mocap_pos(nmocap*3), mocap_quat(nmocap*4)]`` so
+        offline rendering can replay mocap-driven geometry at its recorded
+        pose.
+        """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support physics-state playback"
         )

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -264,6 +264,7 @@ class MjwarpBackend(SimBackend):
         self._geom_bounds = PrimitiveGeomBounds(self._cpu_model.geom_type, deps.mujoco.mjtGeom)
         mocap_bodies = np.flatnonzero(self._cpu_model.body_mocapid >= 0)
         mocap_bodies = mocap_bodies[np.argsort(self._cpu_model.body_mocapid[mocap_bodies])]
+        self._nmocap = len(mocap_bodies)
         self._default_mocap_pos = self._cpu_model.body_pos[mocap_bodies].astype(np.float32)
         self._default_mocap_quat = self._cpu_model.body_quat[mocap_bodies].astype(np.float32)
         self._mocap_pos = np.broadcast_to(
@@ -1776,7 +1777,7 @@ class MjwarpBackend(SimBackend):
             render_spacing=render_spacing,
             headless=should_run_headless,
             record_video=should_record,
-            snapshot_shape=(self._num_envs, 1 + self._nq + self._nv),
+            snapshot_shape=(self._num_envs, 1 + self._nq + self._nv + 7 * self._nmocap),
             frame_state_getter=frame_state_getter,
             camera_kwargs=camera,
             debug_overlay_getter=debug_overlay_getter,
@@ -1784,10 +1785,21 @@ class MjwarpBackend(SimBackend):
         )
 
     def get_physics_state(self) -> np.ndarray:
-        state = np.empty((self._num_envs, 1 + self._nq + self._nv), dtype=np.float32)
+        # Layout: [time, qpos, qvel] plus, when the model has mocap bodies,
+        # [mocap_pos(nmocap*3), mocap_quat(nmocap*4)] so offline playback can
+        # replay mocap-driven geometry (e.g. a mocap palm) at its recorded
+        # pose instead of the model defaults.
+        nstate = 1 + self._nq + self._nv + 7 * self._nmocap
+        state = np.empty((self._num_envs, nstate), dtype=np.float32)
         state[:, 0] = self._time_cache
         state[:, 1 : 1 + self._nq] = self._qpos_cache
-        state[:, 1 + self._nq :] = self._qvel_cache
+        state[:, 1 + self._nq : 1 + self._nq + self._nv] = self._qvel_cache
+        if self._nmocap:
+            base = 1 + self._nq + self._nv
+            state[:, base : base + 3 * self._nmocap] = self._mocap_pos.reshape(
+                self._num_envs, -1
+            )
+            state[:, base + 3 * self._nmocap :] = self._mocap_quat.reshape(self._num_envs, -1)
         return state
 
     def get_playback_mocap_state(self, env_index: int = 0) -> tuple[np.ndarray, np.ndarray]:

--- a/src/unisim/backend/mjwarp/playback.py
+++ b/src/unisim/backend/mjwarp/playback.py
@@ -99,6 +99,7 @@ def _inject_interactive_debug_overlays(
     num_envs: int,
     model: Any,
     mesh_id_cache: dict[str, int],
+    mesh_mat_cache: dict[str, int],
 ) -> int:
     """Inject this frame's debug primitives into the passive viewer scene.
 
@@ -108,7 +109,7 @@ def _inject_interactive_debug_overlays(
     """
     import mujoco
 
-    from unisim.visualization.render_many import append_debug_primitives
+    from unisim.visualization.render_many import _ghost_material_ids, append_debug_primitives
 
     validated = validate_debug_overlays(overlays, num_envs)
     user_scn.ngeom = 0
@@ -127,8 +128,16 @@ def _inject_interactive_debug_overlays(
                     "be injected from files (see append_debug_primitives)"
                 )
             mesh_id_cache[primitive.mesh_asset] = int(mesh_id)
+            # Inherit the textured material of the model geom rendering the
+            # same mesh (e.g. the goal cube's sticker texture); assets without
+            # one keep the flat primitive rgba.
+            mesh_mat_cache.update(_ghost_material_ids(model, mesh_id_cache))
     return append_debug_primitives(
-        user_scn, [env_primitives], offsets=None, mesh_ids=mesh_id_cache
+        user_scn,
+        [env_primitives],
+        offsets=None,
+        mesh_ids=mesh_id_cache,
+        mesh_materials=mesh_mat_cache,
     )
 
 
@@ -174,8 +183,8 @@ def _run_interactive(
         if state.shape != snapshot_shape:
             raise ValueError(f"mjwarp interactive snapshot must have shape {snapshot_shape}.")
         data.time = float(state[world, 0])
-        data.qpos[:] = state[world, 1:1 + model.nq]
-        data.qvel[:] = state[world, 1 + model.nq:]
+        data.qpos[:] = state[world, 1 : 1 + model.nq]
+        data.qvel[:] = state[world, 1 + model.nq : 1 + model.nq + model.nv]
         mocap_pos, mocap_quat = backend.get_playback_mocap_state(world)
         data.mocap_pos[:] = mocap_pos
         data.mocap_quat[:] = mocap_quat
@@ -192,6 +201,7 @@ def _run_interactive(
         ) from exc
     with viewer:
         mesh_id_cache: dict[str, int] = {}
+        mesh_mat_cache: dict[str, int] = {}
         if debug_overlay_getter is not None and viewer.user_scn is None:
             raise RuntimeError(
                 "mjwarp interactive debug overlays require viewer.user_scn support."
@@ -215,6 +225,7 @@ def _run_interactive(
                         num_envs=snapshot_shape[0],
                         model=model,
                         mesh_id_cache=mesh_id_cache,
+                        mesh_mat_cache=mesh_mat_cache,
                     )
             viewer.sync()
             count += 1

--- a/src/unisim/backend/playback_common.py
+++ b/src/unisim/backend/playback_common.py
@@ -98,6 +98,12 @@ def validate_offline_visual_model(
             f"{backend_label} offline playback visual model state dimensions are incompatible: "
             f"physics nq/nv={physics_dims}, visual nq/nv={visual_dims}."
         )
+    if int(visual_model.nmocap) != int(physics_model.nmocap):
+        raise ValueError(
+            f"{backend_label} offline playback visual model mocap layout is incompatible: "
+            f"physics nmocap={int(physics_model.nmocap)}, "
+            f"visual nmocap={int(visual_model.nmocap)}."
+        )
 
     joint_object = mujoco.mjtObj.mjOBJ_JOINT
 
@@ -180,8 +186,9 @@ def run_offline_snapshot_playback(
         state = np.asarray(getter(), dtype=np.float32)
         if state.shape != expected_shape:
             raise ValueError(
-                f"{backend_label} offline playback snapshot must use [time, qpos, qvel] layout "
-                f"with shape {expected_shape}, got {state.shape}."
+                f"{backend_label} offline playback snapshot must use the "
+                f"[time, qpos, qvel, (mocap_pos, mocap_quat)?] layout with shape "
+                f"{expected_shape}, got {state.shape}."
             )
         return state
 

--- a/src/unisim/visualization/render_many.py
+++ b/src/unisim/visualization/render_many.py
@@ -225,6 +225,140 @@ def _replicable_terrain_geom_indices(model) -> np.ndarray:
     return np.asarray(indices, dtype=np.int64)
 
 
+def _set_worker_state(model, d, s, offset, mocap_defaults):
+    """Load one snapshot row into a worker ``MjData`` and apply the grid offset.
+
+    Snapshot rows use the ``[time, qpos, qvel]`` layout with an optional
+    ``[mocap_pos, mocap_quat]`` tail (7 floats per mocap body) so mocap-driven
+    geometry (e.g. a mocap palm) replays its recorded pose.  Legacy snapshots
+    without the tail fall back to the model-default mocap pose.
+    """
+    d.time = s[0]
+    d.qpos[:] = s[1 : 1 + model.nq]
+    d.qvel[:] = s[1 + model.nq : 1 + model.nq + model.nv]
+
+    nmocap = int(getattr(model, "nmocap", 0))
+    base = 1 + model.nq + model.nv
+    if nmocap and s.shape[0] == base + 7 * nmocap:
+        tail = np.asarray(s[base:], dtype=np.float64)
+        d.mocap_pos[:] = tail[: 3 * nmocap].reshape(nmocap, 3)
+        d.mocap_quat[:] = tail[3 * nmocap :].reshape(nmocap, 4)
+    elif nmocap and offset is not None and mocap_defaults is not None:
+        # Reset from the cold-path defaults first: worker MjData is reused for
+        # every frame.
+        d.mocap_pos[:] = mocap_defaults
+    if nmocap and offset is not None:
+        # Mocap bodies are independent from qpos; translate them with the
+        # environment so mocap-driven geometry stays aligned in multi-env
+        # renders.
+        d.mocap_pos[:, 0] += offset[0]
+        d.mocap_pos[:, 1] += offset[1]
+
+    apply_root_offset = False
+    shifted_body_ids: set[int] = set()
+
+    if offset is not None:
+        # Check if Root (Body 1) has a free joint or slide joints allowing X/Y movement
+        # Body 0 is world. Body 1 is usually the robot base.
+        robot_moved = False
+
+        # Better check: Does the first body have a joint?
+        first_body_jnt = model.body_jntadr[1] if model.nbody > 1 else -1
+        if first_body_jnt >= 0:
+            jnt_type = model.jnt_type[first_body_jnt]
+            # mjJNT_FREE=0
+            if jnt_type == 0:
+                d.qpos[0] += offset[0]
+                d.qpos[1] += offset[1]
+                robot_moved = True
+
+        # If robot wasn't moved via qpos, we need to manually offset geometries later
+        if not robot_moved:
+            apply_root_offset = True
+
+        # 2. Offset any independent freejoint objects (e.g. box, largebox)
+        shifted_body_ids = _offset_freejoint_object_qpos(model, d, offset)
+
+        # 3. Target offset (target_x, target_y)
+        target_x = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_x")
+        if target_x >= 0:
+            d.qpos[model.jnt_qposadr[target_x]] += offset[0]
+
+        target_y = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_y")
+        if target_y >= 0:
+            d.qpos[model.jnt_qposadr[target_y]] += offset[1]
+
+    mujoco.mj_forward(model, d)
+
+    # Post-process: Shift all geometries if robot root wasn't moved
+    if apply_root_offset and offset is not None:
+        # Box and Target were already shifted via qpos; shifting ALL geom_pos
+        # would double shift them, so only geoms/sites of bodies that were not
+        # qpos-shifted are moved here.
+        target_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "mocap_target")
+        qpos_shifted_bodies = set(shifted_body_ids)
+        if target_body_id >= 0:
+            qpos_shifted_bodies.add(target_body_id)
+        # Mocap bodies already carry the grid offset via mocap_pos above;
+        # shifting their geom/site xpos again would double the offset.
+        qpos_shifted_bodies.update(
+            int(body_id) for body_id in np.flatnonzero(model.body_mocapid >= 0)
+        )
+
+        for i in range(model.ngeom):
+            body_id = model.geom_bodyid[i]
+            is_already_shifted = body_id in qpos_shifted_bodies
+            is_plane = model.geom_type[i] == mujoco.mjtGeom.mjGEOM_PLANE
+
+            if not is_already_shifted and not is_plane:
+                d.geom_xpos[i, 0] += offset[0]
+                d.geom_xpos[i, 1] += offset[1]
+
+        for i in range(model.nsite):
+            body_id = model.site_bodyid[i]
+            is_already_shifted = body_id in qpos_shifted_bodies
+            if not is_already_shifted:
+                d.site_xpos[i, 0] += offset[0]
+                d.site_xpos[i, 1] += offset[1]
+
+
+def _grid_fit_distance(offsets, model, shape, margin=0.5):
+    """Distance at which the free camera frames the whole env grid.
+
+    The vertical field of view and the frame aspect ratio bound the visible
+    patch; the grid span plus a per-env margin must fit inside it.  Used as a
+    lower bound for ``cam_distance`` when no explicit ``cam_lookat`` pins the
+    camera to a single env.
+    """
+    width, height = shape
+    fovy = math.radians(float(model.vis.global_.fovy))
+    half_tan = math.tan(fovy / 2.0)
+    aspect = max(float(width) / float(height), 1e-6)
+    span_x = float(np.ptp(offsets[:, 0]))
+    span_y = float(np.ptp(offsets[:, 1]))
+    need_h = span_y / 2.0 + margin
+    need_w = span_x / 2.0 + margin
+    return max(need_h / half_tan, need_w / (half_tan * aspect))
+
+
+def _ghost_material_ids(model, ghost_mesh_ids):
+    """Map each ghost mesh asset to the material of a model geom using that mesh.
+
+    Ghost overlays inherit the textured material (e.g. a cube's sticker
+    texture) from the real geom that already renders the same mesh; assets
+    without a textured model geom keep the flat primitive rgba.
+    """
+    mat_ids: dict[str, int] = {}
+    mesh_type = int(mujoco.mjtGeom.mjGEOM_MESH)
+    mesh_geoms = np.flatnonzero(model.geom_type == mesh_type)
+    for asset, mesh_id in ghost_mesh_ids.items():
+        for geom_id in mesh_geoms:
+            if int(model.geom_dataid[geom_id]) == mesh_id and int(model.geom_matid[geom_id]) >= 0:
+                mat_ids[asset] = int(model.geom_matid[geom_id])
+                break
+    return mat_ids
+
+
 def _collect_ghost_mesh_assets(debug_overlays_list) -> list[str]:
     """Collect unique ``ghost_geom`` mesh asset keys across all frames."""
     assets: set[str] = set()
@@ -293,11 +427,16 @@ def _inject_ghost_mesh_assets(model_path, ghost_assets, tmp_dir):
     return result, name_map
 
 
-def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, mesh_ids) -> int:
+def _append_primitive(
+    scene, primitive: DebugPrimitive, offset_xy, mesh_ids, mesh_materials=None
+) -> int:
     """Convert one :class:`DebugPrimitive` into user-scene geoms (env-local pos).
 
-    Returns the number of geoms injected (0 for the documented text no-op or
-    when ``scene.maxgeom`` is exhausted mid-frame).
+    ``mesh_materials`` optionally maps ``ghost_geom`` ``mesh_asset`` keys to
+    material ids in the model that owns this scene; a resolved material binds
+    the mesh's texture to the ghost geom.  Returns the number of geoms
+    injected (0 for the documented text no-op or when ``scene.maxgeom`` is
+    exhausted mid-frame).
     """
     pos = np.array(primitive.pos, dtype=np.float64)
     if offset_xy is not None:
@@ -355,6 +494,12 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, mesh_ids) -> 
             rgba=rgba,
         )
         geom.dataid = mesh_id
+        matid = (mesh_materials or {}).get(primitive.mesh_asset, -1)
+        if matid >= 0:
+            # Bind the inherited material (e.g. a cube's sticker texture);
+            # texcoord enables the mesh's UV coordinates for texturing.
+            geom.matid = matid
+            geom.texcoord = 1
         scene.ngeom += 1
         return 1
     if kind in ("frame", "arrow"):
@@ -390,7 +535,9 @@ def _append_primitive(scene, primitive: DebugPrimitive, offset_xy, mesh_ids) -> 
     return 0
 
 
-def append_debug_primitives(scene, overlays, *, offsets=None, mesh_ids=None) -> int:
+def append_debug_primitives(
+    scene, overlays, *, offsets=None, mesh_ids=None, mesh_materials=None
+) -> int:
     """Inject per-env :class:`DebugPrimitive` overlays into a caller-owned scene.
 
     This is the single conversion implementation shared by the offline render
@@ -408,7 +555,9 @@ def append_debug_primitives(scene, overlays, *, offsets=None, mesh_ids=None) -> 
     (which can inject mesh files into a recompiled render model), an
     interactive viewer cannot be recompiled, so ghost meshes must already be
     registered in the loaded model; unresolved assets fail closed with
-    ``ValueError``.
+    ``ValueError``.  ``mesh_materials`` optionally maps the same keys to
+    material ids so ghost meshes render with their textured material instead
+    of the flat primitive rgba.
 
     The caller owns the scene's capacity (``maxgeom``) and must reset
     ``scene.ngeom`` between frames.  Returns the number of geoms injected.
@@ -424,7 +573,9 @@ def append_debug_primitives(scene, overlays, *, offsets=None, mesh_ids=None) -> 
         for primitive in env_primitives:
             if scene.ngeom >= scene.maxgeom:
                 return added
-            added += _append_primitive(scene, primitive, offset_xy, resolved_mesh_ids)
+            added += _append_primitive(
+                scene, primitive, offset_xy, resolved_mesh_ids, mesh_materials
+            )
     return added
 
 
@@ -472,6 +623,8 @@ def init_worker(model_path, shape, cam_fov=None, ghost_mesh_map=None):
     _worker_ctx["mocap_defaults"] = [data.mocap_pos.copy() for data in _worker_ctx["data_list"]]
     _worker_ctx["terrain_geom_indices"] = [_replicable_terrain_geom_indices(m) for m in models]
     _worker_ctx["ghost_mesh_ids"] = ghost_mesh_ids
+    _worker_ctx["ghost_mat_ids"] = _ghost_material_ids(models[0], ghost_mesh_ids)
+    _worker_ctx["shape"] = shape
     _worker_ctx["renderer"] = mujoco.Renderer(models[0], height=shape[1], width=shape[0])
     atexit.register(_close_worker)
 
@@ -508,97 +661,11 @@ def render_frame_job(args):
     catmask_dynamic = mujoco.mjtCatBit.mjCAT_DYNAMIC
     catmask_static = mujoco.mjtCatBit.mjCAT_STATIC
 
-    # Helper to set state
+    # Helper to set state; resolves the per-model mocap defaults for the
+    # legacy-snapshot fallback inside _set_worker_state.
     def set_state(model, d, s, offset=None):
-        d.time = s[0]
-        d.qpos[:] = s[1 : 1 + model.nq]
-        d.qvel[:] = s[1 + model.nq : 1 + model.nq + model.nv]
-
-        apply_root_offset = False
-
-        if offset is not None:
-            # Mocap bodies are independent from qpos; translate them with
-            # the environment so mocap-driven geometry (e.g. a mocap palm)
-            # stays aligned in multi-env renders. Reset from the cold-path
-            # defaults first: worker MjData is reused for every frame.
-            if getattr(model, "nmocap", 0):
-                model_idx = next(i for i, item in enumerate(data_list) if item is d)
-                d.mocap_pos[:] = _worker_ctx["mocap_defaults"][model_idx]
-                d.mocap_pos[:, 0] += offset[0]
-                d.mocap_pos[:, 1] += offset[1]
-            # Check if Root (Body 1) has a free joint or slide joints allowing X/Y movement
-            # Body 0 is world. Body 1 is usually the robot base.
-            robot_moved = False
-
-            # Heuristic: Check joint at qpos 0, 1.
-            # If jnt_type[0] is free (0), fine.
-            # If jnt_type[0] is slide (2) and axis is x/y...
-
-            # Better check: Does the first body have a joint?
-            first_body_jnt = model.body_jntadr[1] if model.nbody > 1 else -1
-            if first_body_jnt >= 0:
-                jnt_type = model.jnt_type[first_body_jnt]
-                # mjJNT_FREE=0
-                if jnt_type == 0:
-                    d.qpos[0] += offset[0]
-                    d.qpos[1] += offset[1]
-                    robot_moved = True
-
-            # If robot wasn't moved via qpos, we need to manually offset geometries later
-            if not robot_moved:
-                apply_root_offset = True
-
-            # 2. Offset any independent freejoint objects (e.g. box, largebox)
-            shifted_body_ids = _offset_freejoint_object_qpos(model, d, offset)
-
-            # 3. Target offset (target_x, target_y)
-            target_x = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_x")
-            if target_x >= 0:
-                d.qpos[model.jnt_qposadr[target_x]] += offset[0]
-
-            target_y = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_y")
-            if target_y >= 0:
-                d.qpos[model.jnt_qposadr[target_y]] += offset[1]
-
-        mujoco.mj_forward(model, d)
-
-        # Post-process: Shift all geometries if robot root wasn't moved
-        if apply_root_offset and offset is not None:
-            # Shift all geoms?
-            # We should shift Everything that is PART OF THE ROBOT.
-            # Or just everything?
-            # Box and Target were already shifted via qpos.
-            # BUT qpos shift updates body_pos which updates geom_pos.
-            # If we shift ALL geom_pos, we double shift Box and Target!
-
-            # So we need to shift geoms that belong to bodies which are NOT Box or Target.
-            # Or simpler: Shift everything, but subtract offset from Box/Target qpos first? No.
-
-            target_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "mocap_target")
-            qpos_shifted_bodies = set(shifted_body_ids)
-            if target_body_id >= 0:
-                qpos_shifted_bodies.add(target_body_id)
-            # Mocap bodies already carry the grid offset via mocap_pos above;
-            # shifting their geom/site xpos again would double the offset.
-            qpos_shifted_bodies.update(
-                int(body_id) for body_id in np.flatnonzero(model.body_mocapid >= 0)
-            )
-
-            for i in range(model.ngeom):
-                body_id = model.geom_bodyid[i]
-                is_already_shifted = body_id in qpos_shifted_bodies
-                is_plane = model.geom_type[i] == mujoco.mjtGeom.mjGEOM_PLANE
-
-                if not is_already_shifted and not is_plane:
-                    d.geom_xpos[i, 0] += offset[0]
-                    d.geom_xpos[i, 1] += offset[1]
-
-            for i in range(model.nsite):
-                body_id = model.site_bodyid[i]
-                is_already_shifted = body_id in qpos_shifted_bodies
-                if not is_already_shifted:
-                    d.site_xpos[i, 0] += offset[0]
-                    d.site_xpos[i, 1] += offset[1]
+        model_idx = next(i for i, item in enumerate(data_list) if item is d)
+        _set_worker_state(model, d, s, offset, _worker_ctx["mocap_defaults"][model_idx])
 
     num_envs = state_batch.shape[0]
 
@@ -616,6 +683,12 @@ def render_frame_job(args):
         center_y = np.mean(offsets[:, 1])
         if cam_lookat is None:
             cam.lookat = [center_x, center_y, 0.75]
+            # Widen a close-up distance so every grid cell fits the frame;
+            # an explicit cam_lookat opts out (single-env framing).
+            cam_distance = max(
+                float(cam_distance),
+                _grid_fit_distance(offsets, primary_model, _worker_ctx["shape"]),
+            )
         else:
             cam.lookat = [float(cam_lookat[0]), float(cam_lookat[1]), float(cam_lookat[2])]
         cam.distance = cam_distance
@@ -658,6 +731,7 @@ def render_frame_job(args):
             debug_overlays,
             offsets=offsets,
             mesh_ids=_worker_ctx.get("ghost_mesh_ids"),
+            mesh_materials=_worker_ctx.get("ghost_mat_ids"),
         )
 
     return renderer.render()
@@ -820,58 +894,8 @@ def render_frame_tracking_job(args):
     catmask_static = mujoco.mjtCatBit.mjCAT_STATIC
 
     def set_state(model, d, s, offset=None):
-        d.time = s[0]
-        d.qpos[:] = s[1 : 1 + model.nq]
-        d.qvel[:] = s[1 + model.nq : 1 + model.nq + model.nv]
-
-        apply_root_offset = False
-
-        if offset is not None:
-            robot_moved = False
-            first_body_jnt = model.body_jntadr[1] if model.nbody > 1 else -1
-            if first_body_jnt >= 0:
-                jnt_type = model.jnt_type[first_body_jnt]
-                if jnt_type == 0:  # mjJNT_FREE
-                    d.qpos[0] += offset[0]
-                    d.qpos[1] += offset[1]
-                    robot_moved = True
-
-            if not robot_moved:
-                apply_root_offset = True
-
-            shifted_body_ids = _offset_freejoint_object_qpos(model, d, offset)
-
-            target_x = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_x")
-            if target_x >= 0:
-                d.qpos[model.jnt_qposadr[target_x]] += offset[0]
-
-            target_y = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "target_y")
-            if target_y >= 0:
-                d.qpos[model.jnt_qposadr[target_y]] += offset[1]
-
-        mujoco.mj_forward(model, d)
-
-        if apply_root_offset and offset is not None:
-            target_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "mocap_target")
-            qpos_shifted_bodies = set(shifted_body_ids)
-            if target_body_id >= 0:
-                qpos_shifted_bodies.add(target_body_id)
-
-            for i in range(model.ngeom):
-                body_id = model.geom_bodyid[i]
-                is_already_shifted = body_id in qpos_shifted_bodies
-                is_plane = model.geom_type[i] == mujoco.mjtGeom.mjGEOM_PLANE
-
-                if not is_already_shifted and not is_plane:
-                    d.geom_xpos[i, 0] += offset[0]
-                    d.geom_xpos[i, 1] += offset[1]
-
-            for i in range(model.nsite):
-                body_id = model.site_bodyid[i]
-                is_already_shifted = body_id in qpos_shifted_bodies
-                if not is_already_shifted:
-                    d.site_xpos[i, 0] += offset[0]
-                    d.site_xpos[i, 1] += offset[1]
+        model_idx = next(i for i, item in enumerate(data_list) if item is d)
+        _set_worker_state(model, d, s, offset, _worker_ctx["mocap_defaults"][model_idx])
 
     # Primary env first — camera tracks body 1 of this env
     primary_global = env_indices[primary_local_idx]
@@ -928,6 +952,7 @@ def render_frame_tracking_job(args):
             ],
             offsets=offsets[env_indices] if offsets is not None else None,
             mesh_ids=_worker_ctx.get("ghost_mesh_ids"),
+            mesh_materials=_worker_ctx.get("ghost_mat_ids"),
         )
 
     return renderer.render()

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -451,6 +451,53 @@ class TestPrimitiveToGeomConversion:
                 str(mjb_path), ["not_registered"], tmp_path
             )
 
+    MESH_MATERIAL_MODEL = """<mujoco>
+      <asset>
+        <texture name="checker" type="2d" builtin="checker" width="8" height="8"
+                 rgb1="1 0 0" rgb2="0 1 0"/>
+        <material name="sticker" texture="checker"/>
+        <mesh name="tri" vertex="0 0 0  0.1 0 0  0 0.1 0  0 0 0.1"/>
+      </asset>
+      <worldbody>
+        <geom type="mesh" mesh="tri" material="sticker"/>
+      </worldbody>
+    </mujoco>"""
+
+    def test_ghost_geom_inherits_model_material(self) -> None:
+        mujoco = self.mujoco
+        model = mujoco.MjModel.from_xml_string(self.MESH_MATERIAL_MODEL)
+        scene = mujoco.MjvScene(model, maxgeom=8)
+        mesh_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_MESH, "tri")
+        mat_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_MATERIAL, "sticker")
+        assert mesh_id >= 0 and mat_id >= 0
+
+        materials = self.render_many._ghost_material_ids(model, {"goal_mesh": mesh_id})
+        assert materials == {"goal_mesh": mat_id}
+
+        overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0.3), mesh_asset="goal_mesh")]]
+        self.render_many.append_debug_primitives(
+            scene,
+            overlays,
+            offsets=None,
+            mesh_ids={"goal_mesh": mesh_id},
+            mesh_materials=materials,
+        )
+        geom = scene.geoms[0]
+        assert int(geom.matid) == mat_id
+        assert int(geom.texcoord) == 1
+
+    def test_ghost_geom_without_material_stays_flat(self) -> None:
+        mujoco = self.mujoco
+        model = mujoco.MjModel.from_xml_string(self.MESH_MATERIAL_MODEL)
+        scene = mujoco.MjvScene(model, maxgeom=8)
+        mesh_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_MESH, "tri")
+        overlays = [[DebugPrimitive(kind="ghost_geom", pos=(0, 0, 0.3), mesh_asset="goal_mesh")]]
+        self.render_many.append_debug_primitives(
+            scene, overlays, offsets=None, mesh_ids={"goal_mesh": mesh_id}
+        )
+        geom = scene.geoms[0]
+        assert int(geom.matid) == -1
+
 
 class TestHeadlessPrimitiveRendering:
     """Offline snapshot rendering with overlays (skipped without a GL backend).
@@ -636,7 +683,11 @@ class TestInteractiveOverlayInjection:
         self.mujoco = pytest.importorskip("mujoco")
         from unisim.backend.mjwarp.playback import _inject_interactive_debug_overlays
 
-        self.inject = _inject_interactive_debug_overlays
+        def _inject(**kwargs):
+            kwargs.setdefault("mesh_mat_cache", {})
+            return _inject_interactive_debug_overlays(**kwargs)
+
+        self.inject = _inject
         obj_path = tmp_path / "goal.obj"
         obj_path.write_text(self.OBJ)
         self.model = self.mujoco.MjModel.from_xml_string(

--- a/tests/test_mjwarp.py
+++ b/tests/test_mjwarp.py
@@ -21,12 +21,12 @@ MODEL = """<mujoco model='unisim-test-mjwarp'>
 </mujoco>"""
 
 
-def _make_backend(tmp_path: Path, model_name: str = "model.xml") -> MjwarpBackend:
+def _make_backend(tmp_path: Path, model_name: str = "model.xml", xml: str = MODEL) -> MjwarpBackend:
     warp.init()
     if not bool(warp.get_device().is_cuda):
         pytest.skip("mjwarp runtime tests require an active CUDA Warp device")
     model_path = tmp_path / model_name
-    model_path.write_text(MODEL)
+    model_path.write_text(xml)
     return MjwarpBackend(SceneCfg(model_file=str(model_path)), num_envs=2, sim_dt=0.01)
 
 
@@ -97,3 +97,40 @@ def test_mjwarp_pre_step_control_validates_return_shape(tmp_path: Path) -> None:
         backend.step(ctrl, nsteps=1)
     backend.set_pre_step_control(None)
     backend.step(ctrl, nsteps=1)
+
+
+MOCAP_MODEL = """<mujoco model='unisim-test-mjwarp-mocap'>
+  <option timestep='0.01'/>
+  <worldbody>
+    <body name='base'>
+      <joint name='slide' type='slide' axis='1 0 0'/>
+      <geom type='box' size='0.05 0.05 0.05'/>
+    </body>
+    <body name='palm' mocap='true' pos='0 0 0.5'>
+      <geom type='box' size='0.02 0.02 0.02'/>
+    </body>
+  </worldbody>
+  <actuator><motor joint='slide' ctrlrange='-10 10'/></actuator>
+</mujoco>"""
+
+
+def test_mjwarp_snapshot_carries_mocap_state(tmp_path: Path) -> None:
+    backend = _make_backend(tmp_path, "mocap.xml", xml=MOCAP_MODEL)
+
+    snapshot = backend.get_physics_state()
+
+    # Layout: [time, qpos, qvel, mocap_pos(nmocap*3), mocap_quat(nmocap*4)].
+    assert snapshot.shape == (2, 1 + 1 + 1 + 7)
+    np.testing.assert_allclose(snapshot[:, 3:6], [[0.0, 0.0, 0.5]] * 2, atol=1e-6)
+    np.testing.assert_allclose(snapshot[:, 6:10], [[1.0, 0.0, 0.0, 0.0]] * 2, atol=1e-6)
+
+    binding = backend.bind_mocap_pose("palm")
+    poses = np.array(
+        [[0.1, 0.2, 0.3, 1.0, 0.0, 0.0, 0.0], [0.4, 0.5, 0.6, 1.0, 0.0, 0.0, 0.0]],
+        dtype=np.float32,
+    )
+    binding.write(np.arange(2, dtype=np.int32), poses)
+
+    snapshot = backend.get_physics_state()
+    np.testing.assert_allclose(snapshot[:, 3:6], poses[:, :3], atol=1e-6)
+    np.testing.assert_allclose(snapshot[:, 6:10], poses[:, 3:], atol=1e-6)

--- a/tests/test_render_many.py
+++ b/tests/test_render_many.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import subprocess
 import sys
 import textwrap
@@ -64,6 +65,16 @@ _SCRIPT = textwrap.dedent(
     states = np.zeros((2, 1 + model.nq + model.nv))
     for env in range(2):
         states[env, 1 : 1 + model.nq] = data.qpos
+    if mode == "wuji_mocap":
+        # Extended snapshot layout: [time, qpos, qvel, mocap_pos, mocap_quat].
+        # The recorded mocap pose differs from the model default (0, 0, 0.5),
+        # so the palm/finger must render at the recorded pose, not the default.
+        nm = model.nmocap
+        tail = np.zeros((2, 7 * nm))
+        for env in range(2):
+            tail[env, : 3 * nm] = np.tile([0.4, -0.3, 0.6], nm)
+            tail[env, 3 * nm :] = np.tile([1.0, 0.0, 0.0, 0.0], nm)
+        states = np.concatenate([states, tail], axis=1)
     offsets = np.array([[0.0, 0.0], [2.0, 3.0]])
     overlays = None
     if mode == "wuji":
@@ -161,3 +172,46 @@ class TestMultiEnvGridOffsets:
         np.testing.assert_allclose(
             geoms[(1.0, 0.0, 0.0)], [[0.5, 0.5, 0.1], [2.5, 3.5, 0.1]], atol=1e-4
         )
+
+    def test_mocap_snapshot_tail_replays_recorded_pose(self) -> None:
+        geoms = self._scene_geoms(WUJI_LIKE_XML, "wuji_mocap")
+        # The snapshot tail carries mocap (0.4, -0.3, 0.6) + identity quat;
+        # the palm and finger must replay it (plus the grid offset for env 1)
+        # instead of falling back to the model default (0, 0, 0.5).
+        np.testing.assert_allclose(
+            geoms[(1.0, 0.0, 0.0)], [[0.4, -0.3, 0.6], [2.4, 2.7, 0.6]], atol=1e-4
+        )
+        np.testing.assert_allclose(
+            geoms[(0.0, 1.0, 0.0)], [[0.4, -0.3, 0.65], [2.4, 2.7, 0.65]], atol=1e-4
+        )
+
+
+class TestGridFitDistance:
+    """Free-camera distance auto-fit for multi-env grid recording."""
+
+    @pytest.fixture(autouse=True)
+    def _mujoco(self):
+        self.mujoco = pytest.importorskip("mujoco")
+        from unisim.visualization import render_many
+
+        self.render_many = render_many
+        self.model = self.mujoco.MjModel.from_xml_string("<mujoco/>")
+
+    def test_four_env_grid_vertical_fit_dominates(self) -> None:
+        offsets = self.render_many.get_grid_offsets(4, spacing=1.0)
+        fit = self.render_many._grid_fit_distance(offsets, self.model, (1280, 720))
+        # fovy 45°, span 1.0 + margin 0.5 per side -> need_h = 1.0.
+        expected = 1.0 / math.tan(math.radians(22.5))
+        assert fit == pytest.approx(expected, rel=1e-6)
+
+    def test_single_env_fit_stays_below_closeup_distance(self) -> None:
+        offsets = self.render_many.get_grid_offsets(1, spacing=1.0)
+        fit = self.render_many._grid_fit_distance(offsets, self.model, (1280, 720))
+        assert fit == pytest.approx(0.5 / math.tan(math.radians(22.5)), rel=1e-6)
+        assert fit < 2.0  # never pushes a single-env record beyond the default
+
+    def test_cam_fov_widens_fit(self) -> None:
+        self.model.vis.global_.fovy = 90.0
+        offsets = self.render_many.get_grid_offsets(4, spacing=1.0)
+        fit = self.render_many._grid_fit_distance(offsets, self.model, (1280, 720))
+        assert fit == pytest.approx(1.0 / math.tan(math.radians(45.0)), rel=1e-6)


### PR DESCRIPTION
## What

Fixes three record/playback rendering defects reported downstream in wuji_unilab (WujiHand_Reorient):

1. **Record-mode interpenetration**: offline snapshot playback only carried `[time, qpos, qvel]`; mocap poses (the Wuji palm is a mocap body whose wrist pitch is randomized at reset) were reset to model defaults in the render workers, so the hand rendered misaligned with — and interpenetrating — the free-joint cube. Interactive playback was unaffected because it syncs live mocap state every frame.
2. **White/untextured goal ghost**: `_append_primitive` never bound a material to `ghost_geom` meshes (`matid=-1` after `mjv_initGeom`), while the source implementation (wuji-mjlab `command_visualization.py`) inherits the cube's textured material.
3. **Grid camera cropping**: a close-up `cam_distance` tuned for single-env eval cropped all but one env in 4-env grid recordings.

## Changes

- mjwarp `get_physics_state` snapshots append `[mocap_pos(nmocap*3), mocap_quat(nmocap*4)]` when the model has mocap bodies; `run_playback_mode` declares the extended `snapshot_shape`. Render workers replay the recorded mocap pose (shared `_set_worker_state` helper replaces the two duplicated copies, also fixing tracking mode never touching mocap); legacy `[time, qpos, qvel]` snapshots keep the defaults-plus-grid-offset fallback.
- `ghost_geom` overlays inherit the material of the model geom using the same mesh (`_ghost_material_ids`, `geom.matid` + `texcoord=1`), in both offline workers and the mjwarp interactive viewer; `append_debug_primitives` gains an optional `mesh_materials` mapping (backward compatible).
- Grid recording without an explicit `cam_lookat` auto-fits `cam_distance` to cover every grid cell (`_grid_fit_distance` from grid span, fovy, aspect); explicit `cam_lookat` keeps single-env framing.
- `validate_offline_visual_model` now requires `nmocap` parity between physics and visual models.
- mjwarp interactive playback qvel slice is now bounded (required by the extended snapshot width).

## Compatibility note

Consumers that feed snapshots to `mujoco.mj_setState(..., mjSTATE_FULLPHYSICS)` (UniLab `play_interactive.py`) already required `na == 0`; mocap models on that path now fail closed with a clear size error. The mujoco/newton/superdex/drake snapshot layouts are unchanged.

## Validation

- `uv run ruff check .` — clean
- `uv run pytest -q` — 234 passed, 13 skipped (mjwarp CUDA tests skip in this dev env without warp)
- New tests: mocap snapshot tail replay (subprocess render regression), grid-fit distance math, ghost material inheritance, mjwarp mocap snapshot layout (CUDA-gated)
- Downstream end-to-end (wuji_unilab, local editable install): `wuji-play` record with 4 envs and `wuji-eval --record` both produce correct videos — all envs framed, textured goal cube, no hand/cube interpenetration.