### PR TITLE
docs: point mujoco backend docs and CI at mjbatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         if: runner.os == 'Windows'
       - name: Install locked core environment
         run: uv sync --locked
+      # The mjbatch runtime behind the mujoco extra ships prebuilt wheels for
+      # Linux/macOS only (it skips Windows), so the mujoco extra and the
+      # complete suite stay off the Windows job; Windows runs the
+      # core/import-boundary subset against the pure-Python core.
       - name: Install MuJoCo adapter test extra
         if: runner.os != 'Windows'
         run: uv sync --locked --extra mujoco

--- a/README.md
+++ b/README.md
@@ -45,6 +45,37 @@ MuJoCo-Warp 3.11 / warp-lang 1.16.0 line and can be installed together in one
 environment. `newton` keeps exact pins (`newton==1.5.1` with its coupled
 runtimes), while `mjwarp` follows the 3.11 line with `mujoco-warp~=3.11.0`.
 
+## MuJoCo backend
+
+The `mujoco` adapter executes batched simulations through
+[mjbatch](https://github.com/unilabsim/mjbatch), a maintained fork of
+[kevinzakka/mjbatch](https://github.com/kevinzakka/mjbatch), installed with the
+`mujoco` extra:
+
+```bash
+pip install "unisim-core[mujoco]"
+```
+
+mjbatch ships prebuilt wheels for Linux x86_64/aarch64 and macOS
+(CPython 3.10–3.14t) and pins `mujoco==3.11.0`; it skips Windows and
+musllinux. The native executor remains unsupported on Windows, same as the
+previous runtime; the pure-Python core and the `FakeBackend` stay fully
+supported there.
+
+Behavioral consequences of the executor, recorded plainly:
+
+- **Numerical drift**: results before and after the switch from the previous
+  executor are not guaranteed identical. Drift between the two runtimes is
+  characterized by a recorded baseline plus behavior-invariant tests; there is
+  no bit-exact gate.
+- **Model variants**: heterogeneous model structures per environment are
+  unsupported on the `mujoco` backend. Use field-level domain randomization
+  instead — mjbatch's `expand`/`set_const` cover the supported randomization
+  surface.
+- **Chunk tuning**: `chunk_size` and `adaptive_chunk_size` are deprecated
+  warn-and-ignore knobs. The chunk scheduler was removed; mjbatch's
+  work-stealing thread pool is the tuning mechanism.
+
 ## Quick start
 
 The public boundary is deliberately lazy and safe to import anywhere:
@@ -134,8 +165,9 @@ If UniSim contributes to your research, please cite the UniLab paper:
 ### Physics backends
 
 When you use a specific backend through UniSim, please also cite the
-corresponding engine. The `mujoco` and `drake` adapters build on the MuJoCoUni
-and DrakeUni runtimes, so cite those alongside the original engines:
+corresponding engine. The `mujoco` adapter runs on the mjbatch runtime and the
+`drake` adapter on the DrakeUni runtime, so cite those alongside the original
+engines:
 
 ```bibtex
 % MuJoCo
@@ -148,12 +180,14 @@ and DrakeUni runtimes, so cite those alongside the original engines:
   doi       = {10.1109/IROS.2012.6386109}
 }
 
-% MuJoCoUni (runtime of the `mujoco` adapter)
-@article{jia2026mujocouni,
-  title   = {MuJoCoUni: Persistent Batched Runtime Primitives for MuJoCo},
-  author  = {Jia, Yufei and Wu, Junzhe},
-  journal = {arXiv preprint arXiv:2605.24922},
-  year    = {2026}
+% mjbatch (runtime of the `mujoco` adapter; UniLab-maintained fork
+% of kevinzakka/mjbatch)
+@software{mjbatch,
+  title  = {mjbatch: Batched MuJoCo Simulation},
+  author = {Kevin Zakka and the mjbatch contributors},
+  year   = {2026},
+  url    = {https://github.com/unilabsim/mjbatch},
+  note   = {UniLab-maintained fork of kevinzakka/mjbatch}
 }
 
 % MotrixSim

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,6 +39,32 @@ warp-lang 1.16.0 版本线，可以安装在同一环境中。`newton` 保留精
 `uv run scripts/check_newton_runtime.py` 做元数据探针，必要时追加 `--import`
 显式导入原生运行时。
 
+## MuJoCo 后端
+
+`mujoco` 适配器通过 [mjbatch](https://github.com/unilabsim/mjbatch) 执行批量
+仿真，它是 [kevinzakka/mjbatch](https://github.com/kevinzakka/mjbatch)
+的维护中 fork，随 `mujoco` extra 安装：
+
+```bash
+pip install "unisim-core[mujoco]"
+```
+
+mjbatch 为 Linux x86_64/aarch64 与 macOS(CPython 3.10–3.14t)提供预编译
+wheel,并钉版 `mujoco==3.11.0`;跳过 Windows 与 musllinux。原生执行器在
+Windows 上仍然不支持，与旧运行时一致；纯 Python 核心与 `FakeBackend` 在
+Windows 上完整可用。
+
+执行器替换带来的行为影响，如实记录：
+
+- **数值漂移**：替换前后两次执行器的结果不保证一致。两运行时之间的漂移
+  以记录基线表征，并由行为不变量测试保障；不设 bit-exact 门禁。
+- **模型变体（model variants）**：不支持在 `mujoco` 后端使用逐环境异构
+  模型结构。请改用字段级域随机化——mjbatch 的 `expand`/`set_const` 覆盖了
+  支持的随机化面。
+- **chunk 调优**:`chunk_size` 与 `adaptive_chunk_size` 是弃用的
+  warn-and-ignore 参数:chunk 调度器已删除,mjbatch 的 work-stealing 线程池
+  即为调优机制。
+
 ## 快速上手
 
 公共导入边界刻意保持惰性,可以在任何环境安全导入:
@@ -121,9 +147,9 @@ make package    # 本地构建 sdist 与 wheel 检查
 
 ### 物理后端
 
-通过 UniSim 使用某个具体后端时,请同时引用对应的引擎。`mujoco` 与
-`drake` 适配器分别构建在 MuJoCoUni 和 DrakeUni 运行时之上,因此请与原版
-引擎一并引用:
+通过 UniSim 使用某个具体后端时,请同时引用对应的引擎。`mujoco` 适配器
+运行在 mjbatch 运行时之上,`drake` 适配器运行在 DrakeUni 运行时之上,因此
+请与原版引擎一并引用:
 
 ```bibtex
 % MuJoCo
@@ -137,12 +163,14 @@ make package    # 本地构建 sdist 与 wheel 检查
   doi       = {10.1109/IROS.2012.6386109}
 }
 
-% MuJoCoUni(`mujoco` 适配器的运行时)
-@article{jia2026mujocouni,
-  title   = {MuJoCoUni: Persistent Batched Runtime Primitives for MuJoCo},
-  author  = {Jia, Yufei and Wu, Junzhe},
-  journal = {arXiv preprint arXiv:2605.24922},
-  year    = {2026}
+% mjbatch(`mujoco` 适配器的运行时;kevinzakka/mjbatch 的
+% UniLab 维护 fork)
+@software{mjbatch,
+  title  = {mjbatch: Batched MuJoCo Simulation},
+  author = {Kevin Zakka and the mjbatch contributors},
+  year   = {2026},
+  url    = {https://github.com/unilabsim/mjbatch},
+  note   = {UniLab-maintained fork of kevinzakka/mjbatch}
 }
 
 % MotrixSim

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -8,7 +8,10 @@ implementation owned by `unisim-core`.
 
 The first real adapter is MuJoCo. It accepts a package-neutral `SceneCfg`,
 materializes the XML on construction, and exposes cached numeric state through
-`unisim.SimBackend`; task-owned scene composition remains in UniLab.
+`unisim.SimBackend`; task-owned scene composition remains in UniLab. Its
+native batch executor is mjbatch (`unilabsim/mjbatch`, a maintained fork of
+`kevinzakka/mjbatch`); heterogeneous model variants are unsupported, and
+field-level domain randomization goes through mjbatch `expand`/`set_const`.
 
 Motrix is the second in-process adapter. It uses Motrix's batched `SceneData`
 and masked data slices behind the same public state/control/reset contract.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -2,7 +2,7 @@
 
 | Backend | Import | Install/runtime boundary | Status |
 | --- | --- | --- | --- |
-| MuJoCo | `unisim.MuJoCoBackend` | `uv sync --extra mujoco` | available |
+| MuJoCo | `unisim.MuJoCoBackend` | `uv sync --extra mujoco` (mjbatch runtime) | available |
 | Motrix | `unisim.MotrixBackend` | `uv sync --extra motrix` | available |
 | Drake | `unisim.DrakeBackend` | `uv sync --extra drake` (`drake-uni`) + native batch extension | available |
 | MJWarp | `unisim.MJWarpBackend` | `uv sync --extra mjwarp`, CUDA | available |
@@ -16,6 +16,19 @@ The base wheel imports none of these SDKs. Construction performs cold-path
 runtime discovery and raises an adapter-specific, actionable error when the
 runtime is unavailable. The matrix is an adapter/API support statement, not a
 claim that every host has every vendor SDK or GPU capability.
+
+The MuJoCo adapter's native executor is
+[mjbatch](https://github.com/unilabsim/mjbatch), a maintained fork of
+kevinzakka/mjbatch with prebuilt wheels for Linux x86_64/aarch64 and macOS
+(CPython 3.10–3.14t) and an exact `mujoco==3.11.0` pin. Windows and musllinux
+are unsupported for the native executor, so the Windows CI job runs the
+core/import-boundary subset only. Numerical results before and after the
+switch from the previous executor are not guaranteed identical — drift is
+characterized by a recorded baseline, not gated. Heterogeneous model variants
+are unsupported; field-level domain randomization goes through mjbatch
+`expand`/`set_const`. `chunk_size`/`adaptive_chunk_size` are deprecated and
+ignored (warn-and-ignore); the chunk scheduler was removed and mjbatch's
+work-stealing thread pool is the tuning mechanism.
 
 The MuJoCo-related extras share one version line (MuJoCo 3.11 / MuJoCo-Warp
 3.11 / warp-lang 1.16.0) and are jointly installable: `mjwarp` tracks the line


### PR DESCRIPTION
Closes #59. Roadmap: Motphys/UniLab#1552 (child #5, packaging/docs; pairs with #58 which owns the adapter code, pyproject, CHANGELOG, and tests).

Docs/CI-only change; no code, no tests, no version bumps, no CHANGELOG (owned by #58).

## Pages/sections changed

- **README.md / README_zh.md** (kept in sync):
  - New "MuJoCo backend" section: the `mujoco` adapter's native executor is now [mjbatch](https://github.com/unilabsim/mjbatch), a maintained fork of [kevinzakka/mjbatch](https://github.com/kevinzakka/mjbatch), installed via `pip install "unisim-core[mujoco]"`; prebuilt wheels for Linux x86_64/aarch64 + macOS (cp310–cp314t), pins `mujoco==3.11.0`, skips Windows/musllinux.
  - Records the fixed design-decision consequences from the roadmap: numerical results before/after the swap are **not guaranteed identical** (drift characterized by a baseline + behavior-invariant tests, no bit-exact gate); **model variants** (heterogeneous structures) unsupported on the mujoco backend — use field-level DR via mjbatch `expand`/`set_const`; `chunk_size`/`adaptive_chunk_size` deprecated **warn-and-ignore** (chunk scheduler removed, mjbatch work-stealing is the tuning); **Windows** native executor unsupported, unchanged from before (core + `FakeBackend` stay supported).
  - Citation section: replaces the MuJoCoUni bib entry with an mjbatch entry (UniLab-maintained fork note); `drake` keeps DrakeUni.
- **docs/support-matrix.md**: MuJoCo row names the mjbatch runtime; adds a paragraph covering the wheel/platform matrix, drift-not-gated, variants unsupported, chunk knobs deprecated, Windows subset rationale.
- **docs/migration.md**: MuJoCo paragraph notes the mjbatch executor and the variants limitation.
- **.github/workflows/ci.yml**: adds comments explaining the Windows job stays on the core/import-boundary subset because mjbatch also skips Windows, and that it does not install the `mujoco` extra. Verified: no workflow references `mujoco-uni-runtime`/"MuJoCoUni" naming and no `make mujoco`-style toolchain rebuild steps exist.

## Sanity

- `rg -i 'mujoco.?uni' README* .github docs` → no hits in owned files.
- ci.yml parses as valid YAML.

## Left for others / follow-ups

- `AGENTS.md:116` still describes the Windows limitation in terms of the old "MuJoCoUni runtime" — not in this PR's file scope; should be reworded when the runtime naming settles.
- pyproject extra/uv.lock/CHANGELOG/src/tests are owned by #58.
- mjbatch PyPI distribution identity remains an open maintainer decision (dev uses a git pin); docs link the fork repository only.
