### PR TITLE
release: unisim-core 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.2.1 - 2026-09-13
 
 - **Breaking (mujoco executor):** the MuJoCo adapter's native batch executor is
-  now the unilabsim `mjbatch` fork (`mjbatch.Batch`, pinned as a git direct
-  reference in the `mujoco` extra; the final distribution identity is a
-  roadmap open item, Motphys/UniLab#1552), replacing the
+  now the unilabsim `mjbatch` fork (`mjbatch.Batch`, published on PyPI as
+  `mjbatch-uni~=0.1.0` and pulled in by the `mujoco` extra), replacing the
   `mujoco-uni-runtime` `BatchEnvPool`. Canonical state storage is the batch's
   bound per-field views (`time`/`qpos`/`qvel`/`act`/`ctrl` bound at the
   configured numpy dtype, `xfrc_applied`/`qacc_warmstart` native float64,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module-name = "unisim"
 
 [project]
 name = "unisim-core"
-version = "1.2.0"
+version = "1.2.1"
 description = "Unified physics backend contracts and adapters"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3021,7 +3021,7 @@ wheels = [
 
 [[package]]
 name = "unisim-core"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Release PR for unisim-core **1.2.1** (patch bump per maintainer decision). Stacked on #64: this branch is based on the migration head, so the diff shrinks to the release commit alone once #64 merges. Merge #64 first, then this one; I will tag `v1.2.1` afterwards, which triggers the release workflow (sdist build + verify + PyPI publish via trusted publishing).

1.2.1 content (all from #64): the MuJoCo adapter executor switches from `mujoco-uni-runtime` BatchEnvPool to the unilabsim mjbatch fork, with the `mujoco` extra depending on `mjbatch-uni~=0.1.0` from PyPI (redistributable again). Breaking changes are documented in the CHANGELOG (executor state storage, model-variant removal, `post_step_forward_sensor` removal, chunk-tuner deletion, playback model resolution).

## Validation

- `make check`: 254 passed, 11 skipped; the single local failure (`test_debug_overlay` headless rendering subprocess) reproduces on the unmodified base and passes in CI on all three platforms
- Final head CI (this PR) is the release gate per the workflow policy