### PR TITLE
refactor(mujoco): slim adapter after mjbatch query-op slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
   the interval velocity-delta path; state layout offsets are derived from
   `mujoco.mj_stateSize` per component instead of hardcoded FULLPHYSICS
   offsets. The pre-step control hook is driven by mjbatch's native
-  per-substep callback (`callback_sensordata=False`; sensordata stays one
+  per-substep callback (`fn(k, state_view, ctrl_view)`; sensordata stays one
   substep behind qpos/qvel, matching `post_step_forward_sensor=False`, the
   only mode the previous executor's default served).
 - **Breaking (mujoco):** per-env model variants are no longer supported
@@ -31,14 +31,15 @@
   `[time, qpos, qvel]` per row (the old rows carried a FULLPHYSICS tail),
   which also fixes the previous length mismatch for `na > 0` models in the
   offline render workers. Height scanning and site Jacobians run as mjbatch
-  query ops on the live state; both wrap a sensordata save/restore guard
-  because query-op CopyOut would otherwise clobber the bound sensordata view
-  with cross-sim stale data.
+  query ops on the live state; query ops skip the bound-field CopyOut, so the
+  bound views are untouched by the calls. The height scanner is
+  `output="height"`-only on this backend and passes `alignment` through to
+  mjbatch (`"world"`/`"yaw"`).
 - **Breaking (mujoco):** `post_step_forward_sensor` is removed end to end
   (its only `True` behavior is unreachable on the new executor); the chunk
   tuner is deleted entirely (`chunk_size`/`adaptive_chunk_size` are
-  warn-and-ignore `DeprecationWarning` shims at both the factory and the
-  adapter, and `bench_nsteps` is accepted and ignored by the factory).
+  warn-and-ignore `DeprecationWarning` shims at the factory, and
+  `bench_nsteps` is accepted and ignored by the factory).
   Models with `sleep` enabled now fail fast at `Batch` construction.
 - Playback model resolution no longer maps per-env variant geom sizes: one
   visual model file (or one saved mjb) serves every rendered env, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,12 @@ classifiers = [
 # line and are jointly installable. The `mujoco` bound is a compatible-release
 # specifier; `uv.lock` pins the exact MuJoCo version. The executor is the
 # unilabsim mjbatch fork (unilabsim/unisim#58), pinned as a git direct
-# reference because its native per-substep callback, yaw/clearance hfield
-# sampling, and cpu-affinity patches are not on any released wheel. The final
+# reference because its native per-substep callback, yaw hfield sampling, and
+# cpu-affinity patches are not on any released wheel. The final
 # distribution identity (PyPI fork name vs private index) is a roadmap open
 # item (Motphys/UniLab#1552); a git direct reference cannot ship on PyPI, so
 # the `mujoco` extra stays non-redistributable until that decision lands.
-mujoco = ["mujoco~=3.11.0", "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@e6c19bae4d0aec4fc69ec551ff0329296d1db931"]
+mujoco = ["mujoco~=3.11.0", "mjbatch @ git+https://github.com/unilabsim/mjbatch.git@cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f"]
 motrix = ["motrixsim-core==0.8.2"]
 drake = ["drake-uni==0.1.0"]
 mjwarp = ["mujoco-warp~=3.11.0", "warp-lang==1.16.0"]

--- a/src/unisim/backend/mjwarp/backend.py
+++ b/src/unisim/backend/mjwarp/backend.py
@@ -1180,8 +1180,8 @@ class MjwarpBackend(SimBackend):
         substep-start state (the previous step/reset barrier already covers
         substep 0), the owner callback converts the policy control, and the
         result is uploaded as that substep's device ctrl.  Sensordata stays on
-        the end-of-step barrier, matching the MuJoCo backend's
-        ``callback_sensordata=False`` decision: action terms read
+        the end-of-step barrier, matching the MuJoCo backend's decision to not
+        refresh sensordata per substep: action terms read
         physics-state-backed getters only.
         """
         control_upload_ms = 0.0

--- a/src/unisim/backend/mujoco/backend.py
+++ b/src/unisim/backend/mujoco/backend.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import time
-import warnings
 import weakref
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -142,7 +141,6 @@ class _MuJoCoHeightScanner(BackendHeightScanner):
     offsets: np.ndarray
     frame_body_id: int
     alignment: str
-    output: str
 
     def scan(self) -> np.ndarray:
         pool = self.backend._pool
@@ -155,26 +153,20 @@ class _MuJoCoHeightScanner(BackendHeightScanner):
             pool = self.backend._build_pool()
         assert pool is not None
         backend = self.backend
-        # Query ops copy every bound field back from the worker mjData, whose
-        # sensordata is stale cross-sim data (kinematics does not recompute
-        # sensors).  Save/restore the authoritative sensordata view.
-        saved = backend._sensor_data.copy()
-        try:
-            out = np.zeros((backend._num_envs, self.offsets.shape[0]), dtype=np.float64)
-            # Id-based raw binding: geom/body ids are resolved once on the cold
-            # path and may refer to unnamed model elements.
-            _RawMjBatch.sample_hfield(
-                pool,
-                self.hfield_geom_id,
-                self.frame_body_id,
-                self.offsets,
-                out,
-                None,
-                self.alignment,
-                self.output,
-            )
-        finally:
-            backend._sensor_data[:] = saved
+        # mjbatch query ops skip the bound-field CopyOut, so the bound views
+        # are untouched by this call.
+        out = np.zeros((backend._num_envs, self.offsets.shape[0]), dtype=np.float64)
+        # Id-based raw binding: geom/body ids are resolved once on the cold
+        # path and may refer to unnamed model elements.
+        _RawMjBatch.sample_hfield(
+            pool,
+            self.hfield_geom_id,
+            self.frame_body_id,
+            self.offsets,
+            out,
+            None,
+            self.alignment,
+        )
         return np.asarray(out, dtype=backend._np_dtype)
 
 
@@ -334,17 +326,8 @@ class MuJoCoBackend(SimBackend):
         position_actuator_gains: dict | None = None,
         iterations: int | None = None,
         push_body_name: Optional[str] = None,
-        chunk_size: Optional[int] = None,  # deprecated, ignored
-        adaptive_chunk_size: bool = False,  # deprecated, ignored
         cpu_ids: Optional[Sequence[int]] = None,
     ):
-        if chunk_size is not None or adaptive_chunk_size:
-            warnings.warn(
-                "chunk_size/adaptive_chunk_size are ignored: mjbatch schedules per-sim "
-                "work without a chunk knob; remove these from EnvCfg.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         scene_context = _build_mujoco_scene_context(scene)
         self.scene_model_file = scene_context.model_file
         self.scene_visual_model_file = scene_context.visual_model_file
@@ -521,8 +504,6 @@ class MuJoCoBackend(SimBackend):
         sensordata = batch.bind("sensordata", dtype)
         sensordata[:] = self._sensor_data
         self._sensor_data = sensordata
-        # Debug/tests only: the live (N, nstate) integration rows.
-        self._state_view = batch.bind("state")
         self._rebuild_derived_views()
         batch.forward()
 
@@ -825,9 +806,17 @@ class MuJoCoBackend(SimBackend):
         alignment: str = "yaw",
         output: str = "height",
     ) -> BackendHeightScanner:
+        """Create a reusable height-field scanner on the init/cold path.
+
+        The MuJoCo backend supports ``alignment="world"`` and
+        ``alignment="yaw"`` (mjbatch rejects anything else) and only
+        ``output="height"``: the sampled world z of the hfield surface.
+        """
         offsets_np = np.ascontiguousarray(np.asarray(offsets, dtype=np.float64))
         if offsets_np.ndim != 2 or offsets_np.shape[1] != 2:
             raise ValueError(f"offsets must have shape (num_points, 2), got {offsets_np.shape}")
+        if output != "height":
+            raise ValueError(f"MuJoCoBackend only supports output='height', got {output!r}")
 
         return _MuJoCoHeightScanner(
             backend=self,
@@ -835,7 +824,6 @@ class MuJoCoBackend(SimBackend):
             offsets=offsets_np,
             frame_body_id=int(frame_body_id),
             alignment=alignment,
-            output=output,
         )
 
     def get_body_subtree_ids(self, root_body_id: int) -> np.ndarray:
@@ -969,16 +957,15 @@ class MuJoCoBackend(SimBackend):
     ) -> dict[str, dict[str, float]]:
         # Single batch dispatch for all substeps (#1259 M1b): the upstream
         # pre-step control hook recomputes the Manager-Based action before
-        # every substep through mjbatch's native per-substep callback.
-        # callback_sensordata=False because action terms only read
-        # physics-state-backed getters (joint pos/vel); _sensor_data is
-        # refreshed by the end-of-call CopyOut, as observation/metric terms
-        # only consume it after the full step.
+        # every substep through mjbatch's native per-substep callback.  Action
+        # terms only read physics-state-backed getters (joint pos/vel);
+        # _sensor_data is refreshed by the end-of-call CopyOut, as
+        # observation/metric terms only consume it after the full step.
         set_ctrl_ms = 0.0
         refresh_cache_ms = 0.0
         layout = self._state_layout
 
-        def _callback(k, state_view, sensordata_view, ctrl_view) -> None:
+        def _callback(k, state_view, ctrl_view) -> None:
             nonlocal set_ctrl_ms, refresh_cache_ms
             if k > 0:
                 # k == 0 receives the state from before the call, which is
@@ -1003,7 +990,6 @@ class MuJoCoBackend(SimBackend):
         self._pool.step(  # type: ignore[union-attr]
             nstep=nsteps,
             callback=_callback,
-            callback_sensordata=False,
         )
         physics_ms = (time.perf_counter() - t0) * 1000.0 - set_ctrl_ms - refresh_cache_ms
         self._pending_xfrc_applied.fill(0.0)
@@ -1569,10 +1555,8 @@ class MuJoCoBackend(SimBackend):
         """Return batched Jacobians with shape ``(num_envs, 3, len(dof_indices))``.
 
         This uses mjbatch's native live-state ``jac_site`` op, so it does not
-        allocate one ``MjData`` per env.  The op's end-of-call CopyOut would
-        clobber the bound sensordata view with cross-sim stale data
-        (kinematics does not recompute sensors), so the authoritative view is
-        saved and restored around the call.
+        allocate one ``MjData`` per env.  Query ops skip the bound-field
+        CopyOut, so the bound views are untouched by the call.
         """
         site_id_int = int(site_id)
         if site_id_int < 0 or site_id_int >= int(self._model.nsite):
@@ -1585,15 +1569,11 @@ class MuJoCoBackend(SimBackend):
         pool = self._pool
         if pool is None:
             raise RuntimeError("MuJoCo site Jacobians require a materialized backend")
-        saved = self._sensor_data.copy()
-        try:
-            jacp = np.zeros((self._num_envs, 3, self.nv))
-            jacr = np.zeros_like(jacp)
-            # Id-based raw binding: the backend holds site ids and sites may be
-            # unnamed, which the name-based Python wrapper cannot resolve.
-            _RawMjBatch.jac_site(pool, site_id_int, jacp, jacr, None)
-        finally:
-            self._sensor_data[:] = saved
+        jacp = np.zeros((self._num_envs, 3, self.nv))
+        jacr = np.zeros_like(jacp)
+        # Id-based raw binding: the backend holds site ids and sites may be
+        # unnamed, which the name-based Python wrapper cannot resolve.
+        _RawMjBatch.jac_site(pool, site_id_int, jacp, jacr, None)
         return (
             jacp[:, :, dof_indices].astype(self._np_dtype),
             jacr[:, :, dof_indices].astype(self._np_dtype),

--- a/tests/test_mujoco_batch.py
+++ b/tests/test_mujoco_batch.py
@@ -271,7 +271,7 @@ def test_layout_equivalence(tmp_path: Path) -> None:
     backend.apply_body_force(base_id, force)
     backend.step(ctrl, nsteps=2)
 
-    rows = backend._state_view
+    rows = backend._pool.bind("state")
     layout = backend._state_layout
     independent = _independent_layout(backend.model)
 
@@ -421,7 +421,7 @@ def test_set_state_empty_indices_returns_timing(backend: MuJoCoBackend) -> None:
 
 
 # --------------------------------------------------------------------- #
-# Query-op sensordata clobber guard + serial equivalence                #
+# Query ops leave bound views untouched + serial equivalence            #
 # --------------------------------------------------------------------- #
 
 
@@ -482,7 +482,7 @@ def test_jac_site_preserves_sensor_data(backend: MuJoCoBackend) -> None:
 
 
 # --------------------------------------------------------------------- #
-# Height scanner: yaw semantics (native serial reference) + guard       #
+# Height scanner: yaw semantics (native serial reference)               #
 # --------------------------------------------------------------------- #
 
 
@@ -579,11 +579,37 @@ def test_scanner_preserves_sensor_data(tmp_path: Path) -> None:
     )
     b.step(np.zeros((b.num_envs, b.num_actuators)))
     names = tuple(b._sensor_views)
-    assert names, "hfield model carries no sensors; guard untestable"
+    assert names, "hfield model carries no sensors; assertion untestable"
     before = {name: b.get_sensor_data(name).copy() for name in names}
     scanner.scan()
     for name in names:
         np.testing.assert_array_equal(b.get_sensor_data(name), before[name])
+
+
+def test_scanner_rejects_unsupported_output_and_alignment(tmp_path: Path) -> None:
+    path = _write(tmp_path, HFIELD_MODEL)
+    b = MuJoCoBackend(
+        SceneCfg(model_file=path), num_envs=1, sim_dt=0.002, base_name="base", np_dtype=np.float64
+    )
+    geom_id = b.get_geom_id("terrain")
+    body_id = int(b.get_body_ids(["base"])[0])
+    with pytest.raises(ValueError, match="output='height'"):
+        b.create_hfield_scanner(
+            hfield_geom_id=geom_id,
+            offsets=np.zeros((2, 2)),
+            frame_body_id=body_id,
+            alignment="yaw",
+            output="clearance",
+        )
+    b.materialize()
+    scanner = b.create_hfield_scanner(
+        hfield_geom_id=geom_id,
+        offsets=np.zeros((2, 2)),
+        frame_body_id=body_id,
+        alignment="body",
+    )
+    with pytest.raises(ValueError, match="alignment"):
+        scanner.scan()
 
 
 # --------------------------------------------------------------------- #
@@ -686,17 +712,6 @@ def test_factory_cpu_ids_passthrough(tmp_path: Path) -> None:
     )
     assert backend._cpu_ids == (0,)
     assert backend._n_threads == 1
-
-
-def test_ctor_chunk_knobs_warn_and_ignore(tmp_path: Path) -> None:
-    path = _write(tmp_path, MODEL)
-    with pytest.warns(DeprecationWarning, match="chunk_size"):
-        backend = MuJoCoBackend(
-            SceneCfg(model_file=path), num_envs=1, sim_dt=0.002, chunk_size=32,
-            adaptive_chunk_size=True,
-        )
-    backend.materialize()
-    backend.step(np.zeros((1, backend.num_actuators)))
 
 
 def test_bind_sensor_data_reader_follows_materialize(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 [[package]]
 name = "mjbatch"
 version = "0.1.0"
-source = { git = "https://github.com/unilabsim/mjbatch.git?rev=e6c19bae4d0aec4fc69ec551ff0329296d1db931#e6c19bae4d0aec4fc69ec551ff0329296d1db931" }
+source = { git = "https://github.com/unilabsim/mjbatch.git?rev=cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f#cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f" }
 dependencies = [
     { name = "mujoco" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -3058,7 +3058,7 @@ requires-dist = [
     { name = "drake-uni", marker = "extra == 'drake'", specifier = "==0.1.0" },
     { name = "genesis-world", marker = "extra == 'genesis'", specifier = "==1.3.3" },
     { name = "imgui-bundle", marker = "extra == 'newton'", specifier = ">=1.92.0" },
-    { name = "mjbatch", marker = "extra == 'mujoco'", git = "https://github.com/unilabsim/mjbatch.git?rev=e6c19bae4d0aec4fc69ec551ff0329296d1db931" },
+    { name = "mjbatch", marker = "extra == 'mujoco'", git = "https://github.com/unilabsim/mjbatch.git?rev=cf4a83d8526f2fe6dd4847c25e05c34e81f6f91f" },
     { name = "motrixsim-core", marker = "extra == 'motrix'", specifier = "==0.8.2" },
     { name = "mujoco", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and extra == 'superdex'", specifier = "~=3.11.0" },
     { name = "mujoco", marker = "extra == 'mujoco'", specifier = "~=3.11.0" },


### PR DESCRIPTION
Closes #62

Adapter ablation after the mjbatch fork's query-op slim (unilabsim/mjbatch#23, merged into the fork's dev branch). Consumer-ablation audit confirmed every removed shim was unreachable or redundant.

## Ablation table

| Removed | Why safe |
| --- | --- |
| jac-path sensordata save/restore (`get_site_jacobian_w`) | Fork query ops (`jac_site`/`sample_hfield`) now skip the bound-field CopyOut — bound views are untouched, so the guard was a per-call full-field copy of dead weight. Preservation test kept (stronger: views are simply unchanged). |
| scanner-path sensordata save/restore (`_MuJoCoHeightScanner.scan`) | Same query-op contract; the scan no longer costs a full sensordata copy per call. |
| ctor `chunk_size`/`adaptive_chunk_size` warn-and-ignore params + `DeprecationWarning` | The factory (mujoco branch) pops and warns without forwarding; the ctor shim was unreachable. Factory pop+warn stays the single compat point (`test_factory_warns_and_ignores_removed_options` still passes). |
| always-on `bind("state")` (`_state_view`) | Only reader was the layout-equivalence test; the bind copied the full INTEGRATION state vector on every step/reset/forward. The test now binds ad hoc via `backend._pool.bind("state")`. `_StateLayout` stays (the callback path consumes it). |
| `callback_sensordata=False` kwarg + callback sensordata param | Fork step callback is now `fn(k, state_view, ctrl_view)`; per-substep sensordata refresh was never consumed. |
| scanner `output=` passthrough to the fork binding | The fork param is gone. The adapter validates `output == "height"` itself (clear `ValueError`); `alignment` (`"world"`/`"yaw"`) passes through, `"body"` gets the binding's `ValueError`. The scanner docstring states the supported set. |

## Changes

- `src/unisim/backend/mujoco/backend.py`: the six removals above; mjwarp docstring reworded to match the final API.
- `tests/test_mujoco_batch.py`: bound-view tests assert views are unchanged (no guard); ctor chunk-shim test deleted; new `test_scanner_rejects_unsupported_output_and_alignment` pins the scanner ValueErrors.
- `pyproject.toml`/`uv.lock`: mjbatch pin `e6c19bae` → `cf4a83d8` (fork dev tip with the slim API).
- `CHANGELOG.md`: unreleased entry rewritten to the final slim API (no save/restore guard, factory-only chunk shim, height-only scanner).

## Validation

- `uv run --no-sync pytest -q`: **254 passed, 1 failed, 11 skipped** — the single failure (`test_on_frame_paints_video_frames`) is the known pre-existing, unrelated one. All 20 adapter obligation tests in `tests/test_mujoco_batch.py` pass.
- `uv run ruff check .`: clean. `uv lock --check`: clean.
- Behavior differential spot-check: direct stepping and pre-step-control-hooked stepping both match the serial `MjData` reference to 1e-13; `jac_site` leaves every bound view bit-unchanged; no `_state_view` on the production path.

UniLab-side follow-up: Motphys/UniLab#1557.
